### PR TITLE
fix: 修复清理后的配置与脚本回归

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,10 +15,10 @@ PAIR_TOKEN_PEPPER=change-me-min-32-chars
 # 因此如要使用 instance/health_weather.db，请配置为 sqlite:///health_weather.db（不要写 instance/ 前缀）。
 DATABASE_URI=sqlite:///health_weather.db
 
-# 和风天气API配置（可选，未配置时使用 Open-Meteo 兜底）
-# 如使用专属 Host，请在本地 `.env` 中填写，不要把真实 Host 写回仓库。
+# 和风天气API配置（可选，未配置时使用 Open-Meteo / 阈值规则兜底）
+# 如需启用 QWeather，请在本地 `.env` 中显式填写 Host，不要把真实 Host 写回仓库。
 QWEATHER_KEY=your-qweather-api-key
-QWEATHER_API_BASE=https://your-qweather-host.example.com/v7
+QWEATHER_API_BASE=
 
 # 高德地图API配置（推荐前后端分离，避免把 Web 服务 Key 用到前端）
 # 前端地图 JS Key（会出现在浏览器请求里，请在高德后台做好域名绑定）

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -475,7 +475,7 @@ PAIR_TOKEN_PEPPER=<独立的加密盐>
 ```bash
 # 和风天气 API
 QWEATHER_KEY=<你的和风天气 API 密钥>
-QWEATHER_API_BASE=https://devapi.qweather.com
+QWEATHER_API_BASE=<在本地环境中显式配置的 QWeather Host>
 
 # 高德地图
 AMAP_KEY=<你的高德地图 API 密钥>

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ pytest
 
 手动测试类用例默认不会执行；如需单独运行，请查看 `tests/manual/`。
 
+小程序调试 / 联调前，必须先在 `miniprogram/config.js` 中填写真实 HTTPS API 地址。公开仓库默认留空，未配置时小程序请求会直接报错，不会再偷偷打到占位域名。
+
 ## 仓库结构
 
 ```text
@@ -94,6 +96,8 @@ tests/                自动化测试
 docs/                 架构、重构、评审与状态文档
 scripts/              部署与维护脚本
 ```
+
+如果你要启用 QWeather，请在本地 `.env` 中显式设置 `QWEATHER_KEY` 和 `QWEATHER_API_BASE`。公开仓库默认不再内置 QWeather Host；未配置时系统会走 Open-Meteo / 阈值规则兜底。
 
 ## 标准开发流程
 

--- a/core/config.py
+++ b/core/config.py
@@ -15,7 +15,7 @@ from config import (
 from core.constants import DEFAULT_CITY_LABEL, WEATHER_CACHE_TTL_MINUTES
 from utils.parsers import parse_bool, parse_float, parse_int
 
-QWEATHER_API_BASE_DEFAULT = 'https://your-qweather-host.example.com/v7'
+QWEATHER_API_BASE_DEFAULT = ''
 SILICONFLOW_API_BASE_DEFAULT = 'https://api.siliconflow.cn/v1'
 WXPUSHER_API_BASE_DEFAULT = 'https://wxpusher.zjiecode.com/api'
 
@@ -89,6 +89,29 @@ def _normalize_sqlite_uri(database_uri, repo_root):
     return uri
 
 
+def resolve_sqlite_db_path(database_uri, repo_root=None):
+    """将 sqlite URI 解析为稳定的本地路径。"""
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parents[1]
+    repo_root = Path(repo_root)
+    normalized_uri = _normalize_sqlite_uri(database_uri, repo_root)
+    if not isinstance(normalized_uri, str):
+        return None
+
+    for scheme in ('sqlite:///', 'sqlite+pysqlite:///'):
+        if not normalized_uri.startswith(scheme):
+            continue
+        path_and_query = normalized_uri[len(scheme):]
+        path_part, _, _query = path_and_query.partition('?')
+        if not path_part or path_part == ':memory:':
+            return None
+        if path_part.startswith('/'):
+            return Path(path_part)
+        return (repo_root / path_part).resolve()
+
+    return None
+
+
 def resolve_engine_options(database_uri):
     if database_uri.startswith('sqlite'):
         return {}
@@ -140,12 +163,8 @@ def validate_production_config():
             )
 
     database_uri = resolve_database_uri()
-    if database_uri.startswith('sqlite:///'):
-        db_path = database_uri.replace('sqlite:///', '')
-        if not db_path.startswith('/'):
-            db_path = Path(__file__).resolve().parents[1] / db_path
-        else:
-            db_path = Path(db_path)
+    db_path = resolve_sqlite_db_path(database_uri, Path(__file__).resolve().parents[1])
+    if db_path is not None:
         db_dir = db_path.parent
         if not db_dir.exists():
             try:
@@ -266,6 +285,10 @@ def configure_app(app, logger):
         'WEATHER_CACHE_TTL_MINUTES',
         parse_int(os.getenv('WEATHER_CACHE_TTL_MINUTES', str(WEATHER_CACHE_TTL_MINUTES)), default=WEATHER_CACHE_TTL_MINUTES)
     )
+    if qweather_key and not qweather_api_base:
+        logger.warning("QWEATHER_KEY 已配置但 QWEATHER_API_BASE 未配置，将跳过 QWeather Host 相关调用并使用兜底链路。")
+    if qweather_api_base and not qweather_key:
+        logger.warning("QWEATHER_API_BASE 已配置但 QWEATHER_KEY 未配置，QWeather 不会生效。")
     app.config.setdefault('NOTIFICATION_ESCALATION_DAYS', parse_int(os.getenv('NOTIFICATION_ESCALATION_DAYS', '3'), default=3))
     app.config.setdefault('NOTIFICATION_MAX_DAILY', parse_int(os.getenv('NOTIFICATION_MAX_DAILY', '5'), default=5))
     app.config.setdefault('HEAT_HOT_DAY_THRESHOLD', parse_float(os.getenv('HEAT_HOT_DAY_THRESHOLD', '35'), default=35.0))

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -418,7 +418,7 @@ SECRET_KEY=your_secret_key
 
 # 和风天气API（主来源）
 QWEATHER_KEY=YOUR_QWEATHER_KEY
-QWEATHER_API_BASE=https://your-qweather-host.example.com/v7
+QWEATHER_API_BASE=<在本地或私有 ops 中显式配置的 QWeather Host>
 
 # Open-Meteo（兜底，无需 Key）
 # 无需配置，系统会在 QWeather 失败时自动启用
@@ -469,11 +469,12 @@ with app.app_context(): db.create_all(); print('Done')"
 
 #### 3. 天气API返回模拟数据
 
-检查 `.env` 文件中的 `QWEATHER_KEY` 和 `QWEATHER_API_BASE` 是否正确配置；若 QWeather 失败，系统会自动回退 Open-Meteo。
+检查 `.env` 文件中的 `QWEATHER_KEY` 和 `QWEATHER_API_BASE` 是否正确配置；若未配置 QWeather，系统会自动回退 Open-Meteo。
 
 ```bash
-# 测试API
-curl -s --compressed "https://your-qweather-host.example.com/v7/weather/now?key=YOUR_KEY&location=116.20,29.27"
+# 先在当前 shell 中提供真实 Host，再测试 API
+export QWEATHER_API_BASE="https://your-real-qweather-host/v7"
+curl -s --compressed "${QWEATHER_API_BASE}/weather/now?key=YOUR_KEY&location=116.20,29.27"
 ```
 
 ---

--- a/miniprogram/config.js
+++ b/miniprogram/config.js
@@ -1,7 +1,7 @@
 // Backend base URL (must be HTTPS for real MiniProgram requests).
 // During local dev you can temporarily use a LAN IP + HTTPS tunnel.
 module.exports = {
-  // 公开仓库只保留占位值；真实地址请在私有环境或构建流程中注入。
+  // 公开仓库默认留空。调试或联调前，必须先改成真实 HTTPS API 地址。
   // Production: must be HTTPS and whitelisted in WeChat MiniProgram console.
-  API_BASE_URL: 'https://your-miniapp-api.example.com',
+  API_BASE_URL: '',
 };

--- a/miniprogram/utils/request.js
+++ b/miniprogram/utils/request.js
@@ -2,6 +2,10 @@ const { API_BASE_URL } = require('../config');
 
 function request({ method, path, token, data }) {
   return new Promise((resolve, reject) => {
+    if (!API_BASE_URL) {
+      reject(new Error('miniapp_api_base_missing'));
+      return;
+    }
     wx.request({
       url: `${API_BASE_URL}${path}`,
       method: method || 'GET',
@@ -30,4 +34,3 @@ async function api({ method, path, token, data }) {
 }
 
 module.exports = { api };
-

--- a/scripts/reset_admin.py
+++ b/scripts/reset_admin.py
@@ -4,8 +4,15 @@ import argparse
 import getpass
 import os
 import sqlite3
+import sys
 from pathlib import Path
 from werkzeug.security import generate_password_hash
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from core.config import resolve_sqlite_db_path
 
 
 def _load_database_uri():
@@ -29,18 +36,16 @@ def _load_database_uri():
     return ''
 
 
-def _parse_sqlite_path(uri):
-    if not uri:
-        return None
-    if uri.startswith('sqlite:////'):
-        path = f"/{uri[len('sqlite:////'):]}"
-    elif uri.startswith('sqlite:///'):
-        path = uri[len('sqlite:///'):]
-    else:
-        return None
-    if '?' in path:
-        path = path.split('?', 1)[0]
-    return path or None
+def _resolve_db_path(cli_db_path):
+    if cli_db_path:
+        return Path(cli_db_path).expanduser().resolve()
+
+    db_uri = _load_database_uri()
+    resolved = resolve_sqlite_db_path(db_uri, ROOT_DIR)
+    if resolved is not None:
+        return resolved
+
+    return (ROOT_DIR / 'storage' / 'health_weather.db').resolve()
 
 
 def _resolve_new_password(cli_password):
@@ -73,15 +78,21 @@ def main():
     if len(new_password) < 8:
         raise RuntimeError('新密码长度至少为 8 个字符。')
 
-    db_uri = _load_database_uri()
-    db_file = args.db_path or _parse_sqlite_path(db_uri) or str(Path(__file__).resolve().parents[1] / 'storage' / 'health_weather.db')
-    db_path = Path(db_file)
+    db_path = _resolve_db_path(args.db_path)
+    if not db_path.exists():
+        raise RuntimeError(f'数据库文件不存在: {db_path}')
 
-    conn = sqlite3.connect(db_path)
+    try:
+        conn = sqlite3.connect(db_path)
+    except sqlite3.OperationalError as exc:
+        raise RuntimeError(f'无法打开数据库文件: {db_path} ({exc})') from exc
     try:
         cursor = conn.cursor()
         new_hash = generate_password_hash(new_password)
-        cursor.execute('UPDATE users SET password_hash = ? WHERE username = ?', (new_hash, 'admin'))
+        try:
+            cursor.execute('UPDATE users SET password_hash = ? WHERE username = ?', (new_hash, 'admin'))
+        except sqlite3.OperationalError as exc:
+            raise RuntimeError(f'更新 admin 密码失败，请检查 users 表是否存在: {exc}') from exc
         conn.commit()
         print(f'已重置 admin 密码, 更新行数: {cursor.rowcount}')
     finally:

--- a/scripts/test_fixes.py
+++ b/scripts/test_fixes.py
@@ -5,6 +5,34 @@ import sys
 import os
 
 
+def _load_active_env_values(text):
+    values = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith('#') or '=' not in line:
+            continue
+        key, value = line.split('=', 1)
+        values[key.strip()] = value.strip()
+    return values
+
+
+def _is_placeholder_secret(value):
+    text = (value or '').strip()
+    if not text:
+        return True
+    lowered = text.lower()
+    placeholder_prefixes = ('your-', 'your_', 'change-me', 'example')
+    placeholder_values = {
+        'your-qweather-api-key',
+        'your-amap-js-api-key',
+        'your-amap-security-code',
+        'your-amap-web-service-key',
+        'your-siliconflow-api-key',
+        'change-me-min-32-chars',
+    }
+    return lowered.startswith(placeholder_prefixes) or lowered in placeholder_values
+
+
 def main():
     # 设置环境变量
     os.environ['DEBUG'] = 'true'
@@ -94,13 +122,27 @@ def main():
         else:
             print("✅ .env.example 包含所有必需配置项")
 
-        # 检查是否不包含可疑的旧密钥片段
-        suspicious_markers = ['sk-', '73684be4bf0141c7']
-        if any(marker in env_example for marker in suspicious_markers):
-            print("❌ .env.example 包含真实密钥！")
+        env_values = _load_active_env_values(env_example)
+        if any(marker in env_example for marker in ['73684be4bf0141c7', '172.245.126.42', 'mj76x98pfn.re.qweatherapi.com']):
+            print("❌ .env.example 仍包含已知敏感片段！")
             return 1
-        else:
-            print("✅ .env.example 不包含真实密钥")
+
+        secret_like_keys = [
+            'SECRET_KEY',
+            'PAIR_TOKEN_PEPPER',
+            'QWEATHER_KEY',
+            'AMAP_JS_API_KEY',
+            'AMAP_SECURITY_JS_CODE',
+            'AMAP_WEB_SERVICE_KEY',
+            'SILICONFLOW_API_KEY',
+            'WXPUSHER_APP_TOKEN',
+        ]
+        leaked_keys = [key for key in secret_like_keys if not _is_placeholder_secret(env_values.get(key, ''))]
+        if leaked_keys:
+            print(f"❌ .env.example 存在非示例密钥字段: {', '.join(leaked_keys)}")
+            return 1
+
+        print("✅ .env.example 不包含真实密钥")
     except FileNotFoundError:
         print("❌ .env.example 未找到")
         return 1

--- a/services/weather_service.py
+++ b/services/weather_service.py
@@ -35,10 +35,10 @@ class WeatherService:
                 app_config = {}
 
         self.qweather_key = app_config.get('QWEATHER_KEY') or os.getenv('QWEATHER_KEY')
-        self.api_base_url = (
-            app_config.get('QWEATHER_API_BASE')
-            or os.getenv('QWEATHER_API_BASE', 'https://your-qweather-host.example.com/v7')
-        )
+        configured_api_base = app_config.get('QWEATHER_API_BASE')
+        if configured_api_base is None:
+            configured_api_base = os.getenv('QWEATHER_API_BASE')
+        self.api_base_url = (configured_api_base or '').strip()
         self.city_map = app_config.get('CITY_LOCATION_MAP') or {}
         self.default_location = (
             app_config.get('DEFAULT_LOCATION')

--- a/tests/manual/test_weather_api.py
+++ b/tests/manual/test_weather_api.py
@@ -15,16 +15,23 @@ def test_qweather_api():
     print("和风天气API测试")
     print("=" * 50)
     
-    # API配置（如使用付费订阅版，请在本地环境变量里提供专属域名）
+    # API配置（如使用付费订阅版，请在本地环境变量里显式提供专属域名）
     key = os.getenv("QWEATHER_KEY")
-    base_url = os.getenv("QWEATHER_API_BASE", "https://your-qweather-host.example.com/v7")
+    base_url = os.getenv("QWEATHER_API_BASE")
     location = "116.20,29.27"  # 都昌县
 
     if not key:
         print("❌ 未设置环境变量 QWEATHER_KEY，无法测试。")
         return
+    if not base_url:
+        print("❌ 未设置环境变量 QWEATHER_API_BASE，无法测试。")
+        return
+    if "your-qweather-host.example.com" in base_url:
+        print("❌ QWEATHER_API_BASE 仍是占位值，请先改成真实 Host。")
+        return
     
     print(f"\nAPI Key: {key[:6]}...{key[-4:]}")
+    print(f"Base URL: {base_url}")
     print(f"Location: {location}")
     
     # 测试1: 实时天气


### PR DESCRIPTION
1. 这次改了什么

修复清理后带入 `main` 的几处运行时回归：QWeather 默认 Host、小程序默认 API 地址、`reset_admin.py` 的 sqlite 路径解析，以及 `scripts/test_fixes.py` 的误报。

2. 为什么要改

上一轮清理已经把仓库边界收紧并从 GitHub 云端移除了无关内容，但同时引入了几处会影响真实使用的回归：
- 未显式配置 `QWEATHER_API_BASE` 时会打到占位域名
- 小程序默认会连占位地址
- `reset_admin.py` 在相对 sqlite URI 下可能连错库或打不开库
- `scripts/test_fixes.py` 会把普通注释误判成密钥泄漏

3. 怎么测试/验证改动是否生效

- `python3 -m py_compile core/config.py services/weather_service.py scripts/reset_admin.py scripts/test_fixes.py tests/manual/test_weather_api.py`
- 验证 `QWEATHER_KEY` 已配置但 `QWEATHER_API_BASE` 未配置时，运行态配置值为空字符串，不再打占位域名
- 验证 `scripts/reset_admin.py` 在 `DATABASE_URI=sqlite:///instance/health_weather.db` 场景下能按仓库根路径正确更新 admin 密码
- 验证 `scripts/test_fixes.py` 的示例值检测不再把 `Flask-SQLAlchemy` 注释误判为真实密钥
- README 已补充“小程序调试 / 联调前必须先配真实 API 地址”的说明