### PR TITLE
Fix CSV formula injection in pilot usage export

### DIFF
--- a/blueprints/analysis.py
+++ b/blueprints/analysis.py
@@ -35,6 +35,14 @@ logger = logging.getLogger(__name__)
 bp = Blueprint('analysis', __name__)
 
 
+def _csv_safe_cell(value):
+    """Neutralize spreadsheet formula prefixes in exported CSV cells."""
+    text = str(value or '')
+    if text.startswith(('=', '+', '-', '@')):
+        return f"'{text}"
+    return text
+
+
 def _require_admin():
     if getattr(current_user, 'role', None) != 'admin':
         flash('权限不足', 'error')
@@ -939,7 +947,7 @@ def pilot_export_csv():
     for e in events:
         writer.writerow([
             e.created_at.isoformat() if e.created_at else '',
-            e.event_type or '',
+            _csv_safe_cell(e.event_type),
             e.user_id or '',
             e.pair_id or '',
             e.member_id or '',

--- a/tests/test_analysis_csv_export.py
+++ b/tests/test_analysis_csv_export.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""Security tests for analysis CSV export."""
+
+
+def test_csv_safe_cell_neutralizes_formula_prefixes():
+    """CSV cells with formula prefixes should be neutralized."""
+    from blueprints.analysis import _csv_safe_cell
+
+    assert _csv_safe_cell('=HYPERLINK("http://evil","x")').startswith("'")
+    assert _csv_safe_cell('+1+1').startswith("'")
+    assert _csv_safe_cell('-1+2').startswith("'")
+    assert _csv_safe_cell('@cmd').startswith("'")
+    assert _csv_safe_cell('normal_text') == 'normal_text'


### PR DESCRIPTION
### Motivation
- The pilot CSV export wrote `UsageEvent.event_type` verbatim into the exported CSV, allowing attacker-controlled values beginning with formula prefixes (e.g., `=`) to trigger spreadsheet formulas when opened by an admin.
- The vulnerability was present in HEAD for the pilot export route and needed a minimal remediation at export time to block CSV formula injection without altering ingestion semantics.

### Description
- Added `_csv_safe_cell(value)` in `blueprints/analysis.py` to neutralize spreadsheet formula prefixes (`=`, `+`, `-`, `@`) by prefixing the cell with a single quote.
- Updated the `/analysis/pilot/export.csv` export to call `_csv_safe_cell(e.event_type)` when writing rows so exported CSV cells cannot be interpreted as formulas by spreadsheet applications.
- Added a focused regression test `tests/test_analysis_csv_export.py` that asserts formula-prefix values are neutralized and normal text is unchanged.

### Testing
- Ran the focused regression test `python -m pytest tests/test_analysis_csv_export.py -q`, which passed (`1 passed`).
- Ran the broader `tests/test_security_fixes.py` earlier during validation and observed an unrelated test failure in `test_sanitize_input_basic`; that failure predates and is unrelated to the CSV export change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b17f9033bc8333a73434140da4dc59)