### PR TITLE
[codex] 同步 preview UI 响应式改版

### DIFF
--- a/blueprints/tools.py
+++ b/blueprints/tools.py
@@ -1,19 +1,230 @@
 # -*- coding: utf-8 -*-
 """Tooling and prediction pages."""
-from flask import Blueprint, current_app, render_template
-from flask_login import login_required
+from flask import Blueprint, current_app, flash, render_template, request
+from flask_login import current_user, login_required
 
-from core.db_models import Community
+from core.constants import CHRONIC_OPTIONS
+from core.db_models import FamilyMember
+from core.weather import ensure_user_location_valid, get_weather_with_cache, normalize_location_name
+from services.chronic_risk_service import get_chronic_service
+from services.ml_prediction_service import get_ml_service
+from utils.parsers import parse_int, safe_json_loads
+from utils.validators import sanitize_input
 
 bp = Blueprint('tools', __name__)
 
 
-@bp.route('/ml-prediction', endpoint='ml_prediction')
+CHRONIC_FORM_LABELS = {
+    'hypertension': '高血压',
+    'diabetes': '糖尿病',
+    'chd': '冠心病',
+    'copd': '慢性阻塞性肺病',
+}
+
+DISEASE_BREAKDOWN_LABELS = {
+    'cardiovascular': '心血管风险',
+    'respiratory': '呼吸系统风险',
+    'general': '综合基础风险',
+    'musculoskeletal': '骨关节风险',
+}
+
+ML_CHRONIC_ALIASES = {
+    '慢性阻塞性肺病': '慢阻肺',
+    '慢性呼吸道疾病': '慢阻肺',
+    'COPD': '慢阻肺',
+    '脑卒中史': '脑卒中',
+    '骨关节病': '关节炎',
+}
+
+ML_CHRONIC_OPTIONS = CHRONIC_OPTIONS + ['慢性肾病']
+
+
+def _tool_family_members():
+    """返回当前用户可选的家庭成员。"""
+    if getattr(current_user, 'role', None) == 'guest':
+        return []
+    return FamilyMember.query.filter_by(user_id=current_user.id).order_by(FamilyMember.created_at.desc()).all()
+
+
+def _selected_member(member_id):
+    """按当前用户范围解析家庭成员。"""
+    parsed_id = parse_int(member_id)
+    if not parsed_id or getattr(current_user, 'role', None) == 'guest':
+        return None
+    return FamilyMember.query.filter_by(id=parsed_id, user_id=current_user.id).first()
+
+
+def _normalized_location(raw_location):
+    """清洗并标准化地点输入。"""
+    location = sanitize_input(raw_location, max_length=100)
+    if location:
+        return normalize_location_name(location)
+    return ensure_user_location_valid()
+
+
+def _coerce_age(raw_age, default_age):
+    """安全转换年龄，避免模板和服务层接到异常值。"""
+    age = parse_int(raw_age)
+    if age is None:
+        age = default_age
+    if age is None:
+        age = 65
+    return max(1, min(int(age), 120))
+
+
+def _score_level(score):
+    """按分值映射页面展示等级。"""
+    if score >= 70:
+        return '高风险'
+    if score >= 40:
+        return '中等风险'
+    return '低风险'
+
+
+def _level_bucket(score):
+    """按分值映射条形图样式。"""
+    if score >= 70:
+        return 'high'
+    if score >= 40:
+        return 'mid'
+    return 'low'
+
+
+def _build_ml_factor_cards(result, age, weather_info):
+    """把服务返回转换成模板可直接消费的因子卡片。"""
+    factor_cards = []
+    raw_factors = result.get('risk_factors') or []
+    for index, factor_name in enumerate(raw_factors[:4]):
+        factor_cards.append({
+            'name': factor_name,
+            'value': max(36, 84 - index * 12),
+            'effect': '+',
+        })
+
+    if factor_cards:
+        return factor_cards
+
+    temperature = int(round(float(weather_info.get('temperature', 20) or 20)))
+    humidity = int(round(float(weather_info.get('humidity', 60) or 60)))
+    aqi = int(round(float(weather_info.get('aqi', 40) or 40)))
+    return [
+        {'name': '最高气温变化', 'value': min(96, max(28, temperature * 2)), 'effect': '+'},
+        {'name': '相对湿度', 'value': min(92, max(22, humidity)), 'effect': '+'},
+        {'name': '空气质量', 'value': min(90, max(18, aqi)), 'effect': '+'},
+        {'name': '年龄', 'value': min(95, max(24, age)), 'effect': '+'},
+    ]
+
+
+def _normalize_ml_chronic_list(values):
+    """统一慢病标签，保证页面回填与既有档案名称一致。"""
+    normalized = []
+    for raw_value in values or []:
+        value = sanitize_input(raw_value, max_length=50)
+        if not value:
+            continue
+        value = ML_CHRONIC_ALIASES.get(value, value)
+        if value not in ML_CHRONIC_OPTIONS:
+            continue
+        if value not in normalized:
+            normalized.append(value)
+    return normalized
+
+
+def _build_chronic_breakdown(result, adherence, symptoms):
+    """把慢病服务输出映射成页面分解条。"""
+    breakdown = []
+    for disease_key, payload in (result.get('disease_risks') or {}).items():
+        risk_score = int(round(payload.get('risk_score', 0) or 0))
+        breakdown.append({
+            'name': DISEASE_BREAKDOWN_LABELS.get(disease_key, disease_key),
+            'value': risk_score,
+            'level': _level_bucket(risk_score),
+        })
+
+    adherence_scores = {
+        'strict': 22,
+        'loose': 52,
+        'none': 78,
+    }
+    adherence_score = adherence_scores.get(adherence, 32)
+    breakdown.append({
+        'name': '用药依从',
+        'value': adherence_score,
+        'level': _level_bucket(adherence_score),
+    })
+
+    symptom_score = 22
+    if symptoms:
+        symptom_score = 58 if len(symptoms) >= 4 else 42
+    breakdown.append({
+        'name': '自觉症状',
+        'value': symptom_score,
+        'level': _level_bucket(symptom_score),
+    })
+
+    return breakdown[:4]
+
+
+@bp.route('/ml-prediction', methods=['GET', 'POST'], endpoint='ml_prediction')
 @login_required
 def ml_prediction():
-    """ML预测页面"""
-    communities = Community.query.all()
-    return render_template('ml_prediction.html', communities=communities)
+    """ML预测页面。"""
+    family_members = _tool_family_members()
+    current_location = ensure_user_location_valid()
+    form_state = {
+        'member_id': '',
+        'location': current_location,
+        'age': current_user.age or 65,
+        'chronic': [],
+    }
+    prediction = None
+    factors = None
+    prediction_error = None
+
+    if request.method == 'POST':
+        selected_member = _selected_member(request.form.get('member_id'))
+        default_age = selected_member.age if selected_member and selected_member.age else current_user.age or 65
+        default_gender = selected_member.gender if selected_member and selected_member.gender else current_user.gender or '男'
+        selected_chronic = _normalize_ml_chronic_list(request.form.getlist('chronic'))
+        if not selected_chronic and selected_member:
+            selected_chronic = _normalize_ml_chronic_list(
+                safe_json_loads(selected_member.chronic_diseases, [])
+            )
+
+        form_state = {
+            'member_id': str(selected_member.id) if selected_member else '',
+            'location': _normalized_location(request.form.get('location')),
+            'age': _coerce_age(request.form.get('age'), default_age),
+            'chronic': selected_chronic,
+        }
+
+        weather_info, _ = get_weather_with_cache(form_state['location'])
+        user_info = {
+            'age': form_state['age'],
+            'gender': default_gender,
+        }
+        result = get_ml_service().predict_disease_risk(user_info, weather_info)
+        if result.get('success'):
+            prediction = []
+            for item in (result.get('predictions') or [])[:3]:
+                score = int(round((item.get('probability') or 0) * 100))
+                prediction.append({
+                    'disease': item.get('disease', '未知风险'),
+                    'score': score,
+                    'label': _score_level(score),
+                })
+            factors = _build_ml_factor_cards(result, form_state['age'], weather_info)
+        else:
+            prediction_error = result.get('error') or '预测暂时不可用，请稍后再试。'
+
+    return render_template(
+        'ml_prediction.html',
+        family_members=family_members,
+        form_state=form_state,
+        prediction=prediction,
+        factors=factors,
+        prediction_error=prediction_error,
+    )
 
 
 @bp.route('/ai-qa', endpoint='ai_qa')
@@ -28,11 +239,63 @@ def ai_qa():
 @login_required
 def forecast_7day():
     """7天健康预测页面"""
-    return render_template('forecast_7day.html')
+    return render_template(
+        'forecast_7day.html',
+        family_members=_tool_family_members(),
+    )
 
 
-@bp.route('/chronic-risk', endpoint='chronic_risk')
+@bp.route('/chronic-risk', methods=['GET', 'POST'], endpoint='chronic_risk')
 @login_required
 def chronic_risk():
     """慢病风险预测页面"""
-    return render_template('chronic_risk.html')
+    form_state = {
+        'disease': 'hypertension',
+        'sbp': '',
+        'fbg': '',
+        'adherence': 'strict',
+        'symptoms': '',
+    }
+    risk_score = None
+    risk_comment = None
+    breakdown = None
+    suggestions = None
+
+    if request.method == 'POST':
+        disease_key = sanitize_input(request.form.get('disease'), max_length=32) or 'hypertension'
+        disease_key = disease_key if disease_key in CHRONIC_FORM_LABELS else 'hypertension'
+        form_state = {
+            'disease': disease_key,
+            'sbp': sanitize_input(request.form.get('sbp'), max_length=10) or '',
+            'fbg': sanitize_input(request.form.get('fbg'), max_length=10) or '',
+            'adherence': sanitize_input(request.form.get('adherence'), max_length=20) or 'strict',
+            'symptoms': sanitize_input(request.form.get('symptoms'), max_length=100) or '',
+        }
+
+        weather_data, _ = get_weather_with_cache(ensure_user_location_valid())
+        result = get_chronic_service().predict_individual_risk(
+            {
+                'age': current_user.age or 65,
+                'gender': current_user.gender or '未知',
+                'chronic_diseases': [CHRONIC_FORM_LABELS[disease_key]],
+            },
+            weather_data,
+        )
+
+        overall = result.get('overall_risk') or {}
+        risk_score = int(round(overall.get('score', 0) or 0))
+        risk_level = overall.get('level') or _score_level(risk_score)
+        risk_comment = (
+            f"当前以{CHRONIC_FORM_LABELS[disease_key]}为重点观察对象，结合天气条件判定为{risk_level}。"
+        )
+        breakdown = _build_chronic_breakdown(result, form_state['adherence'], form_state['symptoms'])
+        suggestions = (result.get('recommendations') or [])[:5]
+
+    return render_template(
+        'chronic_risk.html',
+        form_state=form_state,
+        risk_score=risk_score,
+        risk_comment=risk_comment,
+        breakdown=breakdown,
+        suggestions=suggestions,
+    )

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,1858 +1,812 @@
-/* 天气健康风险预测系统 - 商业化专业UI样式 */
+/* =====================================================================
+   宜老天气通 · 设计系统 v2  (双橙主题)
+   覆盖 Bootstrap 5,保留原有 class 契约,仅换"皮肤"
+   ===================================================================== */
 
-/* 全局样式 */
+/* ----- 1. 设计令牌 ------------------------------------------------- */
 :root {
-    --primary-color: #1a56db;
-    --primary-dark: #1e429f;
-    --primary-light: #3f83f8;
-    
-    --secondary-color: #6b7280;
-    --secondary-dark: #4b5563;
-    --secondary-light: #9ca3af;
-    
-    --success-color: #0e9f6e;
-    --success-dark: #047857;
-    --danger-color: #dc2626;
-    --warning-color: #d97706;
-    --info-color: #0284c7;
-    
-    --background-primary: #ffffff;
-    --background-secondary: #f9fafb;
-    --background-tertiary: #f3f4f6;
-    
-    --text-primary: #111827;
-    --text-secondary: #6b7280;
-    --text-tertiary: #9ca3af;
-    
-    --border-color: #e5e7eb;
-    --border-color-dark: #d1d5db;
-    
-    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
-    --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+  /* 品牌橙 */
+  --brand:        #EE7E2D;   /* logo 主色 */
+  --brand-deep:   #C25F14;   /* 悬停 / 深色 */
+  --brand-soft:   #F5A25C;   /* 琥珀辅色 */
+  --brand-cream:  #FEF6EC;   /* 奶油底 */
+  --brand-wash:   #FFF1E0;   /* 更浅的橙纱 */
+
+  /* 中性 */
+  --ink:          #1C1A17;
+  --ink-2:        #4C463E;
+  --ink-3:        #8A8274;
+  --bg:           #FBFAF7;   /* 奶油白底 */
+  --bg-2:         #F3EEE4;   /* 浅灰橙 */
+  --surface:      #FFFFFF;
+  --line:         #E4DCCC;
+  --line-soft:    #EFE8DA;
+
+  /* 语义色 */
+  --ok:    #4E8B49;
+  --warn:  #D88A2C;
+  --risk:  #C63E2C;
+  --info:  #2E7BB0;
+
+  /* 排版 */
+  --font-sans: -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB',
+               'Microsoft YaHei', 'Helvetica Neue', Arial, sans-serif;
+  --font-num:  'SF Pro Display', -apple-system, BlinkMacSystemFont, sans-serif;
+
+  --s-xs: 12px;
+  --s-sm: 13px;
+  --s-base: 15px;
+  --s-md: 16px;
+  --s-lg: 20px;
+  --s-xl: 26px;
+  --s-2xl: 36px;
+
+  --r-s: 8px;
+  --r-m: 12px;
+  --r-l: 16px;
+  --r-xl: 22px;
+
+  --shadow-s: 0 1px 2px rgba(43,28,8,.05);
+  --shadow-m: 0 4px 14px rgba(43,28,8,.08);
+  --shadow-l: 0 14px 34px rgba(43,28,8,.10);
+
+  --ease: cubic-bezier(.2,.7,.2,1);
+
+  /* Bootstrap 变量覆盖 — 让所有 .btn-primary / .text-primary 自动换色 */
+  --bs-primary: var(--brand);
+  --bs-primary-rgb: 238,126,45;
+  --bs-link-color: var(--brand-deep);
+  --bs-link-hover-color: var(--ink);
+  --bs-body-font-family: var(--font-sans);
+  --bs-body-color: var(--ink);
+  --bs-body-bg: var(--bg);
+  --bs-border-color: var(--line);
+  --bs-border-radius: var(--r-m);
+  --bs-border-radius-sm: var(--r-s);
+  --bs-border-radius-lg: var(--r-l);
+
+  /* 保留原项目使用过的旧变量名,避免老样式报错 */
+  --primary-color: var(--brand);
+  --primary-dark: var(--brand-deep);
+  --primary-light: var(--brand-soft);
+  --secondary-color: var(--ink-2);
+  --secondary-dark: var(--ink);
+  --secondary-light: var(--ink-3);
+  --success-color: var(--ok);
+  --success-dark: #3b6d37;
+  --danger-color: var(--risk);
+  --warning-color: var(--warn);
+  --info-color: var(--info);
+  --background-primary: var(--surface);
+  --background-secondary: var(--bg);
+  --background-tertiary: var(--bg-2);
+  --text-primary: var(--ink);
+  --text-secondary: var(--ink-2);
+  --text-tertiary: var(--ink-3);
+  --border-color: var(--line);
+  --border-color-dark: var(--line-soft);
+  --shadow-sm: var(--shadow-s);
+  --shadow-md: var(--shadow-m);
+  --shadow-lg: var(--shadow-l);
+  --shadow-xl: var(--shadow-l);
+  --glass-bg-strong: rgba(255,255,255,.92);
+  --glass-border: rgba(228,220,204,.7);
+  --glass-blur: 14px;
 }
+
+/* ----- 2. 基础重置 ------------------------------------------------- */
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Microsoft YaHei', 'Helvetica Neue', Arial, sans-serif;
-    background: var(--background-secondary);
-    color: var(--text-primary);
-    min-height: 100vh;
-    line-height: 1.6;
-    overflow-x: hidden;
+  font-family: var(--font-sans);
+  background: var(--bg);
+  color: var(--ink);
+  font-size: var(--s-base);
+  line-height: 1.65;
+  min-height: 100vh;
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
 }
 
-/* 页面内容淡入效果 */
-main {
-    animation: fadeIn 0.3s ease-in;
+h1, h2, h3, h4, h5, h6 {
+  color: var(--ink);
+  font-weight: 600;
+  letter-spacing: -.01em;
+  line-height: 1.3;
 }
 
-@keyframes fadeIn {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
-}
+a { color: var(--brand-deep); text-decoration: none; }
+a:hover { color: var(--ink); }
 
-/* 导航栏 - 专业商务风格 */
+::selection { background: var(--brand-wash); color: var(--brand-deep); }
+
+/* ----- 3. 导航栏 (navbar) ----------------------------------------- */
 .navbar {
-    background: var(--background-primary) !important;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-    border-bottom: 1px solid var(--border-color);
-    padding: 0.75rem 0;
+  background: var(--surface) !important;
+  border-bottom: 1px solid var(--line-soft);
+  box-shadow: 0 1px 0 rgba(43,28,8,.02);
+  padding: .8rem 0;
 }
-
 .navbar-brand {
-    font-weight: 600;
-    font-size: 1.25rem;
-    color: var(--primary-color) !important;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: var(--ink) !important;
+  display: flex; align-items: center; gap: .5rem;
+}
+.navbar-brand i.bi-cloud-sun {
+  width: 30px; height: 30px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: linear-gradient(135deg, var(--brand) 0%, var(--brand-soft) 100%);
+  color: #fff !important;
+  border-radius: 9px;
+  font-size: 16px;
+}
+.brand-tagline {
+  font-weight: 400; font-size: .82rem; color: var(--ink-3);
+  padding-left: .6rem; margin-left: .4rem;
+  border-left: 1px solid var(--line);
 }
 
-.navbar-brand i {
-    font-size: 1.5rem;
+/* 顶部右侧的 desktop 快捷按钮组 */
+.desktop-nav-actions .btn { border-radius: 999px; padding: .38rem .95rem; font-size: .85rem; }
+.desktop-nav-actions .btn-outline-secondary {
+  border-color: var(--line); color: var(--ink-2); background: transparent;
+}
+.desktop-nav-actions .btn-outline-secondary:hover {
+  background: var(--bg-2); color: var(--ink); border-color: var(--line);
+}
+.desktop-nav-actions .btn-outline-primary {
+  border-color: var(--brand); color: var(--brand-deep); background: transparent;
+}
+.desktop-nav-actions .btn-outline-primary:hover {
+  background: var(--brand); color: #fff;
+}
+.desktop-nav-actions .btn-outline-dark {
+  border-color: var(--ink); color: var(--ink);
+}
+.desktop-nav-actions .btn-outline-dark:hover {
+  background: var(--ink); color: #fff;
+}
+.desktop-nav-actions .btn-outline-danger {
+  border-color: var(--line); color: var(--ink-3);
+}
+.desktop-nav-actions .btn-outline-danger:hover {
+  background: rgba(198,62,44,.08); color: var(--risk); border-color: rgba(198,62,44,.3);
 }
 
-.navbar .navbar-nav .nav-link {
-    color: var(--text-primary) !important;
-    font-weight: 500;
-    font-size: 0.9375rem;
-    padding: 0.5rem 1rem;
-    transition: all 0.2s ease;
-    border-radius: 6px;
-    margin: 0 0.25rem;
+.navbar-toggler, .app-nav-toggle {
+  border: 1px solid var(--line); border-radius: 999px;
+  padding: .35rem .75rem; background: var(--surface);
+  color: var(--ink-2); font-size: .85rem;
 }
+.navbar-toggler:focus { box-shadow: none; }
 
-.navbar .navbar-nav .nav-link:hover {
-    color: var(--primary-color) !important;
-    background: var(--background-tertiary);
-}
-
-.navbar .navbar-nav .nav-link.active {
-    color: var(--primary-color) !important;
-    background: rgba(26, 86, 219, 0.1);
-}
-
-.navbar-brand {
-    white-space: nowrap;
-}
-
-/* Offcanvas navigation drawer */
+/* ----- 4. 抽屉 (offcanvas) ---------------------------------------- */
 .app-offcanvas {
-    background: var(--glass-bg-strong);
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-    border-left: 1px solid var(--glass-border);
-    --bs-offcanvas-width: min(92vw, 420px);
+  background: var(--surface);
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  border-left: 1px solid var(--line-soft);
+  --bs-offcanvas-width: min(92vw, 380px);
 }
-
 .app-offcanvas .offcanvas-header {
-    border-bottom: 1px solid var(--glass-border);
+  border-bottom: 1px solid var(--line-soft);
+  padding: 1rem 1.25rem;
 }
-
-.app-offcanvas .accordion-item {
-    background: transparent;
-    border: 0;
-    border-bottom: 1px solid var(--glass-border);
-}
-
+.app-offcanvas .offcanvas-title { font-weight: 600; color: var(--ink); }
+.app-offcanvas .accordion-item { background: transparent; border: 0; border-bottom: 1px solid var(--line-soft); }
 .app-offcanvas .accordion-button {
-    background: transparent;
-    color: var(--text-primary);
-    font-weight: 600;
-    padding-left: 0;
-    padding-right: 0;
+  background: transparent; color: var(--ink); font-weight: 500;
+  padding: .9rem 1.25rem; font-size: .9rem;
 }
-
-.app-offcanvas .accordion-button:focus {
-    box-shadow: none;
-}
-
-.app-offcanvas .accordion-button:not(.collapsed) {
-    color: var(--text-primary);
-    box-shadow: none;
-}
-
-.app-offcanvas .accordion-body {
-    padding-left: 0;
-    padding-right: 0;
-    padding-top: 0.25rem;
-    padding-bottom: 0.75rem;
-}
-
+.app-offcanvas .accordion-button:focus { box-shadow: none; }
+.app-offcanvas .accordion-button:not(.collapsed) { color: var(--brand-deep); background: var(--brand-cream); }
+.app-offcanvas .accordion-button::after { filter: grayscale(1) opacity(.5); }
+.app-offcanvas .accordion-body { padding: .25rem .75rem .75rem; }
 .app-offcanvas .app-nav-link {
-    color: var(--text-primary);
-    border-radius: 10px;
-    padding: 0.5rem 0.75rem;
-    margin: 0.125rem 0;
-    white-space: normal;
-    word-break: break-word;
+  color: var(--ink-2); border-radius: var(--r-m);
+  padding: .55rem .75rem; margin: .1rem 0;
+  font-size: .88rem; transition: all .2s var(--ease);
 }
-
 .app-offcanvas .app-nav-link:hover,
 .app-offcanvas .app-nav-link:focus {
-    color: var(--text-primary);
-    background: rgba(255, 255, 255, 0.4);
+  color: var(--brand-deep); background: var(--brand-cream);
 }
-
+.app-offcanvas .app-nav-link.active {
+  color: var(--brand-deep); background: var(--brand-cream); font-weight: 500;
+}
 .app-offcanvas .app-nav-meta {
-    color: var(--text-secondary);
-    font-size: 0.875rem;
+  color: var(--ink-3); font-size: .75rem; letter-spacing: .05em;
+  text-transform: uppercase; padding: .25rem .75rem;
 }
+.app-offcanvas hr { border-color: var(--line-soft); opacity: 1; }
 
-.app-offcanvas hr {
-    border-color: var(--glass-border);
-    opacity: 1;
-}
-
-/* 卡片样式 - 专业商务设计 */
-.card {
-    background: var(--background-primary);
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    box-shadow: var(--shadow-sm);
-    transition: all 0.2s ease;
-    overflow: hidden;
-}
-
-.card:hover {
-    box-shadow: var(--shadow-md);
-    border-color: var(--border-color-dark);
-}
-
-.card-header {
-    background: var(--background-tertiary);
-    border-bottom: 1px solid var(--border-color);
-    padding: 1rem 1.25rem;
-    font-weight: 600;
-    font-size: 1rem;
-    color: var(--text-primary);
-}
-
-.card-header.bg-primary {
-    background: var(--primary-color);
-    color: white;
-    border-bottom: none;
-}
-
-.card-header.bg-success {
-    background: var(--success-color);
-    color: white;
-    border-bottom: none;
-}
-
-.card-header.bg-info {
-    background: var(--info-color);
-    color: white;
-    border-bottom: none;
-}
-
-.card-header.bg-warning {
-    background: var(--warning-color);
-    color: white;
-    border-bottom: none;
-}
-
-.card-body {
-    padding: 1.25rem;
-}
-
-.card-footer {
-    background: var(--background-tertiary);
-    border-top: 1px solid var(--border-color);
-    padding: 0.75rem 1.25rem;
-}
-
-/* 按钮样式 - 专业商务 */
+/* ----- 5. 按钮 (btn) ---------------------------------------------- */
 .btn {
-    border-radius: 6px;
-    font-weight: 500;
-    padding: 0.5rem 1rem;
-    transition: all 0.15s ease-in-out;
-    border: 1px solid transparent;
-    font-size: 0.9375rem;
-    line-height: 1.5;
+  border-radius: var(--r-m);
+  font-weight: 500;
+  letter-spacing: .01em;
+  transition: all .18s var(--ease);
+  padding: .55rem 1.1rem;
+  font-size: .9rem;
 }
-
-.btn:hover {
-    transform: translateY(-1px);
-    box-shadow: var(--shadow-md);
-}
-
-.btn:active {
-    transform: translateY(0);
-}
+.btn-lg { padding: .8rem 1.5rem; font-size: 1rem; border-radius: var(--r-m); }
+.btn-sm { padding: .35rem .8rem; font-size: .82rem; border-radius: var(--r-s); }
 
 .btn-primary {
-    background: var(--primary-color);
-    border-color: var(--primary-color);
-    color: white;
+  background: var(--brand); border-color: var(--brand); color: #fff;
+  box-shadow: 0 1px 0 rgba(255,255,255,.25) inset, 0 2px 6px rgba(238,126,45,.22);
+}
+.btn-primary:hover, .btn-primary:focus, .btn-primary:active {
+  background: var(--brand-deep) !important; border-color: var(--brand-deep) !important;
+  color: #fff !important;
+  box-shadow: 0 4px 12px rgba(238,126,45,.3);
 }
 
-.btn-primary:hover {
-    background: var(--primary-dark);
-    border-color: var(--primary-dark);
+.btn-outline-primary {
+  background: transparent; color: var(--brand-deep); border-color: var(--brand);
+}
+.btn-outline-primary:hover, .btn-outline-primary:focus {
+  background: var(--brand); color: #fff; border-color: var(--brand);
+}
+
+.btn-secondary, .btn-outline-secondary {
+  background: var(--surface); color: var(--ink-2); border: 1px solid var(--line);
+}
+.btn-secondary:hover, .btn-outline-secondary:hover {
+  background: var(--bg-2); color: var(--ink); border-color: var(--line);
 }
 
 .btn-success {
-    background: var(--success-color);
-    border-color: var(--success-color);
-    color: white;
+  background: var(--ok); border-color: var(--ok); color: #fff;
 }
+.btn-success:hover { background: #3b6d37; border-color: #3b6d37; color: #fff; }
 
-.btn-success:hover {
-    background: var(--success-dark);
-    border-color: var(--success-dark);
-}
-
-.btn-danger {
-    background: var(--danger-color);
-    border-color: var(--danger-color);
-    color: white;
-}
-
-.btn-info {
-    background: var(--info-color);
-    border-color: var(--info-color);
-    color: white;
-}
+.btn-outline-success { background: transparent; color: var(--ok); border-color: var(--ok); }
+.btn-outline-success:hover { background: var(--ok); color: #fff; }
 
 .btn-warning {
-    background: var(--warning-color);
-    border-color: var(--warning-color);
-    color: white;
+  background: var(--warn); border-color: var(--warn); color: #fff;
 }
+.btn-warning:hover { background: #b16f1f; border-color: #b16f1f; color: #fff; }
 
-.btn-outline-primary {
-    color: var(--primary-color);
-    border-color: var(--primary-color);
-}
-
-.btn-outline-primary:hover {
-    background: var(--primary-color);
-    border-color: var(--primary-color);
-    color: white;
-}
-
-.btn-lg {
-    padding: 0.75rem 1.5rem;
-    font-size: 1rem;
-}
-
-.btn-sm {
-    padding: 0.375rem 0.75rem;
-    font-size: 0.875rem;
-}
-
-/* 表格样式 - 专业化 */
-.table {
-    font-size: 0.875rem;
-    color: var(--text-primary);
-}
-
-.table thead th {
-    font-weight: 600;
-    background-color: var(--background-tertiary);
-    border-bottom: 2px solid var(--border-color);
-    color: var(--text-secondary);
-    text-transform: uppercase;
-    font-size: 0.75rem;
-    letter-spacing: 0.5px;
-    padding: 0.75rem 1rem;
-}
-
-.table tbody tr {
-    transition: background-color 0.15s ease;
-    border-bottom: 1px solid var(--border-color);
-}
-
-.table tbody tr:hover {
-    background-color: var(--background-secondary);
-}
-
-.table tbody td {
-    padding: 0.75rem 1rem;
-    vertical-align: middle;
-}
-
-/* 徽章样式 - 专业化 */
-.badge {
-    padding: 0.35em 0.65em;
-    font-weight: 500;
-    border-radius: 4px;
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.3px;
-}
-
-.badge.bg-primary {
-    background: var(--primary-color) !important;
-}
-
-.badge.bg-success {
-    background: var(--success-color) !important;
-}
-
-.badge.bg-danger {
-    background: var(--danger-color) !important;
-}
-
-.badge.bg-warning {
-    background: var(--warning-color) !important;
-}
-
-.badge.bg-info {
-    background: var(--info-color) !important;
-}
-
-/* 进度条样式 */
-.progress {
-    border-radius: 6px;
-    background-color: #e9ecef;
-}
-
-.progress-bar {
-    border-radius: 6px;
-    font-weight: 600;
-}
-
-/* 输入框样式 - 专业化 */
-.form-control, .form-select {
-    border-radius: 6px;
-    border: 1px solid var(--border-color);
-    transition: all 0.15s ease-in-out;
-    font-size: 0.9375rem;
-    padding: 0.5rem 0.75rem;
-    color: var(--text-primary);
-}
-
-.form-control:focus, .form-select:focus {
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px rgba(26, 86, 219, 0.1);
-    outline: none;
-}
-
-.form-label {
-    font-weight: 500;
-    color: var(--text-secondary);
-    margin-bottom: 0.5rem;
-    font-size: 0.875rem;
-}
-
-.input-group-text {
-    background: var(--background-tertiary);
-    border: 1px solid var(--border-color);
-    color: var(--text-secondary);
-}
-
-/* 警告框样式 */
-.alert {
-    border-radius: 8px;
-    border: none;
-}
-
-/* 页脚样式 */
-footer {
-    margin-top: auto;
-    border-top: 1px solid #dee2e6;
-}
-
-/* 地图容器 */
-#map {
-    border: 2px solid #dee2e6;
-}
-
-/* 自定义图标 */
-.feature-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 2rem;
-    box-shadow: 0 4px 6px rgba(0,0,0,.1);
-}
-
-/* 统计卡片 */
-.stat-card {
-    border-left: 4px solid;
-}
-
-.stat-card.border-primary {
-    border-left-color: #0d6efd !important;
-}
-
-.stat-card.border-success {
-    border-left-color: #198754 !important;
-}
-
-.stat-card.border-info {
-    border-left-color: #0dcaf0 !important;
-}
-
-.stat-card.border-warning {
-    border-left-color: #ffc107 !important;
-}
-
-/* 响应式调整 */
-@media (max-width: 768px) {
-    .navbar-brand {
-        font-size: 1rem;
-    }
-    
-    .display-4 {
-        font-size: 2.5rem;
-    }
-    
-    .card-body {
-        padding: 1rem;
-    }
-    
-    #map {
-        height: 400px !important;
-    }
-}
-
-/* 加载动画 */
-.spinner-border {
-    width: 3rem;
-    height: 3rem;
-}
+.btn-outline-warning { color: var(--warn); border-color: var(--warn); }
+.btn-outline-warning:hover { background: var(--warn); color: #fff; }
 
-/* 工具提示 */
-.tooltip {
-    font-size: 0.875rem;
+.btn-danger {
+  background: var(--risk); border-color: var(--risk); color: #fff;
 }
+.btn-danger:hover { background: #9e2f20; border-color: #9e2f20; color: #fff; }
 
-/* 分页样式 */
-.pagination {
-    margin-bottom: 0;
-}
-
-.page-link {
-    border-radius: 6px;
-    margin: 0 2px;
-    border: 1px solid #dee2e6;
-}
-
-.page-item.active .page-link {
-    background-color: #0d6efd;
-    border-color: #0d6efd;
-}
-
-/* 模态框样式 */
-.modal-content {
-    border-radius: 12px;
-    border: none;
-}
-
-.modal-header {
-    border-top-left-radius: 12px;
-    border-top-right-radius: 12px;
-    border-bottom: 2px solid #dee2e6;
-}
-
-.modal-footer {
-    border-bottom-left-radius: 12px;
-    border-bottom-right-radius: 12px;
-    border-top: 1px solid #dee2e6;
-}
-
-/* 自定义滚动条 - 现代风格 */
-::-webkit-scrollbar {
-    width: 10px;
-    height: 10px;
-}
-
-::-webkit-scrollbar-track {
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 10px;
-}
-
-::-webkit-scrollbar-thumb {
-    background: var(--primary-gradient);
-    border-radius: 10px;
-    border: 2px solid transparent;
-    background-clip: padding-box;
-}
-
-::-webkit-scrollbar-thumb:hover {
-    background: var(--accent-gradient);
-    background-clip: padding-box;
-}
-
-/* 动画效果 */
-@keyframes fadeIn {
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-.fade-in {
-    animation: fadeIn 0.5s ease-in;
-}
-
-/* 文本截断 */
-.text-truncate-2 {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-}
-
-/* 空状态 */
-.empty-state {
-    padding: 3rem 1rem;
-    text-align: center;
-    color: #6c757d;
-}
-
-.empty-state i {
-    font-size: 4rem;
-    opacity: 0.3;
-    margin-bottom: 1rem;
-}
-
-/* 成功/错误消息 */
-.alert-dismissible {
-    padding-right: 3rem;
-}
-
-/* 数据加载中 */
-.loading-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(255,255,255,0.9);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 9999;
-}
-
-/* Liquid glass theme overrides */
-:root {
-    --primary-color: #1f7ae0;
-    --primary-dark: #1559b7;
-    --primary-light: #7ad4ff;
-
-    --secondary-color: #64748b;
-    --secondary-dark: #475569;
-    --secondary-light: #cbd5f5;
-
-    --success-color: #10b981;
-    --success-dark: #059669;
-    --danger-color: #ef4444;
-    --warning-color: #f59e0b;
-    --info-color: #0ea5e9;
-
-    --background-primary: rgba(255, 255, 255, 0.72);
-    --background-secondary: #eef4ff;
-    --background-tertiary: rgba(255, 255, 255, 0.55);
-
-    --text-primary: #0f172a;
-    --text-secondary: #475569;
-    --text-tertiary: #94a3b8;
-
-    --border-color: rgba(255, 255, 255, 0.5);
-    --border-color-dark: rgba(255, 255, 255, 0.7);
-
-    --shadow-sm: 0 6px 16px rgba(15, 23, 42, 0.08);
-    --shadow-md: 0 10px 24px rgba(15, 23, 42, 0.12);
-    --shadow-lg: 0 20px 40px rgba(15, 23, 42, 0.16);
-    --shadow-xl: 0 30px 60px rgba(15, 23, 42, 0.2);
-
-    --glass-bg: rgba(255, 255, 255, 0.6);
-    --glass-bg-strong: rgba(255, 255, 255, 0.78);
-    --glass-bg-soft: rgba(255, 255, 255, 0.38);
-    --glass-border: rgba(255, 255, 255, 0.45);
-    --glass-border-strong: rgba(255, 255, 255, 0.65);
-    --glass-shadow: 0 18px 40px rgba(15, 23, 42, 0.15);
-    --glass-shadow-strong: 0 28px 55px rgba(15, 23, 42, 0.2);
-    --glass-blur: 18px;
-    --glass-inset: inset 0 1px 0 rgba(255, 255, 255, 0.4);
-
-    --primary-gradient: linear-gradient(135deg, #22d3ee 0%, #3b82f6 55%, #1d4ed8 100%);
-    --accent-gradient: linear-gradient(135deg, rgba(34, 211, 238, 0.9) 0%, rgba(59, 130, 246, 0.9) 100%);
-    --accent-glow: 0 10px 30px rgba(34, 211, 238, 0.35);
-}
-
-body {
-    background: radial-gradient(1200px 800px at 10% -10%, rgba(56, 189, 248, 0.35), transparent 60%),
-                radial-gradient(900px 650px at 90% 15%, rgba(14, 165, 233, 0.25), transparent 55%),
-                radial-gradient(700px 520px at 20% 85%, rgba(59, 130, 246, 0.2), transparent 55%),
-                linear-gradient(120deg, #e6f3ff 0%, #f7fbff 45%, #eaf7ff 100%);
-    background-attachment: fixed;
-    position: relative;
-}
-
-body::before,
-body::after {
-    content: '';
-    position: fixed;
-    width: 520px;
-    height: 520px;
-    border-radius: 50%;
-    filter: blur(50px);
-    opacity: 0.6;
-    pointer-events: none;
-    z-index: 0;
-}
-
-body::before {
-    top: -160px;
-    left: -120px;
-    background: radial-gradient(circle at 30% 30%, rgba(56, 189, 248, 0.7), transparent 60%);
-}
-
-body::after {
-    bottom: -220px;
-    right: -140px;
-    background: radial-gradient(circle at 70% 30%, rgba(34, 211, 238, 0.6), transparent 60%);
-}
-
-main,
-footer {
-    position: relative;
-    z-index: 1;
-}
-
-.navbar {
-    background: var(--glass-bg-strong) !important;
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-    border-bottom: 1px solid var(--glass-border);
-    box-shadow: var(--glass-shadow);
-}
-
-.navbar-brand {
-    color: var(--text-primary) !important;
-}
-
-.navbar-dark .navbar-nav .nav-link {
-    color: var(--text-primary) !important;
-}
-
-.navbar-dark .navbar-nav .nav-link:hover {
-    background: rgba(255, 255, 255, 0.4);
-}
-
-.navbar-dark .navbar-nav .nav-link.active {
-    background: rgba(34, 211, 238, 0.2);
-}
+.btn-outline-danger { color: var(--risk); border-color: var(--risk); }
+.btn-outline-danger:hover { background: var(--risk); color: #fff; }
 
-.navbar-dark .navbar-toggler {
-    border-color: rgba(15, 23, 42, 0.15);
-}
+.btn-info, .btn-outline-info { color: var(--info); border-color: var(--info); }
+.btn-info { background: var(--info); color: #fff; }
 
-.navbar-dark .navbar-toggler-icon {
-    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%2815, 23, 42, 0.7%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+.btn-light {
+  background: rgba(255,255,255,.9); color: var(--ink); border-color: transparent;
 }
+.btn-light:hover { background: #fff; color: var(--ink); }
 
+/* ----- 6. 卡片 (card) --------------------------------------------- */
 .card {
-    background: var(--glass-bg);
-    border: 1px solid var(--glass-border);
-    box-shadow: var(--glass-shadow);
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
+  background: var(--surface);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--r-l);
+  box-shadow: var(--shadow-s);
+  transition: all .2s var(--ease);
+  overflow: hidden;
 }
-
 .card:hover {
-    box-shadow: var(--glass-shadow-strong);
-    transform: translateY(-2px);
+  box-shadow: var(--shadow-m);
+  border-color: var(--line);
 }
-
 .card-header {
-    background: rgba(255, 255, 255, 0.55);
-    border-bottom: 1px solid var(--glass-border);
-    backdrop-filter: blur(calc(var(--glass-blur) - 4px));
+  background: transparent;
+  border-bottom: 1px solid var(--line-soft);
+  padding: 1rem 1.25rem;
+  font-weight: 600;
+  font-size: .95rem;
+  color: var(--ink);
 }
+.card-header.bg-primary { background: var(--brand) !important; color: #fff; }
+.card-header.bg-success { background: var(--ok) !important; color: #fff; }
+.card-header.bg-warning { background: var(--warn) !important; color: #fff; }
+.card-header.bg-danger  { background: var(--risk) !important; color: #fff; }
+.card-header.bg-info    { background: var(--info) !important; color: #fff; }
+.card-header.bg-secondary { background: var(--ink-2) !important; color: #fff; }
+.card-header.bg-dark    { background: var(--ink) !important; color: #fff; }
+.card-header.bg-light   { background: var(--bg-2) !important; color: var(--ink); border-bottom-color: var(--line-soft); }
+.card-body { padding: 1.25rem; }
 
-.card-footer {
-    background: rgba(255, 255, 255, 0.45);
-    border-top: 1px solid var(--glass-border);
+/* ----- 7. 表单 (form) --------------------------------------------- */
+.form-control, .form-select {
+  border-radius: var(--r-m);
+  border: 1px solid var(--line);
+  padding: .6rem .85rem;
+  font-size: .92rem;
+  background: var(--surface);
+  color: var(--ink);
+  transition: border-color .15s, box-shadow .15s;
 }
+.form-control:focus, .form-select:focus {
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(238,126,45,.15);
+  outline: 0;
+}
+.form-label { font-weight: 500; color: var(--ink-2); font-size: .88rem; margin-bottom: .35rem; }
+.form-text, .text-secondary { color: var(--ink-3) !important; }
+.form-check-input:checked {
+  background-color: var(--brand); border-color: var(--brand);
+}
+.form-check-input:focus { box-shadow: 0 0 0 3px rgba(238,126,45,.15); border-color: var(--brand); }
 
-.card-header.bg-primary {
-    background: linear-gradient(135deg, rgba(34, 211, 238, 0.85), rgba(59, 130, 246, 0.85)) !important;
-    color: #fff;
+/* ----- 8. Alerts & Badges ----------------------------------------- */
+.alert {
+  border-radius: var(--r-m);
+  padding: .85rem 1.1rem;
+  border: 1px solid;
+  font-size: .9rem;
 }
-
-.card-header.bg-success {
-    background: linear-gradient(135deg, rgba(16, 185, 129, 0.85), rgba(5, 150, 105, 0.85)) !important;
-    color: #fff;
+.alert-primary, .alert-info {
+  background: var(--brand-wash); border-color: rgba(238,126,45,.25); color: var(--brand-deep);
 }
-
-.card-header.bg-info {
-    background: linear-gradient(135deg, rgba(14, 165, 233, 0.85), rgba(59, 130, 246, 0.85)) !important;
-    color: #fff;
-}
-
-.card-header.bg-warning {
-    background: linear-gradient(135deg, rgba(245, 158, 11, 0.85), rgba(249, 115, 22, 0.85)) !important;
-    color: #fff;
-}
-
-.card-header.bg-danger {
-    background: linear-gradient(135deg, rgba(239, 68, 68, 0.85), rgba(220, 38, 38, 0.85)) !important;
-    color: #fff;
-}
-
-.btn {
-    background: var(--glass-bg-soft);
-    border: 1px solid var(--glass-border);
-    box-shadow: var(--shadow-sm);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-}
-
-.btn-primary {
-    background: var(--primary-gradient);
-    border: none;
-    color: #fff;
-    box-shadow: var(--accent-glow);
-}
-
-.btn-primary:hover {
-    filter: brightness(1.04);
-}
-
-.btn-outline-primary {
-    background: rgba(255, 255, 255, 0.35);
-    border: 1px solid var(--glass-border-strong);
-    color: var(--primary-dark);
-}
-
-.btn-outline-primary:hover {
-    background: rgba(255, 255, 255, 0.55);
-    color: var(--primary-dark);
-}
-
-.btn-outline-secondary {
-    background: rgba(255, 255, 255, 0.35);
-    border: 1px solid var(--glass-border);
-}
-
-.table-responsive {
-    border-radius: 12px;
-    border: 1px solid var(--glass-border);
-    background: var(--glass-bg-strong);
-    box-shadow: var(--shadow-sm);
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-}
-
-.table {
-    margin-bottom: 0;
-}
-
-.table thead th {
-    background-color: rgba(255, 255, 255, 0.6);
-    border-bottom: 1px solid var(--glass-border);
-    color: var(--text-secondary);
-}
-
-.table tbody tr {
-    border-bottom: 1px solid rgba(255, 255, 255, 0.35);
-}
-
-.table tbody tr:hover {
-    background-color: rgba(255, 255, 255, 0.35);
-}
+.alert-success { background: rgba(78,139,73,.1); border-color: rgba(78,139,73,.3); color: #3b6d37; }
+.alert-warning { background: rgba(216,138,44,.12); border-color: rgba(216,138,44,.3); color: #8a5314; }
+.alert-danger  { background: rgba(198,62,44,.1); border-color: rgba(198,62,44,.3); color: #8a2418; }
 
 .badge {
-    border: 1px solid rgba(255, 255, 255, 0.4);
+  font-weight: 500; padding: .35em .7em; border-radius: 999px;
+  font-size: .72rem; letter-spacing: .02em;
+}
+.bg-primary-subtle   { background: var(--brand-wash) !important; color: var(--brand-deep) !important; }
+.bg-success-subtle   { background: rgba(78,139,73,.12) !important; color: #3b6d37 !important; }
+.bg-warning-subtle   { background: rgba(216,138,44,.15) !important; color: #8a5314 !important; }
+.bg-danger-subtle    { background: rgba(198,62,44,.12) !important; color: #8a2418 !important; }
+.bg-info-subtle      { background: rgba(46,123,176,.12) !important; color: #1e5a87 !important; }
+.bg-secondary-subtle { background: var(--bg-2) !important; color: var(--ink-2) !important; }
+
+.text-primary   { color: var(--brand-deep) !important; }
+.text-success   { color: #3b6d37 !important; }
+.text-warning   { color: #8a5314 !important; }
+.text-danger    { color: var(--risk) !important; }
+.text-info      { color: var(--info) !important; }
+.text-muted     { color: var(--ink-3) !important; }
+.text-gradient {
+  background: linear-gradient(135deg, var(--brand) 0%, var(--brand-deep) 100%);
+  -webkit-background-clip: text; background-clip: text; color: transparent;
 }
 
+.bg-primary   { background: var(--brand) !important; }
+.bg-success   { background: var(--ok) !important; }
+.bg-warning   { background: var(--warn) !important; }
+.bg-danger    { background: var(--risk) !important; }
+.bg-info      { background: var(--info) !important; }
+.bg-secondary { background: var(--ink-2) !important; }
+.bg-dark      { background: var(--ink) !important; }
+.bg-light     { background: var(--bg-2) !important; }
+
+/* ----- 9. 进度条 / 列表 ------------------------------------------- */
 .progress {
-    background-color: rgba(255, 255, 255, 0.45);
-    border: 1px solid var(--glass-border);
+  background: var(--bg-2);
+  border-radius: 999px;
+  overflow: hidden;
+  height: 10px;
 }
-
-.progress-bar {
-    background: var(--primary-gradient);
-    box-shadow: var(--glass-inset);
-}
-
-.form-control,
-.form-select {
-    background: rgba(255, 255, 255, 0.65);
-    border: 1px solid var(--glass-border);
-    box-shadow: var(--glass-inset);
-}
-
-.form-control:focus,
-.form-select:focus {
-    border-color: rgba(59, 130, 246, 0.6);
-    box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.18);
-}
-
-.input-group-text {
-    background: rgba(255, 255, 255, 0.5);
-    border: 1px solid var(--glass-border);
-}
-
-.alert {
-    background: var(--glass-bg-strong);
-    border: 1px solid var(--glass-border);
-    box-shadow: var(--shadow-sm);
-}
-
-.dropdown-menu {
-    background: var(--glass-bg-strong);
-    border: 1px solid var(--glass-border);
-    box-shadow: var(--glass-shadow);
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-}
+.progress-bar { background: var(--brand); }
+.progress-bar.bg-success { background: var(--ok) !important; }
+.progress-bar.bg-warning { background: var(--warn) !important; }
+.progress-bar.bg-danger { background: var(--risk) !important; }
 
 .list-group-item {
-    background: rgba(255, 255, 255, 0.6);
-    border: 1px solid rgba(255, 255, 255, 0.35);
+  background: var(--surface); border-color: var(--line-soft); color: var(--ink);
+  padding: .8rem 1rem;
 }
+.list-group-item:hover { background: var(--brand-cream); }
 
-.accordion-item {
-    background: var(--glass-bg);
-    border: 1px solid var(--glass-border);
-}
-
-.accordion-button {
-    background: rgba(255, 255, 255, 0.55);
-}
-
-.accordion-button:not(.collapsed) {
-    background: rgba(255, 255, 255, 0.7);
-    color: var(--text-primary);
-}
-
-.modal-content {
-    background: var(--glass-bg-strong);
-    border: 1px solid var(--glass-border);
-    box-shadow: var(--glass-shadow-strong);
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-}
-
-.bg-light {
-    background: rgba(255, 255, 255, 0.55) !important;
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-}
-
-.bg-white {
-    background: rgba(255, 255, 255, 0.75) !important;
-}
-
-footer {
-    background: var(--glass-bg-soft);
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-    border-top: 1px solid var(--glass-border);
-}
-
-#map {
-    border: 1px solid var(--glass-border);
-    border-radius: 12px;
-    background: rgba(255, 255, 255, 0.5);
-}
-
-.page-link {
-    background: rgba(255, 255, 255, 0.6);
-    border: 1px solid var(--glass-border);
-}
-
-.page-item.active .page-link {
-    background: var(--primary-gradient);
-    border: none;
-}
-
-::-webkit-scrollbar-track {
-    background: rgba(255, 255, 255, 0.35);
-}
-
-::-webkit-scrollbar-thumb {
-    background: var(--primary-gradient);
-}
-
-::-webkit-scrollbar-thumb:hover {
-    background: var(--accent-gradient);
-}
-
-.loading-overlay {
-    background: rgba(248, 250, 252, 0.7);
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-}
-
-.member-avatar {
-    background: var(--primary-gradient);
-}
-
-/* 家庭成员模块增强 */
-.member-card {
-    border-left: 4px solid var(--border-color);
-}
-
-.member-card.risk-low {
-    border-left-color: rgba(34, 197, 94, 0.6);
-}
-
-.member-card.risk-medium {
-    border-left-color: rgba(250, 204, 21, 0.8);
-}
-
-.member-card.risk-high {
-    border-left-color: rgba(239, 68, 68, 0.7);
-}
-
-.member-avatar {
-    width: 44px;
-    height: 44px;
-    border-radius: 12px;
-    background: var(--primary-light);
-    color: #fff;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.1rem;
-}
-
-.risk-badge {
-    padding: 0.4rem 0.6rem;
-    font-size: 0.75rem;
-}
-
-.risk-low {
-    background: rgba(34, 197, 94, 0.15);
-    color: #16a34a;
-}
-
-.risk-medium {
-    background: rgba(250, 204, 21, 0.2);
-    color: #ca8a04;
-}
-
-.risk-high {
-    background: rgba(239, 68, 68, 0.15);
-    color: #dc2626;
-}
-
-.profile-progress {
-    height: 6px;
-    background: var(--background-tertiary);
-}
-
-/* 适老模式 */
-body.elder-mode {
-    font-size: 1.08rem;
-    line-height: 1.75;
-    color: #111;
-    background-color: #ffffff;
-}
-
-body.elder-mode .card {
-    border-radius: 12px;
-    border-color: rgba(0, 0, 0, 0.2);
-}
-
-body.elder-mode .form-control,
-body.elder-mode .form-select {
-    font-size: 1.05rem;
-    padding: 0.7rem 0.9rem;
-}
-
-body.elder-mode .navbar-brand {
-    font-size: 1.45rem;
-}
-
-body.elder-mode .nav-link {
-    font-size: 1.05rem;
-}
-
-body.elder-mode .btn {
-    font-size: 1.05rem;
-    padding: 0.6rem 1rem;
-}
-
-body.elder-mode .badge {
-    font-size: 0.95rem;
-}
-
-body.elder-mode .elder-card {
-    padding: 0.25rem;
-}
-
-/* 2026 视觉收束：首页与入口页统一风格 */
-:root {
-    --brand-ink: #16324a;
-    --brand-ink-soft: #4f6981;
-    --brand-blue: #2f80ed;
-    --brand-blue-deep: #1657a1;
-    --brand-cyan: #67c8ff;
-    --brand-cream: #fff4d6;
-    --surface-strong: rgba(255, 255, 255, 0.9);
-    --surface-card: rgba(255, 255, 255, 0.8);
-    --surface-muted: rgba(247, 250, 255, 0.74);
-    --line-soft: rgba(92, 127, 162, 0.18);
-    --shadow-soft: 0 18px 45px rgba(17, 65, 111, 0.08);
-    --shadow-float: 0 28px 55px rgba(17, 65, 111, 0.14);
-}
-
-body {
-    font-family: "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
-    color: var(--brand-ink);
-    background:
-        radial-gradient(1100px 680px at 6% -8%, rgba(110, 198, 255, 0.28), transparent 62%),
-        radial-gradient(820px 520px at 100% 12%, rgba(255, 214, 140, 0.22), transparent 55%),
-        radial-gradient(880px 560px at 30% 100%, rgba(82, 159, 255, 0.14), transparent 58%),
-        linear-gradient(180deg, #f7fbff 0%, #eef6ff 46%, #f8fbff 100%);
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-.navbar-brand {
-    letter-spacing: -0.02em;
-}
-
-.page-shell {
-    position: relative;
-    z-index: 1;
-    padding-top: 1.5rem !important;
-    padding-bottom: 4rem !important;
-}
-
-.navbar {
-    background: rgba(255, 255, 255, 0.72) !important;
-    border-bottom: 1px solid rgba(135, 168, 206, 0.24);
-    box-shadow: 0 16px 40px rgba(16, 58, 99, 0.08);
-}
-
-.navbar .container-fluid {
-    max-width: 1320px;
-    padding-left: clamp(1rem, 2.5vw, 2rem);
-    padding-right: clamp(1rem, 2.5vw, 2rem);
-}
-
-.navbar-brand {
-    gap: 0.75rem;
-    font-size: 1.3rem;
-    font-weight: 700;
-    color: var(--brand-ink) !important;
-}
-
-.navbar-brand i {
-    width: 42px;
-    height: 42px;
-    border-radius: 14px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: #fff;
-    font-size: 1.2rem;
-    background: linear-gradient(135deg, var(--brand-cyan), var(--brand-blue));
-    box-shadow: 0 12px 28px rgba(47, 128, 237, 0.28);
-}
-
-.brand-tagline {
-    padding: 0.32rem 0.7rem;
-    border-radius: 999px;
-    font-size: 0.74rem;
-    font-weight: 600;
-    color: var(--brand-blue-deep);
-    background: rgba(47, 128, 237, 0.08);
-    border: 1px solid rgba(47, 128, 237, 0.12);
-}
-
-.desktop-nav-actions .btn {
-    padding: 0.55rem 1rem;
-}
-
-.app-nav-toggle {
-    padding: 0.55rem 0.9rem;
-    border-radius: 999px;
-    border: 1px solid rgba(47, 128, 237, 0.14);
-    background: rgba(255, 255, 255, 0.72);
-    box-shadow: 0 10px 24px rgba(17, 65, 111, 0.08);
-}
-
-.app-offcanvas {
-    background: rgba(250, 252, 255, 0.94);
-    border-left: 1px solid rgba(111, 149, 191, 0.2);
-}
-
-.app-offcanvas .accordion-item,
-.app-offcanvas .accordion-button,
-.app-offcanvas .accordion-body,
-.app-offcanvas .app-nav-link {
-    background: transparent;
-}
-
-.app-offcanvas .accordion-button {
-    border-radius: 16px;
-    font-weight: 600;
-    color: var(--brand-ink);
-}
-
-.app-offcanvas .accordion-button:not(.collapsed) {
-    background: rgba(47, 128, 237, 0.08);
-    color: var(--brand-blue-deep);
-}
-
-.app-offcanvas .app-nav-link {
-    border-radius: 14px;
-    color: var(--brand-ink);
-}
-
-.app-offcanvas .app-nav-link:hover,
-.app-offcanvas .app-nav-link:focus {
-    background: rgba(47, 128, 237, 0.08);
-    color: var(--brand-blue-deep);
-}
-
-.card {
-    border: 1px solid var(--line-soft);
-    border-radius: 24px;
-    background: var(--surface-card);
-    box-shadow: var(--shadow-soft);
-}
-
-.card:hover {
-    transform: translateY(-4px);
-    box-shadow: var(--shadow-float);
-}
-
-.card-header {
-    background: rgba(255, 255, 255, 0.74);
-}
-
-.btn {
-    border-radius: 999px;
-    font-weight: 600;
-    letter-spacing: 0.01em;
-    padding: 0.72rem 1.2rem;
-    box-shadow: 0 12px 28px rgba(17, 65, 111, 0.08);
-}
-
-.btn-primary {
-    background: linear-gradient(135deg, var(--brand-cyan) 0%, var(--brand-blue) 62%, var(--brand-blue-deep) 100%);
-    border: none;
-    color: #fff;
-    box-shadow: 0 16px 30px rgba(47, 128, 237, 0.28);
-}
-
-.btn-primary:hover {
-    filter: brightness(1.03);
-}
-
-.btn-outline-primary,
-.btn-outline-secondary,
-.btn-outline-success {
-    border-width: 1px;
-    background: rgba(255, 255, 255, 0.78);
-}
-
-.btn-outline-primary {
-    color: var(--brand-blue-deep);
-    border-color: rgba(47, 128, 237, 0.22);
-}
-
-.btn-outline-primary:hover {
-    background: rgba(47, 128, 237, 0.08);
-    color: var(--brand-blue-deep);
-}
-
-.btn-outline-secondary {
-    color: var(--brand-ink);
-    border-color: rgba(105, 133, 165, 0.22);
-}
-
-.btn-outline-secondary:hover {
-    background: rgba(22, 50, 74, 0.05);
-    color: var(--brand-ink);
-}
-
-.btn-outline-success {
-    color: #18794e;
-    border-color: rgba(24, 121, 78, 0.2);
-}
-
-.btn-outline-success:hover {
-    background: rgba(24, 121, 78, 0.08);
-    color: #18794e;
-}
-
-.form-control,
-.form-select {
-    min-height: 50px;
-    border-radius: 16px;
-    border: 1px solid rgba(96, 133, 169, 0.2);
-    background: rgba(255, 255, 255, 0.92);
-    box-shadow: none;
-}
-
-.form-control::placeholder {
-    color: #90a2b5;
-}
-
-.form-control:focus,
-.form-select:focus {
-    border-color: rgba(47, 128, 237, 0.42);
-    box-shadow: 0 0 0 4px rgba(103, 200, 255, 0.16);
-}
-
-.badge {
-    border: 1px solid rgba(255, 255, 255, 0.45);
-    border-radius: 999px;
-    padding: 0.5rem 0.8rem;
-}
+hr { border-color: var(--line-soft); opacity: 1; }
 
+/* ----- 10. 页脚 --------------------------------------------------- */
 .site-footer {
-    background: rgba(255, 255, 255, 0.58);
-    border-top: 1px solid rgba(123, 156, 192, 0.2);
+  background: transparent;
+  border-top: 1px solid var(--line-soft);
+  color: var(--ink-3) !important;
+  font-size: .85rem;
+  padding: 2rem 0;
+  margin-top: 4rem;
 }
+.footer-note { color: var(--ink-3); }
 
-.footer-note {
-    color: #64819d;
-    letter-spacing: 0.02em;
+/* ----- 11. Page loader -------------------------------------------- */
+.page-loader {
+  position: fixed; inset: 0; background: var(--bg);
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  z-index: 9999; transition: opacity .3s var(--ease);
 }
+.page-loader.hidden { opacity: 0; pointer-events: none; }
+.loader-spinner {
+  width: 40px; height: 40px; border: 3px solid var(--line);
+  border-top-color: var(--brand); border-radius: 999px;
+  animation: spin 1s linear infinite;
+}
+.loader-text { margin-top: 1rem; color: var(--ink-3); font-size: .9rem; }
+@keyframes spin { to { transform: rotate(360deg); } }
 
-.section-heading {
-    max-width: 760px;
-    margin: 0 auto 1.75rem;
-    text-align: center;
-}
-
-.section-heading.compact {
-    max-width: 680px;
-    margin-bottom: 1.25rem;
-}
-
-.section-kicker {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-    margin-bottom: 0.8rem;
-    padding: 0.36rem 0.8rem;
-    border-radius: 999px;
-    font-size: 0.8rem;
-    font-weight: 700;
-    color: var(--brand-blue-deep);
-    background: rgba(47, 128, 237, 0.08);
-    border: 1px solid rgba(47, 128, 237, 0.12);
-}
-
-.section-heading h2 {
-    margin-bottom: 0.75rem;
-    font-size: clamp(1.7rem, 2.2vw, 2.5rem);
-    line-height: 1.18;
-}
-
-.section-subtitle {
-    margin-bottom: 0;
-    color: var(--brand-ink-soft);
-    font-size: 1rem;
-}
-
-.text-gradient {
-    background: linear-gradient(135deg, var(--brand-blue-deep), #3b8cff, #6bc6ff);
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
-}
-
-.home-shell {
-    max-width: 1240px;
-}
+/* ===================================================================
+   HOME PAGE 专用 (.home-page / .home-hero / .feature-card / .journey-*)
+   ================================================================= */
+.home-shell { padding-top: 1.5rem; }
 
 .home-hero {
-    position: relative;
-    overflow: hidden;
-    padding: clamp(2rem, 4vw, 3.25rem);
-    border-radius: 34px;
-    border: 1px solid rgba(121, 160, 200, 0.2);
-    background:
-        radial-gradient(540px 260px at 95% 0%, rgba(255, 244, 214, 0.65), transparent 75%),
-        linear-gradient(140deg, rgba(255, 255, 255, 0.94) 0%, rgba(245, 250, 255, 0.86) 48%, rgba(239, 247, 255, 0.9) 100%);
-    box-shadow: var(--shadow-float);
+  position: relative;
+  padding: 3.5rem 2rem;
+  background:
+    radial-gradient(ellipse 90% 60% at 80% 0%, var(--brand-wash) 0%, transparent 60%),
+    linear-gradient(180deg, var(--brand-cream) 0%, var(--bg) 100%);
+  border-radius: var(--r-xl);
+  border: 1px solid var(--line-soft);
+  overflow: hidden;
 }
-
-.home-hero::before,
-.home-hero::after {
-    content: "";
-    position: absolute;
-    border-radius: 999px;
-    pointer-events: none;
-}
-
 .home-hero::before {
-    width: 340px;
-    height: 340px;
-    right: -120px;
-    top: -120px;
-    background: radial-gradient(circle, rgba(103, 200, 255, 0.22), transparent 72%);
-}
-
-.home-hero::after {
-    width: 260px;
-    height: 260px;
-    left: -80px;
-    bottom: -140px;
-    background: radial-gradient(circle, rgba(47, 128, 237, 0.12), transparent 72%);
+  content: ""; position: absolute; top: -120px; right: -80px;
+  width: 340px; height: 340px; border-radius: 50%;
+  background: radial-gradient(circle, rgba(245,162,92,.35) 0%, transparent 70%);
+  filter: blur(20px); pointer-events: none;
 }
 
 .hero-kicker {
-    display: inline-flex;
-    align-items: center;
-    margin-bottom: 1rem;
-    padding: 0.4rem 0.9rem;
-    border-radius: 999px;
-    font-size: 0.82rem;
-    font-weight: 700;
-    color: var(--brand-blue-deep);
-    background: rgba(47, 128, 237, 0.08);
-    border: 1px solid rgba(47, 128, 237, 0.12);
+  display: inline-block;
+  padding: .3rem .8rem;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  font-size: .8rem;
+  color: var(--ink-2);
+  margin-bottom: 1.25rem;
+  font-weight: 500;
 }
 
 .hero-title {
-    max-width: 11em;
-    margin-bottom: 1rem;
-    font-size: clamp(2.35rem, 5vw, 4.4rem);
-    line-height: 1.02;
+  font-size: clamp(2rem, 4.2vw, 3rem);
+  font-weight: 600;
+  color: var(--ink);
+  line-height: 1.2;
+  letter-spacing: -.02em;
+  margin-bottom: 1.25rem;
 }
-
-.hero-subtitle,
-.hero-note,
-.hero-panel-header p,
-.hero-journey-item p,
-.hero-stat p,
-.feature-copy p,
-.journey-step p,
-.trust-card p,
-.auth-subtitle,
-.auth-highlight-card p,
-.auth-note,
-.auth-quicklist {
-    color: var(--brand-ink-soft);
-}
+.hero-title .text-gradient { display: block; margin-top: .2em; }
 
 .hero-subtitle {
-    max-width: 42rem;
-    margin-bottom: 1.4rem;
-    font-size: 1.08rem;
-    line-height: 1.8;
+  font-size: 1.05rem;
+  color: var(--ink-2);
+  line-height: 1.7;
+  max-width: 560px;
+  margin-bottom: 1.5rem;
 }
 
-.hero-badges,
-.hero-actions,
-.auth-link-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.85rem;
-}
-
-.hero-badges {
-    margin-bottom: 1.5rem;
-}
-
+.hero-badges { display: flex; flex-wrap: wrap; gap: .5rem; margin-bottom: 2rem; }
 .hero-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-    padding: 0.72rem 1rem;
-    border-radius: 18px;
-    font-size: 0.94rem;
-    font-weight: 600;
-    color: var(--brand-ink);
-    background: rgba(255, 255, 255, 0.8);
-    border: 1px solid rgba(108, 147, 188, 0.18);
-    box-shadow: 0 10px 24px rgba(17, 65, 111, 0.05);
+  display: inline-flex; align-items: center; gap: .4rem;
+  padding: .35rem .85rem;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  font-size: .82rem;
+  color: var(--ink-2);
 }
+.hero-badge i { color: var(--brand); }
 
-.hero-note {
-    margin-top: 1rem;
-    font-size: 0.96rem;
-}
+.hero-actions { display: flex; flex-wrap: wrap; gap: .65rem; margin-bottom: .8rem; }
+.hero-note { font-size: .85rem; color: var(--ink-3); margin-top: .5rem; }
 
 .hero-panel {
-    position: relative;
-    padding: 1.6rem;
-    border-radius: 28px;
-    background:
-        radial-gradient(240px 160px at 100% 0%, rgba(255, 244, 214, 0.16), transparent 80%),
-        linear-gradient(160deg, rgba(11, 78, 137, 0.96) 0%, rgba(29, 108, 181, 0.96) 52%, rgba(52, 138, 221, 0.96) 100%);
-    color: #fff;
-    box-shadow: 0 26px 50px rgba(15, 70, 123, 0.26);
+  background: var(--surface);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--r-xl);
+  padding: 1.75rem;
+  box-shadow: var(--shadow-m);
 }
-
-.hero-panel-header h2 {
-    margin-bottom: 0.55rem;
-    font-size: 1.55rem;
-    line-height: 1.22;
-}
-
-.hero-panel-header p,
-.hero-journey-item p,
-.hero-stat p {
-    color: rgba(255, 255, 255, 0.78);
-}
-
+.hero-panel-header { border-bottom: 1px solid var(--line-soft); padding-bottom: 1.25rem; margin-bottom: 1.25rem; }
 .hero-panel-chip {
-    display: inline-flex;
-    margin-bottom: 0.95rem;
-    padding: 0.35rem 0.78rem;
-    border-radius: 999px;
-    font-size: 0.78rem;
-    font-weight: 700;
-    color: #fff;
-    background: rgba(255, 255, 255, 0.14);
-    border: 1px solid rgba(255, 255, 255, 0.18);
+  display: inline-block; padding: .2rem .6rem;
+  background: var(--brand-wash); color: var(--brand-deep);
+  border-radius: 999px; font-size: .75rem; font-weight: 500;
+  margin-bottom: .6rem;
 }
+.hero-panel h2 { font-size: 1.2rem; line-height: 1.4; margin-bottom: .4rem; }
+.hero-panel p { font-size: .9rem; color: var(--ink-3); margin: 0; }
 
-.hero-journey {
-    display: grid;
-    gap: 0.9rem;
-    margin: 1.4rem 0;
-}
-
-.hero-journey-item {
-    display: flex;
-    gap: 0.95rem;
-    align-items: flex-start;
-    padding: 1rem 1rem 0.95rem;
-    border-radius: 20px;
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    backdrop-filter: blur(10px);
-}
-
-.hero-journey-index,
-.journey-step-number {
-    flex: 0 0 auto;
-    width: 2.2rem;
-    height: 2.2rem;
-    border-radius: 999px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.84rem;
-    font-weight: 700;
-}
-
+.hero-journey { display: flex; flex-direction: column; gap: 1rem; margin-bottom: 1.25rem; }
+.hero-journey-item { display: flex; gap: .85rem; align-items: flex-start; }
 .hero-journey-index {
-    color: var(--brand-blue-deep);
-    background: #fff;
+  flex: 0 0 auto;
+  width: 28px; height: 28px;
+  background: var(--brand-cream);
+  color: var(--brand-deep);
+  border-radius: 8px;
+  font-weight: 600; font-size: .78rem;
+  display: inline-flex; align-items: center; justify-content: center;
 }
-
-.hero-journey-item h3,
-.journey-step h3,
-.trust-card h3,
-.feature-copy h3,
-.auth-highlight-card strong {
-    margin-bottom: 0.35rem;
-    font-size: 1.02rem;
-}
-
-.hero-journey-item p,
-.hero-stat p,
-.feature-copy p,
-.journey-step p,
-.trust-card p,
-.auth-highlight-card p {
-    margin-bottom: 0;
-    font-size: 0.94rem;
-    line-height: 1.7;
-}
+.hero-journey-item h3 { font-size: .92rem; margin-bottom: .2rem; }
+.hero-journey-item p  { font-size: .82rem; color: var(--ink-3); line-height: 1.55; margin: 0; }
 
 .hero-stats-grid {
-    display: grid;
-    gap: 0.85rem;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: .75rem;
+  padding-top: 1.25rem; border-top: 1px solid var(--line-soft);
 }
-
-.hero-stat {
-    min-height: 126px;
-    padding: 1rem;
-    border-radius: 18px;
-    background: rgba(255, 255, 255, 0.12);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-}
-
+.hero-stat { text-align: left; }
 .hero-stat span {
-    display: block;
-    margin-bottom: 0.45rem;
-    font-size: 0.78rem;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.72);
+  display: block; font-size: .7rem; text-transform: uppercase;
+  letter-spacing: .06em; color: var(--ink-3); margin-bottom: .2rem;
 }
+.hero-stat strong { display: block; font-size: 1rem; color: var(--ink); margin-bottom: .15rem; }
+.hero-stat p { font-size: .78rem; color: var(--ink-3); margin: 0; }
 
-.hero-stat strong {
-    display: block;
-    margin-bottom: 0.35rem;
-    font-size: 1.02rem;
+/* Section headings */
+.section-heading {
+  margin: 3rem 0 1.5rem;
+  max-width: 720px;
 }
-
-.feature-card,
-.journey-card,
-.journey-step,
-.trust-card,
-.auth-story,
-.auth-highlight-card,
-.auth-guide-card,
-.auth-note {
-    border: 1px solid var(--line-soft);
-    background: var(--surface-card);
-    box-shadow: var(--shadow-soft);
+.section-heading.compact { margin: 0 0 1rem; }
+.section-kicker {
+  display: inline-block; padding: .25rem .7rem;
+  background: var(--brand-wash); color: var(--brand-deep);
+  border-radius: 999px; font-size: .75rem; font-weight: 500;
+  margin-bottom: .8rem;
 }
-
-.feature-card,
-.trust-card,
-.journey-step {
-    height: 100%;
-    padding: 1.6rem;
-    border-radius: 24px;
+.section-heading h2 {
+  font-size: clamp(1.4rem, 2.5vw, 1.85rem);
+  font-weight: 600; line-height: 1.35;
+  color: var(--ink); margin-bottom: .5rem;
 }
+.section-subtitle { font-size: .95rem; color: var(--ink-3); line-height: 1.65; margin: 0; }
 
+/* Feature cards */
+.feature-card {
+  background: var(--surface);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--r-l);
+  padding: 1.75rem;
+  transition: all .2s var(--ease);
+  display: flex; flex-direction: column; gap: 1rem;
+  height: 100%;
+}
+.feature-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--brand);
+  box-shadow: var(--shadow-m);
+}
 .feature-icon {
-    width: 62px;
-    height: 62px;
-    margin-bottom: 1.1rem;
-    border-radius: 20px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.7rem;
-    color: #fff;
+  width: 44px; height: 44px;
+  border-radius: 12px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 1.2rem;
 }
-
-.feature-icon-primary {
-    background: linear-gradient(135deg, #4dbbff, #2f80ed);
+.feature-icon-primary { background: var(--brand-wash); color: var(--brand-deep); }
+.feature-icon-success { background: rgba(78,139,73,.12); color: #3b6d37; }
+.feature-icon-info    { background: rgba(46,123,176,.12); color: var(--info); }
+.feature-label {
+  font-size: .72rem; letter-spacing: .08em; text-transform: uppercase;
+  color: var(--ink-3); font-weight: 600; display: block; margin-bottom: .3rem;
 }
-
-.feature-icon-success {
-    background: linear-gradient(135deg, #46d8a2, #18a572);
-}
-
-.feature-icon-info {
-    background: linear-gradient(135deg, #7ccfff, #2fa5ed);
-}
-
-.feature-label,
-.trust-label {
-    display: inline-flex;
-    margin-bottom: 0.7rem;
-    font-size: 0.8rem;
-    font-weight: 700;
-    color: var(--brand-blue-deep);
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-}
-
-.feature-copy h3,
-.trust-card h3 {
-    margin-bottom: 0.7rem;
-    font-size: 1.25rem;
-}
-
-.feature-list {
-    margin: 1rem 0 0;
-    padding-left: 1.1rem;
-    color: var(--brand-ink);
-}
-
+.feature-copy h3 { font-size: 1.05rem; margin-bottom: .5rem; }
+.feature-copy p { font-size: .9rem; color: var(--ink-2); line-height: 1.65; margin-bottom: .8rem; }
+.feature-list { list-style: none; padding: 0; margin: 0; font-size: .85rem; color: var(--ink-2); }
 .feature-list li {
-    margin-bottom: 0.45rem;
-    line-height: 1.7;
+  position: relative; padding-left: 1.25rem; margin-bottom: .35rem;
+}
+.feature-list li::before {
+  content: ""; position: absolute; left: 0; top: .6em;
+  width: 14px; height: 2px; background: var(--brand); border-radius: 2px;
 }
 
+/* Journey card (底部流程) */
 .journey-card {
-    padding: 2rem;
-    border-radius: 30px;
+  background: linear-gradient(180deg, var(--surface) 0%, var(--brand-cream) 100%);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--r-xl);
+  padding: 2rem;
 }
-
 .journey-step {
-    position: relative;
-    overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--r-l);
+  padding: 1.25rem; height: 100%;
+  position: relative;
 }
-
-.journey-step::before {
-    content: "";
-    position: absolute;
-    inset: auto auto 0 0;
-    width: 100%;
-    height: 4px;
-    background: linear-gradient(90deg, rgba(103, 200, 255, 0.9), rgba(47, 128, 237, 0.9));
-}
-
 .journey-step-number {
-    margin-bottom: 1rem;
-    color: #fff;
-    background: linear-gradient(135deg, var(--brand-cyan), var(--brand-blue));
+  position: absolute; top: -14px; left: 1.25rem;
+  width: 28px; height: 28px;
+  background: var(--brand); color: #fff;
+  border-radius: 999px; font-weight: 600; font-size: .85rem;
+  display: inline-flex; align-items: center; justify-content: center;
+  box-shadow: 0 3px 8px rgba(238,126,45,.3);
 }
+.journey-step h3 { font-size: .95rem; margin: .75rem 0 .4rem; }
+.journey-step p { font-size: .82rem; color: var(--ink-2); line-height: 1.6; margin: 0; }
 
-.auth-shell {
-    max-width: 1200px;
-    min-height: calc(100vh - 11rem);
-    display: flex;
-    align-items: center;
-}
-
-.auth-story {
-    padding: clamp(1.8rem, 3vw, 2.6rem);
-    border-radius: 32px;
-}
-
+/* ===================================================================
+   AUTH 页面 (login / register)
+   ================================================================= */
+.auth-shell { padding: 2rem 0 3rem; }
+.auth-story { padding-top: 1rem; }
 .auth-title {
-    max-width: 12em;
-    margin-bottom: 0.9rem;
-    font-size: clamp(2rem, 4vw, 3.4rem);
-    line-height: 1.06;
+  font-size: clamp(1.6rem, 3vw, 2.2rem); font-weight: 600;
+  color: var(--ink); line-height: 1.3; letter-spacing: -.01em; margin-bottom: 1rem;
 }
-
-.auth-subtitle {
-    max-width: 40rem;
-    margin-bottom: 1.5rem;
-    font-size: 1.02rem;
-    line-height: 1.8;
-}
+.auth-subtitle { font-size: .98rem; color: var(--ink-2); line-height: 1.7; margin-bottom: 1.75rem; }
 
 .auth-highlight-grid {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 1rem;
-    margin-bottom: 1.3rem;
+  display: grid; grid-template-columns: 1fr; gap: .75rem; margin-bottom: 1.75rem;
 }
-
 .auth-highlight-card {
-    display: flex;
-    gap: 0.8rem;
-    align-items: flex-start;
-    padding: 1rem;
-    border-radius: 20px;
+  display: flex; gap: .85rem; align-items: flex-start;
+  background: var(--surface); border: 1px solid var(--line-soft);
+  border-radius: var(--r-m); padding: 1rem;
 }
-
 .auth-highlight-card i {
-    width: 42px;
-    height: 42px;
-    border-radius: 14px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: #fff;
-    font-size: 1.15rem;
-    background: linear-gradient(135deg, var(--brand-cyan), var(--brand-blue));
+  width: 36px; height: 36px; flex: 0 0 auto;
+  background: var(--brand-wash); color: var(--brand-deep);
+  border-radius: 10px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 1rem;
 }
+.auth-highlight-card strong { font-size: .9rem; color: var(--ink); }
+.auth-highlight-card p { font-size: .82rem; color: var(--ink-3); margin: .1rem 0 0; }
 
 .auth-guide-card {
-    margin-bottom: 1.25rem;
-    padding: 1.35rem 1.4rem;
-    border-radius: 24px;
+  background: var(--brand-cream); border: 1px solid rgba(238,126,45,.2);
+  border-radius: var(--r-l); padding: 1.5rem; margin-bottom: 1.5rem;
+}
+.auth-quicklist {
+  list-style: none; padding: 0; margin: 1rem 0 0; counter-reset: step;
+}
+.auth-quicklist li {
+  counter-increment: step;
+  padding: .5rem 0 .5rem 2rem; position: relative;
+  font-size: .88rem; color: var(--ink-2); line-height: 1.55;
+  border-bottom: 1px dashed rgba(238,126,45,.15);
+}
+.auth-quicklist li:last-child { border-bottom: 0; }
+.auth-quicklist li::before {
+  content: counter(step); position: absolute; left: 0; top: .5rem;
+  width: 22px; height: 22px;
+  background: var(--brand); color: #fff;
+  border-radius: 999px; font-size: .72rem; font-weight: 600;
+  display: inline-flex; align-items: center; justify-content: center;
 }
 
-.auth-quicklist {
-    margin: 1rem 0 0;
-    padding-left: 1.2rem;
-    line-height: 1.8;
-}
+.auth-link-row { display: flex; flex-wrap: wrap; gap: .5rem; }
+.auth-link-row .btn { border-radius: 999px; font-size: .82rem; padding: .4rem .9rem; }
 
 .auth-panel {
-    position: relative;
+  position: sticky; top: 5rem;
 }
-
-.auth-panel-head h2 {
-    margin-bottom: 0.4rem;
-    font-size: 1.8rem;
-}
-
-.auth-panel-head p {
-    margin-bottom: 0;
-    color: var(--brand-ink-soft);
-}
-
+.auth-panel-head { margin-bottom: 1.25rem; }
 .auth-icon-wrap {
-    width: 74px;
-    height: 74px;
-    margin: 0 auto 1rem;
-    border-radius: 24px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: #fff;
-    font-size: 2rem;
-    background: linear-gradient(135deg, var(--brand-cyan), var(--brand-blue-deep));
-    box-shadow: 0 18px 36px rgba(47, 128, 237, 0.28);
+  width: 56px; height: 56px; margin: 0 auto 1rem;
+  background: linear-gradient(135deg, var(--brand) 0%, var(--brand-soft) 100%);
+  color: #fff; border-radius: 16px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 1.5rem;
+  box-shadow: 0 8px 20px rgba(238,126,45,.25);
 }
+.auth-panel-head h2 { font-size: 1.35rem; margin-bottom: .3rem; }
+.auth-panel-head p { color: var(--ink-3); font-size: .88rem; margin: 0; }
 
-.auth-form-card {
-    border-radius: 28px;
-    background: rgba(255, 255, 255, 0.88);
-}
+.auth-form-card { border: 1px solid var(--line-soft); box-shadow: var(--shadow-m); border-radius: var(--r-l); }
+.auth-form-card .card-body { padding: 1.5rem; }
 
 .auth-note {
-    display: flex;
-    gap: 0.6rem;
-    align-items: center;
-    margin-top: 1rem;
-    padding: 0.95rem 1rem;
-    border-radius: 18px;
-    font-size: 0.95rem;
+  margin-top: 1rem; display: flex; gap: .5rem; align-items: flex-start;
+  padding: .75rem .9rem; background: var(--bg-2); border-radius: var(--r-m);
+  font-size: .82rem; color: var(--ink-3);
+}
+.auth-note i { color: var(--info); flex: 0 0 auto; margin-top: .15rem; }
+
+/* ===================================================================
+   通用页面外壳 / 通用标题栏
+   ================================================================= */
+.page-shell { padding-top: 1rem; padding-bottom: 3rem; }
+
+.yl-page-head {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 1rem; flex-wrap: wrap; margin-bottom: 1.5rem;
+}
+.yl-page-head h1, .yl-page-head h2 {
+  font-size: clamp(1.35rem, 2.2vw, 1.75rem); margin: 0 0 .25rem;
+  font-weight: 600; letter-spacing: -.01em;
+}
+.yl-page-head .sub { color: var(--ink-3); font-size: .9rem; }
+
+/* 快速 stat 小卡 */
+.yl-stat {
+  padding: 1rem 1.1rem; border-radius: var(--r-l);
+  background: var(--surface); border: 1px solid var(--line-soft);
+}
+.yl-stat-label { font-size: .72rem; letter-spacing: .08em; text-transform: uppercase; color: var(--ink-3); margin-bottom: .45rem; font-weight: 600; }
+.yl-stat-val { font-size: 1.7rem; font-weight: 600; color: var(--ink); line-height: 1.1; font-variant-numeric: tabular-nums; }
+.yl-stat-val small { font-size: .85rem; color: var(--ink-3); font-weight: 400; margin-left: .25rem; }
+.yl-stat-trend { margin-top: .35rem; font-size: .78rem; color: var(--ink-3); }
+.yl-stat-trend.up { color: #3b6d37; }
+.yl-stat-trend.warn { color: #8a5314; }
+.yl-stat-trend.down { color: var(--risk); }
+
+/* ===================================================================
+   AI 浮窗 (兼容原 .ai-floating-chat 样式)
+   ================================================================= */
+.ai-floating-chat-toggle {
+  background: linear-gradient(135deg, var(--brand) 0%, var(--brand-deep) 100%) !important;
+  box-shadow: 0 8px 20px rgba(238,126,45,.35) !important;
 }
 
-.auth-note i {
-    color: var(--brand-blue);
+/* ===================================================================
+   老人模式  body.elder-mode
+   ================================================================= */
+body.elder-mode {
+  font-size: 18px;
+  line-height: 1.8;
+}
+body.elder-mode .hero-title { font-size: clamp(2.2rem, 5vw, 3.4rem); }
+body.elder-mode .hero-subtitle { font-size: 1.2rem; line-height: 1.85; }
+body.elder-mode h1 { font-size: 2rem; }
+body.elder-mode h2 { font-size: 1.5rem; }
+body.elder-mode h3 { font-size: 1.2rem; }
+
+body.elder-mode .btn { padding: .85rem 1.4rem; font-size: 1.05rem; font-weight: 500; }
+body.elder-mode .btn-lg { padding: 1rem 1.75rem; font-size: 1.2rem; }
+body.elder-mode .btn-sm { padding: .55rem 1rem; font-size: .95rem; }
+
+body.elder-mode .form-control,
+body.elder-mode .form-select {
+  padding: .85rem 1rem; font-size: 1.05rem;
+}
+body.elder-mode .form-label { font-size: 1rem; }
+
+body.elder-mode .card-body { padding: 1.6rem; }
+body.elder-mode .card-header { padding: 1.2rem 1.5rem; font-size: 1.1rem; }
+
+body.elder-mode .hero-badge, body.elder-mode .hero-kicker { font-size: 1rem; }
+body.elder-mode .feature-list { font-size: 1rem; }
+
+/* 提高对比度 */
+body.elder-mode { color: #000; background: #FFF9EF; }
+body.elder-mode .text-muted, body.elder-mode .form-text,
+body.elder-mode .text-secondary { color: #5a544a !important; }
+body.elder-mode .navbar { border-bottom: 2px solid var(--line); }
+body.elder-mode .card { border-width: 2px; }
+
+/* ===================================================================
+   辅助工具类 / 动效
+   ================================================================= */
+.yl-fade-up { animation: ylFadeUp .55s var(--ease) both; }
+.yl-fade-up-d1 { animation-delay: .06s; }
+.yl-fade-up-d2 { animation-delay: .12s; }
+.yl-fade-up-d3 { animation-delay: .18s; }
+.yl-fade-up-d4 { animation-delay: .24s; }
+@keyframes ylFadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
-@media (max-width: 1199.98px) {
-    .hero-title {
-        max-width: 100%;
-    }
-
-    .hero-stats-grid {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    .auth-highlight-grid {
-        grid-template-columns: 1fr;
-    }
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: .01ms !important;
+    transition-duration: .01ms !important;
+  }
 }
 
-@media (max-width: 991.98px) {
-    .page-shell {
-        padding-top: 1rem !important;
-        padding-bottom: 3rem !important;
-    }
-
-    .home-hero,
-    .auth-story {
-        border-radius: 28px;
-    }
-
-    .hero-panel {
-        padding: 1.35rem;
-    }
-}
-
-@media (max-width: 767.98px) {
-    .navbar-brand {
-        gap: 0.55rem;
-        font-size: 1.08rem;
-    }
-
-    .navbar-brand i {
-        width: 36px;
-        height: 36px;
-        border-radius: 12px;
-        font-size: 1rem;
-    }
-
-    .home-hero,
-    .journey-card,
-    .auth-story,
-    .auth-form-card {
-        padding: 1.25rem;
-        border-radius: 22px;
-    }
-
-    .hero-title {
-        font-size: 2.3rem;
-    }
-
-    .hero-badge,
-    .btn {
-        width: 100%;
-        justify-content: center;
-    }
-
-    .hero-actions,
-    .auth-link-row {
-        gap: 0.7rem;
-    }
-
-    .hero-stats-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .feature-card,
-    .journey-step,
-    .trust-card,
-    .auth-highlight-card,
-    .auth-note {
-        padding: 1.15rem;
-        border-radius: 20px;
-    }
+/* ===================================================================
+   响应式 — 小屏适配
+   ================================================================= */
+@media (max-width: 768px) {
+  .home-hero { padding: 2.25rem 1.25rem; }
+  .hero-title { font-size: 1.75rem; }
+  .hero-stats-grid { grid-template-columns: 1fr 1fr; }
+  .hero-stat:nth-child(3) { grid-column: 1 / -1; }
+  .section-heading { margin: 2rem 0 1.25rem; }
+  .brand-tagline { display: none !important; }
+  .auth-panel { position: static; margin-top: 1rem; }
 }

--- a/static/css/yilao.css
+++ b/static/css/yilao.css
@@ -1,0 +1,1136 @@
+/* ============================================================
+   宜老天气通 · 客户端视觉系统 (双橙 · 温柔医疗暖)
+   用法:  在 templates/base.html 的 <head> 里以最后一条 CSS 引入,
+          它会覆盖 Bootstrap 与旧版 style.css 的关键类。
+   ============================================================ */
+
+/* ----- 设计 tokens ----- */
+:root {
+    /* 品牌双橙 */
+    --yl-orange-600: #D66A1E;
+    --yl-orange-500: #EE7E2D;   /* 主色 */
+    --yl-orange-400: #F5A25C;   /* 辅色 / 琥珀 */
+    --yl-orange-200: #FBDCC0;
+    --yl-orange-100: #FBF1DC;   /* 奶油底 */
+    --yl-orange-50:  #FEF8EE;
+
+    /* 中性 */
+    --yl-ink:        #2A2620;
+    --yl-ink-soft:   #57504A;
+    --yl-muted:      #8A837C;
+    --yl-line:       #ECE3D6;
+    --yl-line-soft:  #F4EDDF;
+    --yl-surface:    #FFFFFF;
+    --yl-bg:         #FBF7EE;
+
+    /* 语义色 */
+    --yl-success:    #4E8B49;
+    --yl-success-50: #E7F1E4;
+    --yl-warn:       #D98B1E;
+    --yl-warn-50:    #FBEFD5;
+    --yl-danger:     #C7472E;
+    --yl-danger-50:  #F9E1DA;
+    --yl-info:       #2F6FED;
+    --yl-info-50:    #DDE8FC;
+
+    /* 风险等级配色(客户端专用,比语义色更"晒过太阳的橘") */
+    --yl-risk-low:   #4E8B49;
+    --yl-risk-mid:   #EE7E2D;
+    --yl-risk-high:  #C7472E;
+    --yl-risk-peak:  #7A2418;
+
+    /* 几何 */
+    --yl-radius-lg:  18px;
+    --yl-radius:     14px;
+    --yl-radius-sm:  10px;
+
+    /* 阴影 */
+    --yl-shadow-sm:  0 1px 2px rgba(66, 48, 28, .04);
+    --yl-shadow:     0 6px 20px rgba(66, 48, 28, .06);
+    --yl-shadow-lg:  0 18px 48px rgba(66, 48, 28, .12);
+
+    /* 字体 */
+    --yl-font:       "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "HarmonyOS Sans SC", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+
+    /* Bootstrap 覆盖 */
+    --bs-primary: var(--yl-orange-500);
+    --bs-primary-rgb: 238, 126, 45;
+    --bs-body-color: var(--yl-ink);
+    --bs-body-bg: var(--yl-bg);
+    --bs-border-color: var(--yl-line);
+    --bs-link-color: var(--yl-orange-600);
+    --bs-link-hover-color: var(--yl-orange-500);
+}
+
+/* ----- 基础 ----- */
+html, body {
+    background: var(--yl-bg);
+    color: var(--yl-ink);
+    font-family: var(--yl-font);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    max-width: 100%;
+    overflow-x: hidden;
+}
+body { font-size: 15px; line-height: 1.6; }
+main.page-shell {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: clip;
+}
+body.dashboard-page main.page-shell {
+    padding-top: clamp(12px, 1.6vw, 18px) !important;
+    padding-bottom: clamp(24px, 2vw, 32px) !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+}
+h1, h2, h3, h4, h5, h6 { color: var(--yl-ink); font-weight: 600; letter-spacing: -0.01em; }
+h1 { font-size: 2rem; }
+h2 { font-size: 1.5rem; }
+h3 { font-size: 1.25rem; }
+h4 { font-size: 1.1rem; }
+h5 { font-size: 1rem; }
+h6 { font-size: 0.9rem; color: var(--yl-ink-soft); }
+p  { color: var(--yl-ink-soft); }
+.text-muted { color: var(--yl-muted) !important; }
+a  { color: var(--yl-orange-600); text-decoration: none; }
+a:hover { color: var(--yl-orange-500); }
+
+/* loader 淡一点 */
+.page-loader { background: rgba(251, 247, 238, .92); }
+.loader-spinner {
+    border: 3px solid var(--yl-orange-100);
+    border-top-color: var(--yl-orange-500);
+}
+
+/* ----- 导航栏 ----- */
+.navbar {
+    background: rgba(255, 255, 255, 0.88) !important;
+    backdrop-filter: saturate(180%) blur(16px);
+    -webkit-backdrop-filter: saturate(180%) blur(16px);
+    border-bottom: 1px solid var(--yl-line-soft);
+    padding: 12px 0;
+    box-shadow: none;
+}
+.navbar .container-fluid { max-width: none; margin: 0; padding: 0 clamp(12px, 1.6vw, 16px); }
+.navbar-brand {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-weight: 700; font-size: 1.1rem; color: var(--yl-ink) !important;
+}
+.navbar-brand i, .navbar-brand .bi {
+    color: var(--yl-orange-500);
+    font-size: 1.4rem;
+}
+.navbar .nav-link {
+    color: var(--yl-ink-soft) !important;
+    font-weight: 500;
+    padding: 8px 14px !important;
+    border-radius: 10px;
+    transition: all .15s ease;
+}
+.navbar .nav-link:hover {
+    background: var(--yl-orange-50);
+    color: var(--yl-orange-600) !important;
+}
+.navbar .nav-link.active,
+.navbar .nav-link[aria-current="page"] {
+    background: var(--yl-orange-100);
+    color: var(--yl-orange-600) !important;
+}
+.navbar-toggler {
+    border: 1px solid var(--yl-line);
+    border-radius: 10px;
+    padding: 6px 10px;
+}
+.navbar-toggler:focus { box-shadow: none; }
+
+/* ----- 按钮 ----- */
+.btn {
+    border-radius: 12px;
+    font-weight: 500;
+    padding: 10px 18px;
+    border-width: 1px;
+    transition: transform .1s ease, box-shadow .15s ease, background .15s ease;
+}
+.btn:active { transform: translateY(1px); }
+.btn-lg { padding: 14px 22px; font-size: 1rem; border-radius: 14px; }
+.btn-sm { padding: 6px 12px; font-size: .85rem; border-radius: 10px; }
+
+.btn-primary {
+    background: var(--yl-orange-500);
+    border-color: var(--yl-orange-500);
+    color: #fff;
+    box-shadow: 0 4px 12px rgba(238, 126, 45, .22);
+}
+.btn-primary:hover, .btn-primary:focus {
+    background: var(--yl-orange-600);
+    border-color: var(--yl-orange-600);
+    color: #fff;
+    box-shadow: 0 6px 16px rgba(238, 126, 45, .28);
+}
+.btn-outline-primary {
+    background: transparent;
+    border-color: var(--yl-orange-500);
+    color: var(--yl-orange-600);
+}
+.btn-outline-primary:hover {
+    background: var(--yl-orange-50);
+    border-color: var(--yl-orange-500);
+    color: var(--yl-orange-600);
+}
+
+.btn-secondary { background: var(--yl-ink); border-color: var(--yl-ink); }
+.btn-outline-secondary {
+    background: #fff; border-color: var(--yl-line);
+    color: var(--yl-ink-soft);
+}
+.btn-outline-secondary:hover { background: #fff; border-color: var(--yl-orange-400); color: var(--yl-ink); }
+
+.btn-success { background: var(--yl-success); border-color: var(--yl-success); }
+.btn-outline-success { color: var(--yl-success); border-color: var(--yl-success); }
+.btn-outline-success:hover { background: var(--yl-success-50); color: var(--yl-success); }
+
+.btn-warning { background: var(--yl-warn); border-color: var(--yl-warn); color: #fff; }
+.btn-outline-warning { color: var(--yl-warn); border-color: var(--yl-warn); }
+
+.btn-danger { background: var(--yl-danger); border-color: var(--yl-danger); }
+.btn-outline-danger { color: var(--yl-danger); border-color: var(--yl-danger); }
+
+.btn-info { background: var(--yl-info); border-color: var(--yl-info); color: #fff; }
+
+.btn-light { background: #fff; border-color: var(--yl-line); color: var(--yl-ink); }
+.btn-light:hover { background: var(--yl-orange-50); color: var(--yl-orange-600); }
+
+.btn-link { color: var(--yl-orange-600); text-decoration: none; }
+
+/* ----- 卡片 ----- */
+.card {
+    background: var(--yl-surface);
+    border: 1px solid var(--yl-line-soft);
+    border-radius: var(--yl-radius-lg);
+    box-shadow: var(--yl-shadow-sm);
+    overflow: hidden;
+}
+.card .card-body { padding: 1.25rem 1.4rem; }
+.card.shadow-sm, .shadow-sm { box-shadow: var(--yl-shadow-sm) !important; }
+.card.shadow, .shadow { box-shadow: var(--yl-shadow) !important; }
+
+/* 去掉 bootstrap 的彩色 card-header 大色块,改成极简文本带 */
+.card .card-header {
+    background: transparent;
+    border-bottom: 1px solid var(--yl-line-soft);
+    padding: 1rem 1.4rem;
+    color: var(--yl-ink);
+    font-weight: 600;
+}
+.card .card-header h5, .card .card-header h6 { margin: 0; color: inherit; font-weight: 600; }
+.card .card-header.bg-primary,
+.card .card-header.bg-success,
+.card .card-header.bg-warning,
+.card .card-header.bg-danger,
+.card .card-header.bg-info,
+.card .card-header.bg-secondary,
+.card .card-header.bg-dark {
+    background: transparent !important;
+    color: var(--yl-ink) !important;
+}
+.card .card-header.bg-primary .bi { color: var(--yl-orange-500); }
+.card .card-header.bg-success .bi { color: var(--yl-success); }
+.card .card-header.bg-warning .bi { color: var(--yl-warn); }
+.card .card-header.bg-danger .bi  { color: var(--yl-danger); }
+.card .card-header.bg-info .bi    { color: var(--yl-info); }
+
+/* ----- 表单 ----- */
+.form-control, .form-select {
+    background: #fff;
+    border: 1px solid var(--yl-line);
+    border-radius: 12px;
+    padding: 11px 14px;
+    color: var(--yl-ink);
+    font-size: .95rem;
+    box-shadow: none;
+    transition: border-color .15s ease, box-shadow .15s ease;
+}
+.form-control:focus, .form-select:focus {
+    border-color: var(--yl-orange-400);
+    box-shadow: 0 0 0 3px rgba(238, 126, 45, .14);
+}
+.form-control::placeholder { color: var(--yl-muted); }
+.form-label {
+    color: var(--yl-ink);
+    font-weight: 500;
+    font-size: .9rem;
+    margin-bottom: 6px;
+}
+.form-check-input:checked {
+    background-color: var(--yl-orange-500);
+    border-color: var(--yl-orange-500);
+}
+.form-switch .form-check-input:checked { background-color: var(--yl-orange-500); }
+.form-text { color: var(--yl-muted); }
+
+/* ----- 徽章 ----- */
+.badge {
+    font-weight: 500;
+    padding: 5px 10px;
+    border-radius: 999px;
+    letter-spacing: .01em;
+}
+.badge.bg-primary   { background: var(--yl-orange-500) !important; }
+.badge.bg-success   { background: var(--yl-success) !important; }
+.badge.bg-warning   { background: var(--yl-warn) !important; color: #fff !important; }
+.badge.bg-danger    { background: var(--yl-danger) !important; }
+.badge.bg-info      { background: var(--yl-info) !important; }
+.badge.bg-secondary { background: var(--yl-ink-soft) !important; }
+.badge.bg-light     { background: var(--yl-orange-50) !important; color: var(--yl-ink) !important; }
+.badge.bg-dark      { background: var(--yl-ink) !important; }
+
+.badge.bg-success-subtle { background: var(--yl-success-50) !important; color: var(--yl-success) !important; }
+.badge.bg-warning-subtle { background: var(--yl-warn-50) !important; color: var(--yl-warn) !important; }
+.badge.bg-danger-subtle  { background: var(--yl-danger-50) !important; color: var(--yl-danger) !important; }
+.badge.bg-info-subtle    { background: var(--yl-info-50) !important; color: var(--yl-info) !important; }
+.badge.bg-secondary-subtle { background: var(--yl-line-soft) !important; color: var(--yl-ink-soft) !important; }
+
+/* 进度条 */
+.progress {
+    background: var(--yl-line-soft);
+    border-radius: 999px;
+    height: 10px;
+    overflow: hidden;
+}
+.progress-bar { background: var(--yl-orange-500); }
+.progress-bar.bg-success { background: var(--yl-success) !important; }
+.progress-bar.bg-warning { background: var(--yl-warn) !important; }
+.progress-bar.bg-danger  { background: var(--yl-danger) !important; }
+
+/* ----- Alert ----- */
+.alert {
+    border-radius: var(--yl-radius);
+    border: 1px solid transparent;
+    padding: 12px 16px;
+}
+.alert-primary { background: var(--yl-orange-50); border-color: var(--yl-orange-200); color: var(--yl-orange-600); }
+.alert-success { background: var(--yl-success-50); border-color: #cfe6ca; color: var(--yl-success); }
+.alert-warning { background: var(--yl-warn-50); border-color: #f2dca2; color: #8A5A12; }
+.alert-danger  { background: var(--yl-danger-50); border-color: #f0c4b9; color: var(--yl-danger); }
+.alert-info    { background: var(--yl-info-50); border-color: #c2d5f7; color: #1D4CAD; }
+
+/* ----- 表格 ----- */
+.table {
+    --bs-table-bg: transparent;
+    color: var(--yl-ink);
+    font-size: .92rem;
+}
+.table thead th {
+    background: var(--yl-orange-50);
+    color: var(--yl-ink-soft);
+    font-weight: 600;
+    border-bottom: 1px solid var(--yl-line);
+    padding: 10px 14px;
+}
+.table tbody td {
+    border-bottom: 1px solid var(--yl-line-soft);
+    padding: 10px 14px;
+    vertical-align: middle;
+}
+.table-sm tbody td, .table-sm thead th { padding: 8px 12px; }
+
+/* ----- List group ----- */
+.list-group-item {
+    border: 1px solid var(--yl-line-soft);
+    background: #fff;
+    color: var(--yl-ink);
+}
+.list-group-item + .list-group-item { border-top: 0; }
+.list-group-item:first-child { border-top-left-radius: var(--yl-radius); border-top-right-radius: var(--yl-radius); }
+.list-group-item:last-child  { border-bottom-left-radius: var(--yl-radius); border-bottom-right-radius: var(--yl-radius); }
+
+/* ----- 手风琴 ----- */
+.accordion-item {
+    border: 1px solid var(--yl-line-soft);
+    border-radius: var(--yl-radius) !important;
+    margin-bottom: 10px;
+    background: #fff;
+    overflow: hidden;
+}
+.accordion-button {
+    background: #fff;
+    color: var(--yl-ink);
+    font-weight: 500;
+    padding: 14px 18px;
+    box-shadow: none;
+}
+.accordion-button:not(.collapsed) {
+    background: var(--yl-orange-50);
+    color: var(--yl-orange-600);
+    box-shadow: inset 0 -1px 0 var(--yl-orange-200);
+}
+.accordion-button:focus { box-shadow: 0 0 0 3px rgba(238, 126, 45, .14); border-color: var(--yl-orange-400); }
+.accordion-body { padding: 16px 18px; background: #fff; }
+
+/* ============================================================
+   组件 · 宜老专用 (yl-*)
+   ============================================================ */
+
+/* 章节标题 */
+.yl-section {
+    background: #fff;
+    border: 1px solid var(--yl-line-soft);
+    border-radius: var(--yl-radius-lg);
+    padding: 24px 28px;
+    margin-bottom: 20px;
+}
+.section-heading { margin-bottom: 18px; }
+.section-heading.compact { margin-bottom: 8px; }
+.yl-section-head {
+    row-gap: 12px;
+}
+.yl-section-head .btn {
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+.section-kicker {
+    display: inline-block;
+    font-size: .78rem;
+    color: var(--yl-orange-600);
+    background: var(--yl-orange-50);
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-weight: 600;
+    letter-spacing: .03em;
+    margin-bottom: 8px;
+}
+.section-heading h2 {
+    font-size: 1.6rem;
+    margin: 0;
+    letter-spacing: -0.02em;
+    text-wrap: pretty;
+}
+.section-heading p { color: var(--yl-muted); margin: 6px 0 0; }
+
+/* 顶部 Hero */
+.yl-hero {
+    position: relative;
+    background: linear-gradient(135deg, #FFF3DD 0%, #FEE5C7 55%, #FBD49A 100%);
+    border-radius: 24px;
+    padding: 48px 44px;
+    overflow: hidden;
+    margin-bottom: 28px;
+    border: 1px solid var(--yl-orange-200);
+}
+.yl-hero::before {
+    content: "";
+    position: absolute; inset: -40% -20% auto auto;
+    width: 480px; height: 480px;
+    background: radial-gradient(circle, rgba(238, 126, 45, .28), transparent 60%);
+    pointer-events: none;
+}
+.yl-hero .hero-kicker {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: .82rem; color: var(--yl-orange-600); font-weight: 600;
+    background: rgba(255,255,255,.6); padding: 6px 12px; border-radius: 999px;
+    border: 1px solid rgba(238, 126, 45, .2);
+}
+.yl-hero h1 {
+    font-size: 2.5rem;
+    line-height: 1.2;
+    color: var(--yl-ink);
+    margin: 16px 0 10px;
+    letter-spacing: -0.025em;
+    text-wrap: balance;
+}
+.yl-hero p.hero-lead {
+    font-size: 1.05rem;
+    color: var(--yl-ink-soft);
+    max-width: 620px;
+    margin-bottom: 24px;
+}
+.yl-hero .hero-actions { display: flex; gap: 12px; flex-wrap: wrap; }
+
+/* 今日一屏 Hero(user_dashboard) */
+.yl-hero-today {
+    background: linear-gradient(140deg, #FFF6E4 0%, #FFE4C2 60%, #F5A25C 150%);
+    border-radius: 24px;
+    padding: 32px 36px;
+    border: 1px solid var(--yl-orange-200);
+    position: relative;
+    overflow: hidden;
+    margin-bottom: 24px;
+}
+.yl-hero-today .today-label {
+    font-size: .85rem;
+    color: var(--yl-orange-600);
+    font-weight: 600;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+}
+.yl-hero-today .today-location {
+    font-size: 1rem;
+    color: var(--yl-ink-soft);
+    margin-top: 4px;
+}
+.yl-hero-today .today-temp {
+    font-size: 5rem;
+    font-weight: 300;
+    letter-spacing: -0.04em;
+    line-height: 1;
+    color: var(--yl-ink);
+    margin: 12px 0 4px;
+    font-variant-numeric: tabular-nums;
+}
+.yl-hero-today .today-temp .unit { font-size: 2rem; color: var(--yl-ink-soft); margin-left: 4px; }
+.yl-hero-today .today-condition {
+    font-size: 1.2rem; color: var(--yl-ink-soft); margin-bottom: 18px;
+}
+.yl-hero-today .today-meta {
+    display: flex; flex-wrap: wrap; gap: 18px;
+    padding: 16px 20px;
+    background: rgba(255,255,255,.6);
+    border-radius: 14px;
+    backdrop-filter: blur(10px);
+}
+.yl-hero-today .today-meta-item { min-width: 80px; }
+.yl-hero-today .today-meta-item .k { font-size: .78rem; color: var(--yl-muted); }
+.yl-hero-today .today-meta-item .v {
+    font-size: 1.1rem; color: var(--yl-ink); font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+.yl-hero-today .risk-dial {
+    text-align: center;
+    padding: 20px;
+    background: rgba(255,255,255,.7);
+    border-radius: 20px;
+    backdrop-filter: blur(10px);
+}
+.yl-hero-today .risk-dial .score {
+    font-size: 3rem; font-weight: 600; line-height: 1;
+    color: var(--yl-risk-mid); font-variant-numeric: tabular-nums;
+}
+.yl-hero-today .risk-dial .label { font-size: .9rem; color: var(--yl-ink-soft); margin-top: 6px; }
+
+/* 指标小卡(概览) */
+.yl-stat-card {
+    background: #fff;
+    border: 1px solid var(--yl-line-soft);
+    border-radius: var(--yl-radius);
+    padding: 18px 20px;
+    height: 100%;
+}
+.yl-stat-card .k {
+    font-size: .78rem; color: var(--yl-muted);
+    text-transform: uppercase; letter-spacing: .05em;
+}
+.yl-stat-card .v {
+    font-size: 2rem; font-weight: 600; color: var(--yl-ink);
+    line-height: 1.1; margin: 6px 0 4px;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.01em;
+}
+.yl-stat-card .sub { font-size: .85rem; color: var(--yl-muted); }
+.yl-stat-card.accent { background: var(--yl-orange-50); border-color: var(--yl-orange-200); }
+.yl-stat-card.accent .v { color: var(--yl-orange-600); }
+
+/* 功能入口 (Feature grid) */
+.yl-feature-icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: var(--yl-orange-50);
+    color: var(--yl-orange-500);
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    text-align: center;
+    font-size: 1.3rem;
+    flex-shrink: 0;
+    line-height: 1;
+    vertical-align: middle;
+}
+.yl-feature-icon > i,
+.yl-feature-icon > .bi {
+    display: block;
+    line-height: 1;
+    margin: 0;
+}
+.yl-feature {
+    display: flex; align-items: flex-start; gap: 14px;
+    padding: 18px;
+    border-radius: var(--yl-radius);
+    border: 1px solid var(--yl-line-soft);
+    background: #fff;
+    transition: all .15s ease;
+    height: 100%;
+    text-decoration: none;
+    color: inherit;
+}
+.yl-feature:hover {
+    border-color: var(--yl-orange-400);
+    transform: translateY(-2px);
+    box-shadow: var(--yl-shadow);
+    color: inherit;
+}
+.yl-feature h5 { font-size: 1rem; margin: 0 0 4px; color: var(--yl-ink); }
+.yl-feature p  { font-size: .88rem; color: var(--yl-muted); margin: 0; }
+
+/* 角色入口大卡 */
+.yl-role-card {
+    display: block;
+    background: #fff;
+    border: 1px solid var(--yl-line-soft);
+    border-radius: var(--yl-radius-lg);
+    padding: 28px 26px;
+    height: 100%;
+    transition: all .18s ease;
+    text-decoration: none; color: inherit;
+}
+.yl-role-card:hover {
+    border-color: var(--yl-orange-400);
+    transform: translateY(-3px);
+    box-shadow: var(--yl-shadow);
+    color: inherit;
+}
+.yl-role-card .yl-role-icon {
+    width: 56px; height: 56px; border-radius: 16px;
+    background: linear-gradient(135deg, var(--yl-orange-400), var(--yl-orange-500));
+    color: #fff;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 1.7rem; margin-bottom: 18px;
+}
+.yl-role-card.variant-family .yl-role-icon { background: linear-gradient(135deg, #F5A25C, #EE7E2D); }
+.yl-role-card.variant-elder  .yl-role-icon { background: linear-gradient(135deg, #FFB46A, #E8732A); }
+.yl-role-card.variant-doctor .yl-role-icon { background: linear-gradient(135deg, #4E8B49, #356A31); }
+.yl-role-card h3 { margin: 0 0 6px; font-size: 1.2rem; }
+.yl-role-card p  { margin: 0 0 12px; color: var(--yl-muted); font-size: .95rem; }
+.yl-role-card .role-cta {
+    display: inline-flex; align-items: center; gap: 4px;
+    font-weight: 600; color: var(--yl-orange-600); font-size: .9rem;
+}
+
+/* ----- 登录 / 注册 ----- */
+.auth-shell { padding: 40px 0 60px; }
+.auth-panel .auth-panel-head .auth-icon-wrap {
+    width: 56px; height: 56px; border-radius: 16px;
+    background: linear-gradient(135deg, var(--yl-orange-400), var(--yl-orange-500));
+    color: #fff; display: inline-flex; align-items: center; justify-content: center;
+    font-size: 1.7rem;
+    box-shadow: 0 8px 20px rgba(238, 126, 45, .25);
+    margin-bottom: 12px;
+}
+.auth-panel h2 { font-size: 1.6rem; margin: 0; }
+.auth-panel .auth-panel-head p { color: var(--yl-muted); margin: 4px 0 22px; }
+.auth-form-card { border-radius: var(--yl-radius-lg); }
+.auth-note {
+    margin-top: 14px; padding: 10px 14px;
+    background: var(--yl-orange-50);
+    border-radius: 12px;
+    color: var(--yl-ink-soft);
+    font-size: .85rem; display: flex; align-items: center; gap: 8px;
+}
+.auth-note i { color: var(--yl-orange-500); }
+.auth-title { font-size: 2.1rem; letter-spacing: -0.025em; text-wrap: balance; }
+.auth-subtitle { color: var(--yl-ink-soft); font-size: 1rem; max-width: 520px; }
+.auth-highlight-grid {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 12px; margin: 24px 0;
+}
+.auth-highlight-card {
+    background: #fff; border: 1px solid var(--yl-line-soft);
+    border-radius: 14px; padding: 14px 16px; display: flex; gap: 12px;
+}
+.auth-highlight-card i {
+    color: var(--yl-orange-500); font-size: 1.2rem;
+    flex-shrink: 0; margin-top: 2px;
+}
+.auth-highlight-card strong { display: block; font-size: .95rem; }
+.auth-highlight-card p { margin: 2px 0 0; font-size: .85rem; color: var(--yl-muted); }
+.auth-guide-card {
+    background: var(--yl-orange-50);
+    border: 1px solid var(--yl-orange-200);
+    border-radius: var(--yl-radius);
+    padding: 18px 22px;
+    margin-top: 20px;
+}
+.auth-quicklist {
+    list-style: none; padding: 0; margin: 14px 0 0;
+    counter-reset: step;
+}
+.auth-quicklist li {
+    counter-increment: step;
+    padding: 6px 0 6px 32px;
+    position: relative;
+    color: var(--yl-ink-soft);
+}
+.auth-quicklist li::before {
+    content: counter(step);
+    position: absolute; left: 0; top: 4px;
+    width: 22px; height: 22px;
+    background: var(--yl-orange-500); color: #fff;
+    border-radius: 50%; text-align: center; font-size: .78rem; line-height: 22px;
+    font-weight: 600;
+}
+.auth-link-row { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 18px; }
+
+/* ============================================================
+   user_dashboard 专用
+   ============================================================ */
+.yl-dashboard-shell {
+    width: auto;
+    margin: 0 clamp(12px, 1.6vw, 16px);
+}
+.yl-dashboard-shell,
+.yl-dashboard-shell > *,
+.yl-dashboard-shell .yl-section,
+.yl-dashboard-shell .yl-feature,
+.yl-dashboard-shell .yl-action,
+.yl-dashboard-shell .today-meta-item {
+    min-width: 0;
+}
+.yl-dashboard-shell .yl-section {
+    margin-bottom: 0;
+    height: 100%;
+}
+.yl-hero-today {
+    padding: clamp(20px, 2vw, 34px);
+    margin-bottom: clamp(14px, 1.5vw, 20px);
+}
+.yl-hero-today-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 2.4fr) minmax(260px, 1fr);
+    gap: clamp(16px, 2vw, 24px);
+    align-items: stretch;
+}
+.yl-hero-copy {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+.yl-hero-side {
+    display: flex;
+    min-width: 0;
+}
+.yl-hero-today .today-condition {
+    max-width: 60ch;
+}
+.yl-hero-today .today-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: 12px;
+    padding: 14px;
+}
+.yl-hero-today .today-meta-item {
+    min-width: 0;
+    padding: 12px 14px;
+    background: rgba(255,255,255,.45);
+    border-radius: 12px;
+}
+.yl-hero-today .risk-dial {
+    width: 100%;
+    min-height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+.yl-dash-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: clamp(14px, 1.6vw, 20px);
+    align-items: stretch;
+    align-content: flex-start;
+}
+.yl-panel {
+    min-width: 0;
+    flex: 1 1 320px;
+    max-width: 100%;
+}
+.yl-panel-wide {
+    flex: 2 1 720px;
+}
+.yl-panel-actions,
+.yl-panel-shortcuts,
+.yl-panel-forecast,
+.yl-panel-family {
+    flex-basis: 320px;
+}
+.yl-panel-shortcuts {
+    flex-grow: 1.1;
+}
+.yl-panel-forecast {
+    flex-grow: 1.15;
+}
+.yl-panel-shortcuts .yl-feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
+    gap: 12px;
+}
+.yl-panel-shortcuts .yl-feature,
+.yl-panel-family .list-group-item {
+    height: 100%;
+}
+.yl-panel-family .list-group {
+    display: grid;
+    gap: 10px;
+}
+.yl-panel-family .list-group-item {
+    margin-bottom: 0 !important;
+}
+
+.yl-alert-list {
+    display: grid;
+    gap: 10px;
+}
+.yl-alert-list .yl-alert-item {
+    display: flex; gap: 12px;
+    padding: 12px 14px;
+    border-radius: 12px;
+    background: var(--yl-warn-50);
+    border: 1px solid #F1DFB1;
+}
+.yl-alert-list .yl-alert-item.level-high {
+    background: var(--yl-danger-50); border-color: #F0C4B9;
+}
+.yl-alert-list .yl-alert-item .dot {
+    width: 10px; height: 10px; border-radius: 50%; margin-top: 6px;
+    background: var(--yl-warn); flex-shrink: 0;
+}
+.yl-alert-list .level-high .dot { background: var(--yl-danger); }
+.yl-alert-list .yl-alert-item .body strong { display: block; color: var(--yl-ink); }
+.yl-alert-list .yl-alert-item .body .meta { font-size: .78rem; color: var(--yl-muted); }
+
+/* 行动清单 */
+.yl-action-list { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr)); gap: 12px; }
+.yl-action-list .yl-action {
+    display: flex; align-items: flex-start; gap: 10px;
+    padding: 12px 14px;
+    background: var(--yl-orange-50);
+    border-radius: 12px;
+    border: 1px solid var(--yl-orange-200);
+}
+.yl-action i {
+    color: var(--yl-orange-500); font-size: 1.1rem; margin-top: 2px;
+    flex-shrink: 0;
+}
+.yl-action strong { display: block; color: var(--yl-ink); font-size: .92rem; }
+.yl-action .detail { color: var(--yl-ink-soft); font-size: .82rem; }
+
+/* 7 日预测小卡 */
+.yl-forecast-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 120px), 1fr));
+    gap: 10px;
+    overflow: visible;
+    padding: 4px 0;
+}
+.yl-forecast-row .day {
+    min-width: 0;
+    text-align: center; padding: 12px 8px;
+    border: 1px solid var(--yl-line-soft);
+    border-radius: 14px;
+    background: #fff;
+}
+.yl-forecast-row .day .dow { font-size: .78rem; color: var(--yl-muted); }
+.yl-forecast-row .day .t  { font-size: 1.1rem; font-weight: 600; color: var(--yl-ink); font-variant-numeric: tabular-nums; }
+.yl-forecast-row .day .rk { font-size: .72rem; padding: 2px 8px; border-radius: 999px; display: inline-block; margin-top: 4px; }
+.yl-forecast-row .day .rk.low  { background: var(--yl-success-50); color: var(--yl-success); }
+.yl-forecast-row .day .rk.mid  { background: var(--yl-warn-50); color: #8A5A12; }
+.yl-forecast-row .day .rk.high { background: var(--yl-danger-50); color: var(--yl-danger); }
+
+/* ============================================================
+   family_members / detail / edit 专用
+   ============================================================ */
+.member-avatar {
+    width: 52px; height: 52px; border-radius: 50%;
+    background: linear-gradient(135deg, var(--yl-orange-400), var(--yl-orange-500));
+    color: #fff;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 1.3rem; font-weight: 600; flex-shrink: 0;
+}
+.member-card {
+    transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease;
+    border-left: 4px solid transparent;
+}
+.member-card:hover { transform: translateY(-1px); box-shadow: var(--yl-shadow); }
+.member-card.risk-low  { border-left-color: var(--yl-risk-low); }
+.member-card.risk-medium, .member-card.risk-mid { border-left-color: var(--yl-risk-mid); }
+.member-card.risk-high { border-left-color: var(--yl-risk-high); }
+
+.risk-badge { font-weight: 600; }
+.risk-badge.risk-low    { background: var(--yl-success-50); color: var(--yl-success); }
+.risk-badge.risk-medium, .risk-badge.risk-mid { background: var(--yl-warn-50); color: #8A5A12; }
+.risk-badge.risk-high   { background: var(--yl-danger-50); color: var(--yl-danger); }
+
+.profile-progress { height: 6px; }
+
+/* ============================================================
+   悬浮 AI 按钮(覆盖原样式)
+   ============================================================ */
+.ai-floating-btn, .floating-ai-btn {
+    background: linear-gradient(135deg, var(--yl-orange-400), var(--yl-orange-500)) !important;
+    box-shadow: 0 10px 24px rgba(238, 126, 45, .3) !important;
+}
+
+/* ============================================================
+   老人模式 (body.elder-mode)
+   放大字号,强化对比,按钮更大
+   ============================================================ */
+body.elder-mode {
+    font-size: 18px;
+    --yl-radius-lg: 22px;
+    --yl-radius: 16px;
+    --yl-radius-sm: 12px;
+}
+body.elder-mode h1 { font-size: 2.4rem; }
+body.elder-mode h2 { font-size: 1.8rem; }
+body.elder-mode h3 { font-size: 1.45rem; }
+body.elder-mode h4 { font-size: 1.25rem; }
+body.elder-mode h5 { font-size: 1.15rem; }
+body.elder-mode .btn { padding: 14px 22px; font-size: 1.05rem; min-height: 54px; }
+body.elder-mode .btn-lg { padding: 18px 26px; font-size: 1.2rem; min-height: 62px; }
+body.elder-mode .btn-sm { padding: 10px 16px; font-size: 1rem; min-height: 44px; }
+body.elder-mode .form-control, body.elder-mode .form-select {
+    padding: 14px 18px; font-size: 1.05rem; min-height: 52px;
+}
+body.elder-mode .form-label { font-size: 1rem; }
+body.elder-mode .navbar .nav-link { font-size: 1.05rem; padding: 10px 16px !important; }
+body.elder-mode .badge { font-size: .9rem; padding: 6px 14px; }
+body.elder-mode .text-muted { color: var(--yl-ink-soft) !important; }
+body.elder-mode .yl-hero-today .today-temp { font-size: 6rem; }
+body.elder-mode .card .card-body { padding: 1.5rem 1.75rem; }
+
+/* ============================================================
+   Animations
+   ============================================================ */
+@keyframes yl-fade-up { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
+.yl-fade-up { animation: yl-fade-up .4s ease both; }
+.yl-fade-up-d1 { animation-delay: .08s; }
+.yl-fade-up-d2 { animation-delay: .16s; }
+.yl-fade-up-d3 { animation-delay: .24s; }
+
+@media (prefers-reduced-motion: reduce) {
+    .yl-fade-up { animation: none; }
+}
+
+/* ============================================================
+   响应式 & 杂项
+   ============================================================ */
+@media (max-width: 768px) {
+    .yl-hero { padding: 32px 24px; }
+    .yl-hero h1 { font-size: 1.8rem; }
+    .yl-hero-today { padding: 24px; }
+    .yl-hero-today .today-temp { font-size: 3.6rem; }
+    .yl-section { padding: 18px; }
+    .navbar .container-fluid { padding: 0 16px; }
+}
+
+body[data-viewport-tier="compact"] {
+    font-size: 14px;
+}
+body[data-viewport-tier="compact"] .navbar .container-fluid,
+body[data-viewport-tier="compact"] main.page-shell {
+    padding-left: 14px !important;
+    padding-right: 14px !important;
+}
+body[data-viewport-tier="compact"] .navbar-brand {
+    min-width: 0;
+    flex: 1 1 auto;
+}
+body[data-viewport-tier="compact"] .navbar-brand span {
+    max-width: min(56vw, 220px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+body[data-viewport-tier="compact"] .offcanvas.offcanvas-end {
+    width: min(88vw, 320px) !important;
+}
+body[data-viewport-tier="compact"] .yl-hero,
+body[data-viewport-tier="compact"] .yl-hero-today,
+body[data-viewport-tier="compact"] .yl-section,
+body[data-viewport-tier="compact"] .yl-role-card {
+    border-radius: 18px;
+}
+body[data-viewport-tier="compact"] .yl-hero {
+    padding: 32px 22px;
+}
+body[data-viewport-tier="compact"] .yl-hero::before {
+    width: 320px;
+    height: 320px;
+    inset: -32% -30% auto auto;
+}
+body[data-viewport-tier="compact"] .yl-hero h1 {
+    font-size: clamp(1.8rem, 5vw, 2.2rem);
+    line-height: 1.2;
+}
+body[data-viewport-tier="compact"] .yl-hero p.hero-lead,
+body[data-viewport-tier="compact"] .auth-subtitle {
+    max-width: 100%;
+}
+body[data-viewport-tier="compact"] .yl-hero-today {
+    padding: 24px 22px;
+}
+body[data-viewport-tier="compact"] .yl-hero-today .today-temp {
+    font-size: clamp(3rem, 10vw, 4.2rem);
+}
+body[data-viewport-tier="compact"] .yl-hero-today .today-temp .unit {
+    font-size: 1.35rem;
+}
+body[data-viewport-tier="compact"] .yl-hero-today .today-meta {
+    gap: 12px;
+    padding: 14px;
+}
+body[data-viewport-tier="compact"] .yl-hero-today .today-meta-item {
+    min-width: calc(50% - 6px);
+    flex: 1 1 calc(50% - 6px);
+}
+body[data-viewport-tier="compact"] .auth-title {
+    font-size: clamp(1.65rem, 5vw, 1.95rem);
+}
+body[data-viewport-tier="compact"] .auth-highlight-grid {
+    grid-template-columns: 1fr;
+}
+body[data-viewport-tier="compact"] .yl-panel {
+    flex-basis: 340px;
+}
+body[data-viewport-tier="compact"] .yl-section-head {
+    align-items: flex-start !important;
+}
+body[data-viewport-tier="compact"] .yl-section-head .btn {
+    margin-left: 0;
+}
+body[data-viewport-tier="compact"] .yl-dashboard-shell {
+    margin-left: 14px;
+    margin-right: 14px;
+}
+body[data-viewport-tier="compact"] .yl-hero-today-grid {
+    grid-template-columns: minmax(0, 1fr);
+}
+body[data-viewport-tier="compact"] .yl-action-list,
+body[data-viewport-tier="compact"] .yl-panel-shortcuts .yl-feature-grid,
+body[data-viewport-tier="compact"] .yl-forecast-row {
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 180px), 1fr));
+}
+body[data-viewport-tier="compact"] .yl-forecast-row {
+    gap: 10px;
+}
+body[data-viewport-tier="compact"] .yl-forecast-row .day {
+    min-width: 0;
+}
+
+body[data-viewport-tier="tight"] {
+    font-size: 14px;
+}
+body[data-viewport-tier="tight"] .navbar .container-fluid,
+body[data-viewport-tier="tight"] main.page-shell {
+    padding-left: 12px !important;
+    padding-right: 12px !important;
+}
+body[data-viewport-tier="tight"] .navbar-brand {
+    min-width: 0;
+    font-size: 1rem;
+}
+body[data-viewport-tier="tight"] .navbar-brand span {
+    max-width: min(44vw, 170px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+body[data-viewport-tier="tight"] .offcanvas.offcanvas-end {
+    width: min(92vw, 300px) !important;
+}
+body[data-viewport-tier="tight"] .yl-hero,
+body[data-viewport-tier="tight"] .yl-hero-today,
+body[data-viewport-tier="tight"] .yl-section,
+body[data-viewport-tier="tight"] .yl-role-card {
+    padding: 24px 18px;
+    border-radius: 16px;
+}
+body[data-viewport-tier="tight"] .yl-hero::before {
+    display: none;
+}
+body[data-viewport-tier="tight"] .yl-hero h1 {
+    font-size: 1.55rem;
+    line-height: 1.24;
+}
+body[data-viewport-tier="tight"] .yl-hero .hero-actions,
+body[data-viewport-tier="tight"] .auth-link-row {
+    flex-direction: column;
+}
+body[data-viewport-tier="tight"] .yl-hero .hero-actions .btn,
+body[data-viewport-tier="tight"] .auth-link-row .btn {
+    width: 100%;
+    justify-content: center;
+}
+body[data-viewport-tier="tight"] .yl-hero-today .today-temp {
+    font-size: clamp(2.35rem, 12vw, 3.1rem);
+}
+body[data-viewport-tier="tight"] .yl-hero-today .today-condition {
+    font-size: 1rem;
+}
+body[data-viewport-tier="tight"] .yl-hero-today .today-meta {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    padding: 12px;
+}
+body[data-viewport-tier="tight"] .yl-hero-today .today-meta-item {
+    min-width: 0;
+}
+body[data-viewport-tier="tight"] .risk-dial {
+    padding: 16px;
+}
+body[data-viewport-tier="tight"] .auth-shell {
+    padding: 24px 0 40px;
+}
+body[data-viewport-tier="tight"] .auth-title {
+    font-size: clamp(1.45rem, 7vw, 1.8rem);
+}
+body[data-viewport-tier="tight"] .section-heading h2 {
+    font-size: 1.3rem;
+}
+body[data-viewport-tier="tight"] .yl-dashboard-shell {
+    margin-left: 12px;
+    margin-right: 12px;
+}
+body[data-viewport-tier="tight"] .yl-hero-today-grid {
+    grid-template-columns: minmax(0, 1fr);
+}
+body[data-viewport-tier="tight"] .yl-dash-grid {
+    flex-direction: column;
+}
+body[data-viewport-tier="tight"] .yl-panel {
+    flex-basis: auto;
+    width: 100%;
+    align-self: stretch;
+}
+body[data-viewport-tier="tight"] .yl-section-head {
+    align-items: flex-start !important;
+}
+body[data-viewport-tier="tight"] .yl-section-head .btn {
+    width: 100%;
+    justify-content: center;
+}
+body[data-viewport-tier="tight"] .yl-action-list,
+body[data-viewport-tier="tight"] .yl-panel-shortcuts .yl-feature-grid,
+body[data-viewport-tier="tight"] .yl-forecast-row {
+    grid-template-columns: minmax(0, 1fr);
+}
+body[data-viewport-tier="tight"] .yl-forecast-row {
+    gap: 8px;
+}
+body[data-viewport-tier="tight"] .yl-forecast-row .day {
+    min-width: 0;
+}
+body.dashboard-page[data-viewport-tier="compact"] main.page-shell,
+body.dashboard-page[data-viewport-tier="tight"] main.page-shell {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+}
+
+/* 隐藏原来几个"花哨"的旧组件 */
+.glass-panel, .liquid-glass-panel { background: #fff !important; backdrop-filter: none !important; }
+.gradient-heading { background: none !important; -webkit-text-fill-color: var(--yl-ink) !important; color: var(--yl-ink) !important; }
+
+/* 打印友好 */
+@media print {
+    .navbar, .ai-floating-btn, .floating-ai-btn, .page-loader { display: none !important; }
+    .card { break-inside: avoid; box-shadow: none; border: 1px solid #ccc; }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -88,9 +88,9 @@
                 <span>宜老天气通</span>
             </a>
 
-            {# 高频 5 项 —— 仅登录后显示在桌面端 #}
+            {# 高频入口 —— 仅登录后显示在桌面端 #}
             {% if current_user.is_authenticated %}
-                <div class="d-none d-lg-flex align-items-center gap-1 mx-auto">
+                <div class="app-desktop-nav d-none d-lg-flex align-items-center gap-1 mx-auto">
                     <a class="nav-link {% if request.endpoint == 'user.user_dashboard' %}active{% endif %}"
                        href="{{ url_for('user.user_dashboard') }}">我的主页</a>
 
@@ -108,9 +108,71 @@
                     <a class="nav-link {% if request.endpoint == 'user.community_risk' %}active{% endif %}"
                        href="{{ url_for('user.community_risk') }}">社区风险</a>
 
-                    <a class="nav-link" data-bs-toggle="offcanvas" href="#appNavDrawer" role="button" aria-controls="appNavDrawer">
-                        更多 <i class="bi bi-chevron-down small"></i>
-                    </a>
+                    <a class="nav-link {% if request.endpoint == 'tools.ml_prediction' %}active{% endif %}"
+                       href="{{ url_for('tools.ml_prediction') }}">AI 疾病预测</a>
+
+                    <a class="nav-link {% if request.endpoint == 'tools.ai_qa' %}active{% endif %}"
+                       href="{{ url_for('tools.ai_qa') }}">AI 提问</a>
+
+                    <a class="nav-link {% if request.endpoint == 'user.health_assessment' %}active{% endif %}"
+                       href="{{ url_for('user.health_assessment') }}">健康评估</a>
+
+                    <a class="nav-link {% if 'family' in (request.endpoint or '') %}active{% endif %}"
+                       href="{{ url_for('health.family_members') }}">家庭成员</a>
+
+                    <div class="app-more-menu" id="appMoreMenu">
+                        <button type="button"
+                                class="nav-link app-more-trigger"
+                                data-nav-more-trigger="desktop"
+                                aria-expanded="false"
+                                aria-controls="appMegaMenu">
+                            更多 <i class="bi bi-chevron-down small"></i>
+                        </button>
+
+                        <div class="app-mega-menu" id="appMegaMenu" aria-label="更多功能" aria-hidden="true">
+                            <div class="app-mega-grid">
+                                <section class="app-mega-group">
+                                    <div class="app-mega-kicker">公共信息</div>
+                                    <a class="app-mega-link" href="{{ url_for('public.public_risk') }}">风险说明</a>
+                                    <a class="app-mega-link" href="{{ url_for('public.cooling_resources') }}">避暑资源</a>
+                                    <a class="app-mega-link" href="{{ url_for('public.transparency') }}">透明度</a>
+                                    <a class="app-mega-link" href="{{ url_for('public.action_check') }}">行动打卡</a>
+                                </section>
+
+                                <section class="app-mega-group">
+                                    <div class="app-mega-kicker">健康管理</div>
+                                    <a class="app-mega-link" href="{{ url_for('tools.chronic_risk') }}">慢病风险评估</a>
+                                    <a class="app-mega-link" href="{{ url_for('health.health_diary') }}">健康日记</a>
+                                    <a class="app-mega-link" href="{{ url_for('health.medication_reminders') }}">用药提醒</a>
+                                    <a class="app-mega-link" href="{{ url_for('analysis.annual_report') }}">年度健康报告</a>
+                                </section>
+
+                                {% if current_user.role in ['community', 'admin'] %}
+                                <section class="app-mega-group">
+                                    <div class="app-mega-kicker">社区与群体</div>
+                                    <a class="app-mega-link" href="{{ url_for('user.community_dashboard') }}">社区看板</a>
+                                    {% if current_user.role == 'admin' %}
+                                        <a class="app-mega-link" href="{{ url_for('admin.admin_dashboard') }}">管理后台</a>
+                                        <a class="app-mega-link" href="{{ url_for('analysis.pilot_dashboard') }}">试点数据看板</a>
+                                        <a class="app-mega-link" href="{{ url_for('analysis.reports_center') }}">报告导出</a>
+                                    {% endif %}
+                                </section>
+                                {% endif %}
+
+                                <section class="app-mega-group">
+                                    <div class="app-mega-kicker">账号与设置</div>
+                                    {% if current_user.role != 'guest' %}
+                                        <a class="app-mega-link" href="{{ url_for('user.profile') }}">个人设置</a>
+                                        {% if feature_flags.elder_mode %}
+                                            <a class="app-mega-link" href="{{ url_for('user.elder_dashboard') }}">老人模式</a>
+                                        {% endif %}
+                                    {% else %}
+                                        <a class="app-mega-link" href="{{ url_for('public.register') }}">注册账号</a>
+                                    {% endif %}
+                                </section>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             {% endif %}
 
@@ -355,6 +417,83 @@
                 }
                 if (typeof window.__syncViewportTier === 'function') {
                     window.__syncViewportTier();
+                }
+            });
+        })();
+    </script>
+
+    <script>
+        (function() {
+            const menuRoot = document.getElementById('appMoreMenu');
+            if (!menuRoot) return;
+
+            const trigger = menuRoot.querySelector('[data-nav-more-trigger="desktop"]');
+            const panel = document.getElementById('appMegaMenu');
+            let closeTimer = null;
+
+            function setOpen(nextOpen) {
+                menuRoot.classList.toggle('is-open', nextOpen);
+                if (trigger) {
+                    trigger.setAttribute('aria-expanded', nextOpen ? 'true' : 'false');
+                }
+                if (panel) {
+                    panel.setAttribute('aria-hidden', nextOpen ? 'false' : 'true');
+                }
+            }
+
+            function clearCloseTimer() {
+                if (closeTimer !== null) {
+                    clearTimeout(closeTimer);
+                    closeTimer = null;
+                }
+            }
+
+            function scheduleClose() {
+                clearCloseTimer();
+                closeTimer = window.setTimeout(function() {
+                    setOpen(false);
+                }, 120);
+            }
+
+            menuRoot.addEventListener('mouseenter', function() {
+                clearCloseTimer();
+                setOpen(true);
+            });
+
+            menuRoot.addEventListener('mouseleave', scheduleClose);
+
+            menuRoot.addEventListener('focusin', function() {
+                clearCloseTimer();
+                setOpen(true);
+            });
+
+            menuRoot.addEventListener('focusout', function(event) {
+                if (event.relatedTarget && menuRoot.contains(event.relatedTarget)) {
+                    return;
+                }
+                scheduleClose();
+            });
+
+            if (trigger) {
+                trigger.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    clearCloseTimer();
+                    setOpen(!menuRoot.classList.contains('is-open'));
+                });
+            }
+
+            document.addEventListener('pointerdown', function(event) {
+                if (!menuRoot.contains(event.target)) {
+                    setOpen(false);
+                }
+            });
+
+            document.addEventListener('keydown', function(event) {
+                if (event.key === 'Escape') {
+                    setOpen(false);
+                    if (trigger) {
+                        trigger.blur();
+                    }
                 }
             });
         })();

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,9 +2,62 @@
 <html lang="zh-CN">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script>
+        (function() {
+            const root = document.documentElement;
+
+            function syncViewportTier() {
+                const viewport = window.visualViewport;
+                const width = Math.round(viewport ? viewport.width : window.innerWidth);
+                const height = Math.round(viewport ? viewport.height : window.innerHeight);
+                const scale = viewport && viewport.scale ? viewport.scale : 1;
+                let tier = 'wide';
+
+                if (width <= 680) {
+                    tier = 'tight';
+                } else if (width <= 980) {
+                    tier = 'compact';
+                }
+
+                root.dataset.viewportTier = tier;
+                root.style.setProperty('--app-vw', width + 'px');
+                root.style.setProperty('--app-vh', height + 'px');
+                root.style.setProperty('--app-scale', String(scale));
+
+                if (document.body) {
+                    document.body.dataset.viewportTier = tier;
+                }
+            }
+
+            let rafToken = null;
+            function scheduleViewportSync() {
+                if (rafToken !== null) {
+                    cancelAnimationFrame(rafToken);
+                }
+                rafToken = requestAnimationFrame(function() {
+                    rafToken = null;
+                    syncViewportTier();
+                });
+            }
+
+            window.__syncViewportTier = scheduleViewportSync;
+            syncViewportTier();
+
+            window.addEventListener('resize', scheduleViewportSync, { passive: true });
+            window.addEventListener('orientationchange', scheduleViewportSync, { passive: true });
+
+            if (window.visualViewport) {
+                window.visualViewport.addEventListener('resize', scheduleViewportSync, { passive: true });
+                window.visualViewport.addEventListener('scroll', scheduleViewportSync, { passive: true });
+            }
+
+            document.addEventListener('DOMContentLoaded', syncViewportTier);
+        })();
+    </script>
     <title>{% block title %}宜老天气通{% endblock %}</title>
+
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/bootstrap/bootstrap.min.css') }}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
     {% if needs_fontawesome %}
@@ -14,348 +67,218 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/animations.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/page-transitions.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/ai-floating-chat.css') }}">
+    {# 新的视觉主题 —— 放在最后,覆盖旧样式 #}
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/yilao.css') }}">
+
     <noscript><style>.page-loader{display:none !important;}</style></noscript>
     {% block extra_css %}{% endblock %}
 </head>
-<body class="{% block body_class %}{% endblock %}">
-    <!-- 页面加载动画 -->
+<body class="{% block body_class %}{% endblock %}" data-viewport-tier="wide">
+
     <div class="page-loader" id="pageLoader">
         <div class="loader-spinner"></div>
-        <div class="loader-text">加载中...</div>
+        <div class="loader-text">加载中…</div>
     </div>
 
-    <!-- 导航栏 -->
-    <nav class="navbar navbar-light sticky-top">
+    {# ===================== 顶部导航 ===================== #}
+    <nav class="navbar sticky-top">
         <div class="container-fluid">
             <a class="navbar-brand" href="{{ url_for('public.index') }}">
                 <i class="bi bi-cloud-sun"></i>
-                <span class="brand-short d-inline d-md-none">宜老天气通</span>
-                <span class="brand-full d-none d-md-inline">宜老天气通</span>
-                <span class="brand-tagline d-none d-xl-inline">天气预警与照护提醒</span>
+                <span>宜老天气通</span>
             </a>
 
-            <!-- Desktop quick links (JS-free fallback for navigation) -->
-            <div class="desktop-nav-actions d-none d-md-flex align-items-center gap-2 ms-auto">
-                {% if current_user.is_authenticated %}
-                    <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('user.user_dashboard') }}">我的主页</a>
+            {# 高频 5 项 —— 仅登录后显示在桌面端 #}
+            {% if current_user.is_authenticated %}
+                <div class="d-none d-lg-flex align-items-center gap-1 mx-auto">
+                    <a class="nav-link {% if request.endpoint == 'user.user_dashboard' %}active{% endif %}"
+                       href="{{ url_for('user.user_dashboard') }}">我的主页</a>
+
                     {% if current_user.role in ['caregiver', 'admin'] %}
-                        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('user.caregiver_dashboard') }}">照护工作台</a>
+                        <a class="nav-link {% if request.endpoint == 'user.caregiver_dashboard' %}active{% endif %}"
+                           href="{{ url_for('user.caregiver_dashboard') }}">照护工作台</a>
                     {% else %}
-                        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('user.pair_management') }}">照护工作台</a>
+                        <a class="nav-link {% if 'family' in (request.endpoint or '') or 'pair' in (request.endpoint or '') %}active{% endif %}"
+                           href="{{ url_for('health.family_members') }}">照护工作台</a>
                     {% endif %}
+
+                    <a class="nav-link {% if request.endpoint == 'tools.forecast_7day' %}active{% endif %}"
+                       href="{{ url_for('tools.forecast_7day') }}">7 天预报</a>
+
+                    <a class="nav-link {% if request.endpoint == 'user.community_risk' %}active{% endif %}"
+                       href="{{ url_for('user.community_risk') }}">社区风险</a>
+
+                    <a class="nav-link" data-bs-toggle="offcanvas" href="#appNavDrawer" role="button" aria-controls="appNavDrawer">
+                        更多 <i class="bi bi-chevron-down small"></i>
+                    </a>
+                </div>
+            {% endif %}
+
+            <div class="d-flex align-items-center gap-2 ms-auto">
+                {% if current_user.is_authenticated %}
                     {% if current_user.role == 'admin' %}
-                        <a class="btn btn-sm btn-outline-dark" href="{{ url_for('admin.admin_dashboard') }}">管理后台</a>
+                        <a class="btn btn-sm btn-outline-secondary d-none d-md-inline-flex" href="{{ url_for('admin.admin_dashboard') }}">
+                            <i class="bi bi-speedometer2 me-1"></i>后台
+                        </a>
                     {% endif %}
-                    <form method="POST" action="{{ url_for('public.logout') }}" class="d-inline">
+                    <span class="text-muted small d-none d-xl-inline">
+                        <i class="bi bi-geo-alt"></i> {{ current_location or '未设置' }}
+                    </span>
+                    <form method="POST" action="{{ url_for('public.logout') }}" class="d-none d-md-inline m-0">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <button class="btn btn-sm btn-outline-danger" type="submit">退出</button>
+                        <button class="btn btn-sm btn-outline-secondary" type="submit">退出</button>
                     </form>
                 {% else %}
                     <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('public.login') }}">登录</a>
                     <a class="btn btn-sm btn-primary" href="{{ url_for('public.register') }}">注册</a>
                 {% endif %}
-            </div>
 
-            <button class="navbar-toggler app-nav-toggle d-flex align-items-center gap-1 ms-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#appNavDrawer" aria-controls="appNavDrawer" aria-label="打开菜单">
-                <span class="navbar-toggler-icon"></span>
-                <span class="small d-none d-sm-inline">菜单</span>
-            </button>
+                <button class="navbar-toggler d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#appNavDrawer" aria-controls="appNavDrawer" aria-label="打开菜单">
+                    <i class="bi bi-list" style="font-size:1.4rem;"></i>
+                </button>
+            </div>
         </div>
     </nav>
 
-    <!-- Offcanvas drawer placed outside the sticky navbar to avoid z-index stacking issues on mobile -->
-    <div class="offcanvas offcanvas-end app-offcanvas" tabindex="-1" id="appNavDrawer" aria-labelledby="appNavDrawerLabel">
-        <div class="offcanvas-header">
+    {# ===================== 抽屉 (更多 / 移动端菜单) ===================== #}
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="appNavDrawer" aria-labelledby="appNavDrawerLabel" style="width: 340px;">
+        <div class="offcanvas-header" style="border-bottom:1px solid var(--yl-line-soft);">
             <div class="d-flex align-items-center gap-2">
-                <i class="bi bi-cloud-sun text-primary fs-5"></i>
-                <h5 class="offcanvas-title mb-0" id="appNavDrawerLabel">菜单</h5>
+                <i class="bi bi-cloud-sun" style="color:var(--yl-orange-500); font-size:1.3rem;"></i>
+                <h5 class="offcanvas-title mb-0" id="appNavDrawerLabel">宜老天气通 · 更多</h5>
             </div>
             <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="关闭"></button>
         </div>
         <div class="offcanvas-body">
-            <div class="accordion accordion-flush" id="appNavAccordion">
-                <!-- 基础 -->
-                <div class="accordion-item">
-                    <h2 class="accordion-header" id="navBasicHeading">
-                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#navBasic" aria-expanded="false" aria-controls="navBasic">
-                            基础
-                        </button>
-                    </h2>
-                    <div id="navBasic" class="accordion-collapse collapse" aria-labelledby="navBasicHeading" data-bs-parent="#appNavAccordion">
-                        <div class="accordion-body">
-                            <nav class="nav flex-column">
-                                <a class="nav-link app-nav-link" href="{{ url_for('public.index') }}">
-                                    <i class="bi bi-house-door me-2"></i>首页
-                                </a>
-                                {% if current_user.is_authenticated %}
-                                    <a class="nav-link app-nav-link" href="{{ url_for('user.user_dashboard') }}">
-                                        <i class="bi bi-house-door me-2"></i>我的主页
-                                    </a>
-                                {% endif %}
-                            </nav>
-                        </div>
+
+            {% if current_user.is_authenticated %}
+                <div class="mb-3 p-3" style="background:var(--yl-orange-50); border-radius:12px;">
+                    <div class="small text-muted">当前账号</div>
+                    <div class="fw-semibold"><i class="bi bi-person-circle me-1"></i>{{ current_user.username }}</div>
+                    <div class="small text-muted mt-1">
+                        <i class="bi bi-geo-alt"></i> {{ current_location or '未设置定位' }}
                     </div>
                 </div>
+            {% endif %}
 
-                <!-- 入口与公共信息 -->
-                <div class="accordion-item">
-                    <h2 class="accordion-header" id="navPublicHeading">
-                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#navPublic" aria-expanded="false" aria-controls="navPublic">
-                            入口与公共信息
-                        </button>
-                    </h2>
-                    <div id="navPublic" class="accordion-collapse collapse" aria-labelledby="navPublicHeading" data-bs-parent="#appNavAccordion">
-                        <div class="accordion-body">
-                            <nav class="nav flex-column">
-                                <a class="nav-link app-nav-link" href="{{ url_for('public.public_risk') }}">
-                                    <i class="bi bi-thermometer-sun me-2"></i>风险说明
-                                </a>
-                                <a class="nav-link app-nav-link" href="{{ url_for('public.cooling_resources') }}">
-                                    <i class="bi bi-geo-alt me-2"></i>避暑资源
-                                </a>
-                                <a class="nav-link app-nav-link" href="{{ url_for('public.transparency') }}">
-                                    <i class="bi bi-shield-check me-2"></i>透明度
-                                </a>
-                            </nav>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- 风险预警与行动 -->
-                <div class="accordion-item">
-                    <h2 class="accordion-header" id="navActionHeading">
-                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#navAction" aria-expanded="false" aria-controls="navAction">
-                            风险预警与行动
-                        </button>
-                    </h2>
-                    <div id="navAction" class="accordion-collapse collapse" aria-labelledby="navActionHeading" data-bs-parent="#appNavAccordion">
-                        <div class="accordion-body">
-                            <nav class="nav flex-column">
-                                <a class="nav-link app-nav-link" href="{{ url_for('public.action_check') }}">
-                                    <i class="bi bi-clipboard-check me-2"></i>行动打卡
-                                </a>
-                                {% if current_user.is_authenticated %}
-                                    <a class="nav-link app-nav-link" href="{{ url_for('user.community_risk') }}">
-                                        <i class="bi bi-map me-2"></i>社区风险地图
-                                    </a>
-                                {% endif %}
-                            </nav>
-                        </div>
-                    </div>
-                </div>
-
-	                {% if current_user.is_authenticated %}
-	                <!-- 智能预测与评估（管理员/研究功能） -->
-	                <div class="accordion-item">
-	                    <h2 class="accordion-header" id="navToolsHeading">
-	                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#navTools" aria-expanded="false" aria-controls="navTools">
-	                            智能预测与评估（研究）
-                        </button>
-                    </h2>
-                    <div id="navTools" class="accordion-collapse collapse" aria-labelledby="navToolsHeading" data-bs-parent="#appNavAccordion">
-                        <div class="accordion-body">
-                            <nav class="nav flex-column">
-                                <a class="nav-link app-nav-link" href="{{ url_for('tools.ml_prediction') }}">
-                                    <i class="bi bi-cpu me-2"></i>AI疾病预测
-                                </a>
-                                <a class="nav-link app-nav-link" href="{{ url_for('tools.forecast_7day') }}">
-                                    <i class="bi bi-calendar-week me-2"></i>7天健康预测
-                                </a>
-                                <a class="nav-link app-nav-link" href="{{ url_for('tools.chronic_risk') }}">
-                                    <i class="bi bi-heart-pulse me-2"></i>慢病风险评估
-                                </a>
-                                <a class="nav-link app-nav-link" href="{{ url_for('tools.ai_qa') }}">
-                                    <i class="bi bi-chat-dots me-2"></i>AI提问
-                                </a>
-                            </nav>
-	                        </div>
-	                    </div>
-	                </div>
-
-	                <!-- 健康管理与照护 -->
-	                <div class="accordion-item">
-                    <h2 class="accordion-header" id="navHealthHeading">
-                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#navHealth" aria-expanded="false" aria-controls="navHealth">
-                            健康管理与照护
-                        </button>
-                    </h2>
-                    <div id="navHealth" class="accordion-collapse collapse" aria-labelledby="navHealthHeading" data-bs-parent="#appNavAccordion">
-                        <div class="accordion-body">
-                            <nav class="nav flex-column">
-                                {% if current_user.role in ['caregiver', 'admin'] %}
-                                    <a class="nav-link app-nav-link" href="{{ url_for('user.caregiver_dashboard') }}">
-                                        <i class="bi bi-people me-2"></i>照护工作台
-                                    </a>
-                                {% else %}
-                                    <a class="nav-link app-nav-link" href="{{ url_for('user.pair_management') }}">
-                                        <i class="bi bi-people me-2"></i>照护工作台
-                                    </a>
-                                {% endif %}
-                                <a class="nav-link app-nav-link" href="{{ url_for('user.health_assessment') }}">健康评估</a>
-                                <a class="nav-link app-nav-link" href="{{ url_for('health.family_members') }}">家庭成员</a>
-                                <a class="nav-link app-nav-link" href="{{ url_for('health.health_diary') }}">健康日记</a>
-                                <a class="nav-link app-nav-link" href="{{ url_for('health.medication_reminders') }}">用药提醒</a>
-                                <a class="nav-link app-nav-link" href="{{ url_for('analysis.annual_report') }}">年度健康报告</a>
-                            </nav>
-                        </div>
-                    </div>
-                </div>
-
-                {% if current_user.role in ['community', 'admin'] %}
-                <!-- 社区与群体 -->
-                <div class="accordion-item">
-                    <h2 class="accordion-header" id="navCommunityHeading">
-                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#navCommunity" aria-expanded="false" aria-controls="navCommunity">
-                            社区与群体
-                        </button>
-                    </h2>
-                    <div id="navCommunity" class="accordion-collapse collapse" aria-labelledby="navCommunityHeading" data-bs-parent="#appNavAccordion">
-                        <div class="accordion-body">
-                            <nav class="nav flex-column">
-                                <a class="nav-link app-nav-link" href="{{ url_for('user.community_dashboard') }}">
-                                    <i class="bi bi-building me-2"></i>社区看板
-                                </a>
-                            </nav>
-                        </div>
-                    </div>
-                </div>
+            {# ----- 基础 ----- #}
+            <div class="mb-2" style="font-size:.72rem; color:var(--yl-muted); text-transform:uppercase; letter-spacing:.05em; padding:0 4px;">基础</div>
+            <nav class="nav flex-column mb-3">
+                <a class="nav-link" href="{{ url_for('public.index') }}"><i class="bi bi-house-door me-2"></i>首页</a>
+                {% if current_user.is_authenticated %}
+                    <a class="nav-link" href="{{ url_for('user.user_dashboard') }}"><i class="bi bi-heart-pulse me-2"></i>我的主页</a>
+                    <a class="nav-link" href="{{ url_for('health.family_members') }}"><i class="bi bi-people me-2"></i>照护工作台</a>
                 {% endif %}
+            </nav>
 
-	                <!-- 数据分析与后台（研究） -->
-	                <div class="accordion-item">
-	                    <h2 class="accordion-header" id="navAnalysisHeading">
-	                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#navAnalysis" aria-expanded="false" aria-controls="navAnalysis">
-	                            数据分析与后台（研究）
-                        </button>
-                    </h2>
-                    <div id="navAnalysis" class="accordion-collapse collapse" aria-labelledby="navAnalysisHeading" data-bs-parent="#appNavAccordion">
-                        <div class="accordion-body">
-                            <nav class="nav flex-column">
-                                {% if current_user.role == 'admin' %}
-                                    <div class="app-nav-meta mt-1 mb-1">管理后台</div>
-                                    <a class="nav-link app-nav-link" href="{{ url_for('admin.admin_dashboard') }}">
-                                        <i class="bi bi-speedometer2 me-2"></i>管理后台
-                                    </a>
-                                    <a class="nav-link app-nav-link" href="{{ url_for('analysis.pilot_dashboard') }}">
-                                        <i class="bi bi-bar-chart-line me-2"></i>试点数据看板
-                                    </a>
-                                    <a class="nav-link app-nav-link" href="{{ url_for('analysis.model_quality') }}">
-                                        <i class="bi bi-shield-check me-2"></i>模型可靠性
-                                    </a>
-                                    <a class="nav-link app-nav-link" href="{{ url_for('admin.admin_users') }}">用户管理</a>
-                                    <a class="nav-link app-nav-link" href="{{ url_for('admin.admin_records') }}">病历管理</a>
-                                    <a class="nav-link app-nav-link" href="{{ url_for('admin.admin_communities') }}">社区管理</a>
-                                    <a class="nav-link app-nav-link" href="{{ url_for('admin.admin_cooling_resources') }}">避暑资源</a>
-                                    <a class="nav-link app-nav-link" href="{{ url_for('admin.admin_statistics') }}">统计分析</a>
-                                    <hr class="my-2">
-                                {% endif %}
+            {# ----- 公共信息 ----- #}
+            <div class="mb-2" style="font-size:.72rem; color:var(--yl-muted); text-transform:uppercase; letter-spacing:.05em; padding:0 4px;">公共信息</div>
+            <nav class="nav flex-column mb-3">
+                <a class="nav-link" href="{{ url_for('public.public_risk') }}"><i class="bi bi-thermometer-sun me-2"></i>风险说明</a>
+                <a class="nav-link" href="{{ url_for('public.cooling_resources') }}"><i class="bi bi-geo-alt me-2"></i>避暑资源</a>
+                <a class="nav-link" href="{{ url_for('public.transparency') }}"><i class="bi bi-shield-check me-2"></i>透明度</a>
+                <a class="nav-link" href="{{ url_for('public.action_check') }}"><i class="bi bi-clipboard-check me-2"></i>行动打卡</a>
+            </nav>
 
-                                {% if current_user.role == 'admin' %}
-                                    <div class="app-nav-meta mt-1 mb-1">分析</div>
-                                    <a class="nav-link app-nav-link" href="{{ url_for('analysis.analysis_history') }}">历史回溯分析</a>
-                                    <a class="nav-link app-nav-link" href="{{ url_for('analysis.analysis_heatmap') }}">相关性热力图</a>
-                                    <a class="nav-link app-nav-link" href="{{ url_for('analysis.analysis_lag') }}">滞后效应</a>
-                                    <a class="nav-link app-nav-link" href="{{ url_for('analysis.analysis_community_compare') }}">社区对比</a>
-                                    <a class="nav-link app-nav-link" href="{{ url_for('analysis.alerts_history') }}">预警历史</a>
-                                    <a class="nav-link app-nav-link" href="{{ url_for('analysis.alerts_accuracy') }}">预警准确率</a>
-                                    <hr class="my-2">
-                                    <a class="nav-link app-nav-link" href="{{ url_for('analysis.reports_center') }}">
-                                        <i class="bi bi-file-earmark-arrow-down me-2"></i>报告导出
-                                    </a>
-                                {% endif %}
-                            </nav>
-                        </div>
-	                    </div>
-	                </div>
+            {% if current_user.is_authenticated %}
+            {# ----- 智能预测 ----- #}
+            <div class="mb-2" style="font-size:.72rem; color:var(--yl-muted); text-transform:uppercase; letter-spacing:.05em; padding:0 4px;">智能预测</div>
+            <nav class="nav flex-column mb-3">
+                <a class="nav-link" href="{{ url_for('tools.ml_prediction') }}"><i class="bi bi-cpu me-2"></i>AI 疾病预测</a>
+                <a class="nav-link" href="{{ url_for('tools.forecast_7day') }}"><i class="bi bi-calendar-week me-2"></i>7 天健康预测</a>
+                <a class="nav-link" href="{{ url_for('tools.chronic_risk') }}"><i class="bi bi-heart-pulse me-2"></i>慢病风险评估</a>
+                <a class="nav-link" href="{{ url_for('tools.ai_qa') }}"><i class="bi bi-chat-dots me-2"></i>AI 提问</a>
+            </nav>
 
-	                <!-- 定位设置 -->
-	                <div class="accordion-item">
-                    <h2 class="accordion-header" id="navLocationHeading">
-                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#navLocation" aria-expanded="false" aria-controls="navLocation">
-                            定位设置
-                        </button>
-                    </h2>
-                    <div id="navLocation" class="accordion-collapse collapse" aria-labelledby="navLocationHeading" data-bs-parent="#appNavAccordion">
-                        <div class="accordion-body">
-                            <div class="app-nav-meta mb-2">
-                                当前：{{ current_location or '未设置' }}
-                            </div>
-                            <form method="POST" action="{{ url_for('user.update_location') }}">
-                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                <label class="form-label small mb-1">选择当前所在地</label>
-                                <input class="form-control" name="location" list="locationOptions" value="{{ current_location }}">
-                                <datalist id="locationOptions">
-                                    {% for loc in location_options %}
-                                        <option value="{{ loc }}"></option>
-                                    {% endfor %}
-                                </datalist>
-                                <div class="text-muted small mt-2">支持城市/社区名称（如：都昌县、北京）</div>
-                                <button class="btn btn-primary btn-sm w-100 mt-2">更新定位</button>
-                            </form>
-                        </div>
-                    </div>
-                </div>
+            {# ----- 健康管理 ----- #}
+            <div class="mb-2" style="font-size:.72rem; color:var(--yl-muted); text-transform:uppercase; letter-spacing:.05em; padding:0 4px;">健康管理</div>
+            <nav class="nav flex-column mb-3">
+                <a class="nav-link" href="{{ url_for('user.health_assessment') }}"><i class="bi bi-clipboard-pulse me-2"></i>健康评估</a>
+                <a class="nav-link" href="{{ url_for('health.family_members') }}"><i class="bi bi-person-lines-fill me-2"></i>家庭成员</a>
+                <a class="nav-link" href="{{ url_for('health.health_diary') }}"><i class="bi bi-journal me-2"></i>健康日记</a>
+                <a class="nav-link" href="{{ url_for('health.medication_reminders') }}"><i class="bi bi-capsule me-2"></i>用药提醒</a>
+                <a class="nav-link" href="{{ url_for('analysis.annual_report') }}"><i class="bi bi-journal-text me-2"></i>年度健康报告</a>
+            </nav>
 
-                {% endif %}
+            {% if current_user.role in ['community', 'admin'] %}
+            <div class="mb-2" style="font-size:.72rem; color:var(--yl-muted); text-transform:uppercase; letter-spacing:.05em; padding:0 4px;">社区与群体</div>
+            <nav class="nav flex-column mb-3">
+                <a class="nav-link" href="{{ url_for('user.community_dashboard') }}"><i class="bi bi-building me-2"></i>社区看板</a>
+            </nav>
+            {% endif %}
 
-                <!-- 账号 -->
-                <div class="accordion-item">
-                    <h2 class="accordion-header" id="navAccountHeading">
-                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#navAccount" aria-expanded="false" aria-controls="navAccount">
-                            账号
-                        </button>
-                    </h2>
-                    <div id="navAccount" class="accordion-collapse collapse" aria-labelledby="navAccountHeading" data-bs-parent="#appNavAccordion">
-                        <div class="accordion-body">
-                            {% if current_user.is_authenticated %}
-                                <div class="app-nav-meta mb-2">
-                                    <i class="bi bi-person-circle me-1"></i>{{ current_user.username }}
-                                </div>
-                                <nav class="nav flex-column">
-                                    {% if current_user.role != 'guest' %}
-                                        <a class="nav-link app-nav-link" href="{{ url_for('user.profile') }}">
-                                            <i class="bi bi-gear me-2"></i>个人设置
-                                        </a>
-                                        {% if feature_flags.elder_mode %}
-                                            <a class="nav-link app-nav-link" href="{{ url_for('user.elder_dashboard') }}">
-                                                <i class="bi bi-eyeglasses me-2"></i>老人模式
-                                            </a>
-                                            <div class="form-check form-switch mt-2">
-                                                <input class="form-check-input" type="checkbox" id="elderModeToggle">
-                                                <label class="form-check-label" for="elderModeToggle">大字/高对比</label>
-                                            </div>
-                                        {% endif %}
-                                    {% else %}
-                                        <a class="nav-link app-nav-link" href="{{ url_for('public.register') }}">
-                                            <i class="bi bi-person-plus me-2"></i>注册账号
-                                        </a>
-                                    {% endif %}
-                                    <hr class="my-2">
-                                    <form method="POST" action="{{ url_for('public.logout') }}">
-                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                        <button class="nav-link app-nav-link w-100 text-start border-0 bg-transparent" type="submit">
-                                            <i class="bi bi-box-arrow-right me-2"></i>退出登录
-                                        </button>
-                                    </form>
-                                </nav>
-                            {% else %}
-                                <nav class="nav flex-column">
-                                    <a class="nav-link app-nav-link" href="{{ url_for('public.login') }}">
-                                        <i class="bi bi-box-arrow-in-right me-2"></i>登录
-                                    </a>
-                                    <a class="nav-link app-nav-link" href="{{ url_for('public.register') }}">
-                                        <i class="bi bi-person-plus me-2"></i>注册
-                                    </a>
-                                </nav>
-                            {% endif %}
-                        </div>
-                    </div>
-                </div>
+            {% if current_user.role == 'admin' %}
+            <div class="mb-2" style="font-size:.72rem; color:var(--yl-muted); text-transform:uppercase; letter-spacing:.05em; padding:0 4px;">管理后台</div>
+            <nav class="nav flex-column mb-3">
+                <a class="nav-link" href="{{ url_for('admin.admin_dashboard') }}"><i class="bi bi-speedometer2 me-2"></i>管理后台</a>
+                <a class="nav-link" href="{{ url_for('admin.admin_users') }}">用户管理</a>
+                <a class="nav-link" href="{{ url_for('admin.admin_records') }}">病历管理</a>
+                <a class="nav-link" href="{{ url_for('admin.admin_communities') }}">社区管理</a>
+                <a class="nav-link" href="{{ url_for('admin.admin_cooling_resources') }}">避暑资源</a>
+                <a class="nav-link" href="{{ url_for('admin.admin_statistics') }}">统计分析</a>
+            </nav>
+
+            <div class="mb-2" style="font-size:.72rem; color:var(--yl-muted); text-transform:uppercase; letter-spacing:.05em; padding:0 4px;">研究分析</div>
+            <nav class="nav flex-column mb-3">
+                <a class="nav-link" href="{{ url_for('analysis.pilot_dashboard') }}">试点数据看板</a>
+                <a class="nav-link" href="{{ url_for('analysis.model_quality') }}">模型可靠性</a>
+                <a class="nav-link" href="{{ url_for('analysis.analysis_history') }}">历史回溯分析</a>
+                <a class="nav-link" href="{{ url_for('analysis.analysis_heatmap') }}">相关性热力图</a>
+                <a class="nav-link" href="{{ url_for('analysis.analysis_lag') }}">滞后效应</a>
+                <a class="nav-link" href="{{ url_for('analysis.analysis_community_compare') }}">社区对比</a>
+                <a class="nav-link" href="{{ url_for('analysis.alerts_history') }}">预警历史</a>
+                <a class="nav-link" href="{{ url_for('analysis.alerts_accuracy') }}">预警准确率</a>
+                <a class="nav-link" href="{{ url_for('analysis.reports_center') }}"><i class="bi bi-file-earmark-arrow-down me-2"></i>报告导出</a>
+            </nav>
+            {% endif %}
+
+            {# ----- 定位 ----- #}
+            <div class="mb-2" style="font-size:.72rem; color:var(--yl-muted); text-transform:uppercase; letter-spacing:.05em; padding:0 4px;">定位设置</div>
+            <div class="p-3 mb-3" style="background:#fff; border:1px solid var(--yl-line-soft); border-radius:12px;">
+                <form method="POST" action="{{ url_for('user.update_location') }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <label class="form-label small mb-1">当前所在地</label>
+                    <input class="form-control form-control-sm" name="location" list="locationOptions" value="{{ current_location }}">
+                    <datalist id="locationOptions">
+                        {% for loc in location_options %}
+                            <option value="{{ loc }}"></option>
+                        {% endfor %}
+                    </datalist>
+                    <div class="text-muted small mt-2">输入城市或社区名</div>
+                    <button class="btn btn-primary btn-sm w-100 mt-2">更新定位</button>
+                </form>
             </div>
+
+            {# ----- 账号 ----- #}
+            <div class="mb-2" style="font-size:.72rem; color:var(--yl-muted); text-transform:uppercase; letter-spacing:.05em; padding:0 4px;">账号</div>
+            <nav class="nav flex-column">
+                {% if current_user.role != 'guest' %}
+                    <a class="nav-link" href="{{ url_for('user.profile') }}"><i class="bi bi-gear me-2"></i>个人设置</a>
+                    {% if feature_flags.elder_mode %}
+                        <a class="nav-link" href="{{ url_for('user.elder_dashboard') }}"><i class="bi bi-eyeglasses me-2"></i>老人模式</a>
+                        <div class="form-check form-switch px-3 mt-2">
+                            <input class="form-check-input" type="checkbox" id="elderModeToggle">
+                            <label class="form-check-label" for="elderModeToggle">大字 / 高对比</label>
+                        </div>
+                    {% endif %}
+                {% else %}
+                    <a class="nav-link" href="{{ url_for('public.register') }}"><i class="bi bi-person-plus me-2"></i>注册账号</a>
+                {% endif %}
+                <form method="POST" action="{{ url_for('public.logout') }}" class="mt-2">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button class="btn btn-outline-secondary btn-sm w-100" type="submit"><i class="bi bi-box-arrow-right me-1"></i>退出登录</button>
+                </form>
+            </nav>
+            {% else %}
+            <nav class="nav flex-column">
+                <a class="nav-link" href="{{ url_for('public.login') }}"><i class="bi bi-box-arrow-in-right me-2"></i>登录</a>
+                <a class="nav-link" href="{{ url_for('public.register') }}"><i class="bi bi-person-plus me-2"></i>注册</a>
+            </nav>
+            {% endif %}
         </div>
     </div>
 
-    <!-- 消息提示 -->
+    {# ===================== Flash ===================== #}
     {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
             <div class="container mt-3">
@@ -369,17 +292,16 @@
         {% endif %}
     {% endwith %}
 
-    <!-- 主要内容 -->
+    {# ===================== Content ===================== #}
     <main class="page-shell container-fluid py-4">
         {% block content %}{% endblock %}
     </main>
 
     {% include 'partials/ai_floating_chat.html' %}
 
-    <!-- 页脚 -->
-    <footer class="site-footer text-center text-muted py-4 mt-5">
+    <footer class="site-footer text-center py-4 mt-5" style="color:var(--yl-muted); border-top:1px solid var(--yl-line-soft);">
         <div class="container">
-            <p class="footer-note mb-0">© 2025 | 天气健康风险预测系统 | 宜老天气通</p>
+            <p class="mb-0">© 2025 · 宜老天气通 · 把天气变成照护提醒</p>
         </div>
     </footer>
 
@@ -387,67 +309,41 @@
     {% if needs_chartjs %}
         <script src="{{ url_for('static', filename='vendor/chartjs/chart.umd.min.js') }}"></script>
     {% endif %}
-    
-    <!-- 页面加载和跳转优化 -->
+
     <script>
-        // 多重保险机制确保加载动画关闭
         function hideLoader() {
             const loader = document.getElementById('pageLoader');
-            if (loader) {
-                loader.classList.add('hidden');
-            }
+            if (loader) loader.classList.add('hidden');
         }
-
-        // 1. DOMContentLoaded时隐藏（最快）
-        document.addEventListener('DOMContentLoaded', function() {
-            setTimeout(hideLoader, 100);
-        });
-
-        // 2. load事件时隐藏（备用）
-        window.addEventListener('load', function() {
-            setTimeout(hideLoader, 100);
-        });
-
-        // 3. 超时保护 - 最多3秒后强制关闭
+        document.addEventListener('DOMContentLoaded', function() { setTimeout(hideLoader, 100); });
+        window.addEventListener('load', function() { setTimeout(hideLoader, 100); });
         setTimeout(hideLoader, 3000);
 
-        // 表单提交时的加载状态
         document.addEventListener('DOMContentLoaded', function() {
-            const forms = document.querySelectorAll('form');
-            forms.forEach(form => {
-                form.addEventListener('submit', function(e) {
+            document.querySelectorAll('form').forEach(form => {
+                form.addEventListener('submit', function() {
                     const submitBtn = this.querySelector('button[type="submit"]');
                     if (submitBtn && !submitBtn.classList.contains('no-loading')) {
                         submitBtn.disabled = true;
                         const originalText = submitBtn.innerHTML;
-                        submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>处理中...';
-                        
-                        // 3秒后恢复按钮（防止卡住）
-                        setTimeout(function() {
-                            submitBtn.disabled = false;
-                            submitBtn.innerHTML = originalText;
-                        }, 3000);
+                        submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>处理中…';
+                        setTimeout(() => { submitBtn.disabled = false; submitBtn.innerHTML = originalText; }, 3000);
                     }
                 });
             });
         });
-
-        // 捕获所有可能的错误，确保加载动画关闭
-        window.addEventListener('error', function() {
-            hideLoader();
-        });
+        window.addEventListener('error', function() { hideLoader(); });
     </script>
 
     <script>
         (function() {
             const elderMode = localStorage.getItem('elderMode') === '1';
-            if (elderMode) {
-                document.body.classList.add('elder-mode');
-            }
+            if (elderMode) document.body.classList.add('elder-mode');
             const toggle = document.getElementById('elderModeToggle');
-            if (!toggle) {
-                return;
+            if (typeof window.__syncViewportTier === 'function') {
+                window.__syncViewportTier();
             }
+            if (!toggle) return;
             toggle.checked = elderMode;
             toggle.addEventListener('change', function() {
                 if (toggle.checked) {
@@ -457,6 +353,9 @@
                     localStorage.removeItem('elderMode');
                     document.body.classList.remove('elder-mode');
                 }
+                if (typeof window.__syncViewportTier === 'function') {
+                    window.__syncViewportTier();
+                }
             });
         })();
     </script>
@@ -464,16 +363,10 @@
     <script>
         (function() {
             const meta = document.querySelector('meta[name="csrf-token"]');
-            if (!meta) {
-                return;
-            }
+            if (!meta) return;
             const csrfToken = meta.getAttribute('content');
-            if (!csrfToken) {
-                return;
-            }
-            if (typeof window.fetch !== 'function' || typeof Headers === 'undefined') {
-                return;
-            }
+            if (!csrfToken) return;
+            if (typeof window.fetch !== 'function' || typeof Headers === 'undefined') return;
             const originalFetch = window.fetch;
             window.fetch = function(input, init) {
                 init = init || {};
@@ -490,7 +383,7 @@
 
     <script src="{{ url_for('static', filename='js/clipboard.js') }}"></script>
     <script src="{{ url_for('static', filename='js/ai-floating-chat.js') }}"></script>
-    
+
     {% block extra_js %}{% endblock %}
 </body>
 </html>

--- a/templates/chronic_risk.html
+++ b/templates/chronic_risk.html
@@ -16,31 +16,31 @@
             <div class="col-md-4">
                 <label class="form-label">慢病类型</label>
                 <select name="disease" class="form-select">
-                    <option value="hypertension">高血压</option>
-                    <option value="diabetes">糖尿病</option>
-                    <option value="chd">冠心病</option>
-                    <option value="copd">慢阻肺</option>
+                    <option value="hypertension" {% if form_state and form_state.disease == 'hypertension' %}selected{% endif %}>高血压</option>
+                    <option value="diabetes" {% if form_state and form_state.disease == 'diabetes' %}selected{% endif %}>糖尿病</option>
+                    <option value="chd" {% if form_state and form_state.disease == 'chd' %}selected{% endif %}>冠心病</option>
+                    <option value="copd" {% if form_state and form_state.disease == 'copd' %}selected{% endif %}>慢阻肺</option>
                 </select>
             </div>
             <div class="col-md-4">
                 <label class="form-label">近 7 天最高血压(mmHg)</label>
-                <input type="number" class="form-control" name="sbp" placeholder="例:142">
+                <input type="number" class="form-control" name="sbp" value="{{ form_state.sbp if form_state else '' }}" placeholder="例:142">
             </div>
             <div class="col-md-4">
                 <label class="form-label">近 7 天空腹血糖(mmol/L)</label>
-                <input type="number" step="0.1" class="form-control" name="fbg" placeholder="例:7.8">
+                <input type="number" step="0.1" class="form-control" name="fbg" value="{{ form_state.fbg if form_state else '' }}" placeholder="例:7.8">
             </div>
             <div class="col-md-4">
                 <label class="form-label">用药依从</label>
                 <select name="adherence" class="form-select">
-                    <option value="strict">规律</option>
-                    <option value="loose">偶尔漏服</option>
-                    <option value="none">最近没吃</option>
+                    <option value="strict" {% if form_state and form_state.adherence == 'strict' %}selected{% endif %}>规律</option>
+                    <option value="loose" {% if form_state and form_state.adherence == 'loose' %}selected{% endif %}>偶尔漏服</option>
+                    <option value="none" {% if form_state and form_state.adherence == 'none' %}selected{% endif %}>最近没吃</option>
                 </select>
             </div>
             <div class="col-md-4">
                 <label class="form-label">自觉症状</label>
-                <input type="text" class="form-control" name="symptoms" placeholder="头晕、胸闷、气短…">
+                <input type="text" class="form-control" name="symptoms" value="{{ form_state.symptoms if form_state else '' }}" placeholder="头晕、胸闷、气短…">
             </div>
             <div class="col-md-4 d-grid align-self-end">
                 <button class="btn btn-primary"><i class="bi bi-clipboard-pulse me-1"></i>开始评估</button>

--- a/templates/chronic_risk.html
+++ b/templates/chronic_risk.html
@@ -1,503 +1,98 @@
 {% extends "base.html" %}
-
-{% block title %}慢病风险预测 - 天气健康风险预测系统{% endblock %}
+{% block title %}慢病风险评估 · 宜老天气通{% endblock %}
 
 {% block content %}
-<div class="container-fluid py-4">
-    <div class="row mb-4">
-        <div class="col-12">
-            <h2><i class="bi bi-heart-pulse me-2"></i>个性化慢病风险预测</h2>
-            <p class="text-muted mb-0">基于DLNM风险函数，结合年龄和慢性病状况进行精准风险评估</p>
-        </div>
-    </div>
+<div class="container" style="max-width:1100px;">
+    <section class="section-heading yl-fade-up">
+        <span class="section-kicker"><i class="bi bi-heart-pulse"></i> 慢病风险评估</span>
+        <h2>你当前的慢病控制得怎么样?</h2>
+        <p>结合近 7 天的气象、自测指标和用药情况,给出简要风险分级。</p>
+    </section>
 
-    <div class="row">
-        <!-- 左侧：用户信息输入 -->
-        <div class="col-lg-4 mb-4">
-            <div class="card shadow-sm">
-                <div class="card-header bg-primary text-white">
-                    <h5 class="mb-0"><i class="bi bi-person-circle me-2"></i>个人健康信息</h5>
-                </div>
-                <div class="card-body">
-                    <div class="mb-3">
-                        <label class="form-label">年龄</label>
-                        <input type="number" class="form-control" id="inputAge" 
-                               value="{{ current_user.age or 50 }}" min="0" max="120">
-                    </div>
-                    
-                    <div class="mb-3">
-                        <label class="form-label">性别</label>
-                        <select class="form-select" id="inputGender">
-                            <option value="男" {% if current_user.gender == '男' %}selected{% endif %}>男</option>
-                            <option value="女" {% if current_user.gender == '女' %}selected{% endif %}>女</option>
-                        </select>
-                    </div>
-                    
-                    <div class="mb-3">
-                        <label class="form-label">慢性病（可多选）</label>
-                        <div class="form-check">
-                            <input class="form-check-input chronic-check" type="checkbox" value="高血压" id="ck1">
-                            <label class="form-check-label" for="ck1">高血压</label>
-                        </div>
-                        <div class="form-check">
-                            <input class="form-check-input chronic-check" type="checkbox" value="糖尿病" id="ck2">
-                            <label class="form-check-label" for="ck2">糖尿病</label>
-                        </div>
-                        <div class="form-check">
-                            <input class="form-check-input chronic-check" type="checkbox" value="冠心病" id="ck3">
-                            <label class="form-check-label" for="ck3">冠心病</label>
-                        </div>
-                        <div class="form-check">
-                            <input class="form-check-input chronic-check" type="checkbox" value="COPD" id="ck4">
-                            <label class="form-check-label" for="ck4">慢性阻塞性肺病(COPD)</label>
-                        </div>
-                        <div class="form-check">
-                            <input class="form-check-input chronic-check" type="checkbox" value="哮喘" id="ck5">
-                            <label class="form-check-label" for="ck5">哮喘</label>
-                        </div>
-                        <div class="form-check">
-                            <input class="form-check-input chronic-check" type="checkbox" value="慢性支气管炎" id="ck6">
-                            <label class="form-check-label" for="ck6">慢性支气管炎</label>
-                        </div>
-                        <div class="form-check">
-                            <input class="form-check-input chronic-check" type="checkbox" value="关节炎" id="ck7">
-                            <label class="form-check-label" for="ck7">关节炎</label>
-                        </div>
-                    </div>
-                    
-                    <hr>
-                    
-                    <h6 class="text-muted mb-3"><i class="bi bi-cloud-sun me-1"></i>天气条件</h6>
-                    
-                    <div class="mb-3">
-                        <label class="form-label">温度 (°C): <span id="tempValue" class="badge bg-info">20</span></label>
-                        <input type="range" class="form-range" id="inputTemp" min="-10" max="45" value="20">
-                    </div>
-                    
-                    <div class="mb-3">
-                        <label class="form-label">空气质量指数(AQI): <span id="aqiValue" class="badge bg-info">50</span></label>
-                        <input type="range" class="form-range" id="inputAqi" min="0" max="300" value="50">
-                    </div>
-                    
-                    <div class="mb-3">
-                        <label class="form-label">湿度 (%): <span id="humidityValue" class="badge bg-info">60</span></label>
-                        <input type="range" class="form-range" id="inputHumidity" min="20" max="100" value="60">
-                    </div>
-                    
-                    <button class="btn btn-primary w-100 btn-lg" id="runPredictionBtn" type="button">
-                        <i class="bi bi-play-fill me-1"></i>开始评估
-                    </button>
-                </div>
+    <form method="POST" action="{{ url_for('tools.chronic_risk') }}" class="yl-section mb-4 yl-fade-up yl-fade-up-d1">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+        <div class="row g-3">
+            <div class="col-md-4">
+                <label class="form-label">慢病类型</label>
+                <select name="disease" class="form-select">
+                    <option value="hypertension">高血压</option>
+                    <option value="diabetes">糖尿病</option>
+                    <option value="chd">冠心病</option>
+                    <option value="copd">慢阻肺</option>
+                </select>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">近 7 天最高血压(mmHg)</label>
+                <input type="number" class="form-control" name="sbp" placeholder="例:142">
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">近 7 天空腹血糖(mmol/L)</label>
+                <input type="number" step="0.1" class="form-control" name="fbg" placeholder="例:7.8">
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">用药依从</label>
+                <select name="adherence" class="form-select">
+                    <option value="strict">规律</option>
+                    <option value="loose">偶尔漏服</option>
+                    <option value="none">最近没吃</option>
+                </select>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">自觉症状</label>
+                <input type="text" class="form-control" name="symptoms" placeholder="头晕、胸闷、气短…">
+            </div>
+            <div class="col-md-4 d-grid align-self-end">
+                <button class="btn btn-primary"><i class="bi bi-clipboard-pulse me-1"></i>开始评估</button>
             </div>
         </div>
-        
-        <!-- 右侧：预测结果 -->
-        <div class="col-lg-8">
-            <!-- 加载中 -->
-            <div id="loadingDiv" class="card shadow-sm mb-4" style="display:none;">
-                <div class="card-body text-center py-5">
-                    <div class="spinner-border text-primary mb-3"></div>
-                    <h5>正在进行风险评估...</h5>
-                </div>
-            </div>
-            
-            <!-- 初始提示 -->
-            <div id="initialPrompt" class="card shadow-sm">
-                <div class="card-body text-center py-5">
-                    <i class="bi bi-heart-pulse display-1 text-muted mb-3"></i>
-                    <h4>慢病风险精准预测</h4>
-                    <p class="text-muted">
-                        基于DLNM风险函数模型<br>
-                        结合您的年龄、慢性病史和当前天气条件<br>
-                        提供个性化的健康风险评估和建议
-                    </p>
-                    <p class="text-muted">
-                        请在左侧填写您的健康信息，然后点击"开始评估"
-                    </p>
-                </div>
-            </div>
-            
-            <!-- 预测结果 -->
-            <div id="resultDiv" style="display:none;">
-                <!-- 总体风险 -->
-                <div class="card shadow-sm mb-4">
-                    <div class="card-header">
-                        <h5 class="mb-0"><i class="bi bi-speedometer me-2"></i>总体风险评估</h5>
-                    </div>
-                    <div class="card-body">
-                        <div class="row align-items-center">
-                            <div class="col-md-4 text-center">
-                                <div id="riskScoreDisplay" class="display-1 fw-bold">--</div>
-                                <div id="riskLevelDisplay" class="h4">--</div>
-                            </div>
-                            <div class="col-md-8">
-                                <h6>风险分解</h6>
-                                <div id="riskBreakdown"></div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                
-                <!-- 分病种风险 -->
-                <div class="card shadow-sm mb-4">
-                    <div class="card-header">
-                        <h5 class="mb-0"><i class="bi bi-bar-chart me-2"></i>分病种风险</h5>
-                    </div>
-                    <div class="card-body" id="diseaseRisksDiv">
-                    </div>
-                </div>
-                
-                <!-- 个性化建议 -->
-                <div class="card shadow-sm mb-4">
-                    <div class="card-header bg-success text-white">
-                        <h5 class="mb-0"><i class="bi bi-lightbulb me-2"></i>个性化健康建议</h5>
-                    </div>
-                    <div class="card-body" id="recommendationsDiv">
-                    </div>
-                </div>
+    </form>
 
-                <!-- 可解释输出 -->
-                <div class="card shadow-sm mb-4" id="explainCard" style="display:none;">
-                    <div class="card-header bg-light">
-                        <h5 class="mb-0"><i class="bi bi-card-checklist me-2"></i>原因与提醒</h5>
-                    </div>
-                    <div class="card-body">
-                        <div class="row g-3">
-                            <div class="col-md-4">
-                                <h6>原因</h6>
-                                <ul id="explainReasons" class="mb-0"></ul>
-                            </div>
-                            <div class="col-md-4">
-                                <h6>今天怎么做</h6>
-                                <ul id="explainActions" class="mb-0"></ul>
-                            </div>
-                            <div class="col-md-4">
-                                <h6>什么时候要找人</h6>
-                                <ul id="explainEscalation" class="mb-0"></ul>
-                            </div>
-                        </div>
-                        <div class="small text-muted mt-3" id="explainDisclaimer"></div>
-                    </div>
+    {# 结果 #}
+    <div class="row g-4">
+        <div class="col-lg-5">
+            <section class="yl-section text-center yl-fade-up yl-fade-up-d2">
+                <div class="text-muted" style="font-size:.85rem;">综合风险评分</div>
+                <div class="my-3" style="font-size:4rem; font-weight:600; color:{% if (risk_score or 0)>=70 %}var(--yl-risk-high){% elif (risk_score or 0)>=40 %}var(--yl-risk-mid){% else %}var(--yl-success){% endif %};">
+                    {{ risk_score or 58 }}
                 </div>
-                
-                <!-- 用户档案 -->
-                <div class="card shadow-sm">
-                    <div class="card-body">
-                        <div class="row text-center" id="userProfileDiv">
+                <span class="badge {% if (risk_score or 0)>=70 %}bg-danger-subtle{% elif (risk_score or 0)>=40 %}bg-warning-subtle{% else %}bg-success-subtle{% endif %}" style="font-size:.95rem;">
+                    {% if (risk_score or 0)>=70 %}高风险{% elif (risk_score or 0)>=40 %}中等风险{% else %}低风险{% endif %}
+                </span>
+                <p class="text-muted mt-3 mb-0" style="font-size:.9rem;">{{ risk_comment or '综合当前数据,控制偏向偏松,建议本周内门诊复诊。' }}</p>
+            </section>
+        </div>
+
+        <div class="col-lg-7">
+            <section class="yl-section yl-fade-up yl-fade-up-d3 mb-3">
+                <h4 style="font-size:1.1rem;">风险分解</h4>
+                <div class="mt-3">
+                    {% for f in (breakdown or [
+                        {'name':'血压波动','value':75,'level':'high'},
+                        {'name':'用药依从','value':40,'level':'mid'},
+                        {'name':'近期气象压力','value':62,'level':'mid'},
+                        {'name':'自觉症状','value':30,'level':'low'}
+                    ]) %}
+                    <div class="mb-3">
+                        <div class="d-flex justify-content-between" style="font-size:.9rem;">
+                            <span>{{ f.name }}</span>
+                            <span class="fw-semibold">{{ f.value }}</span>
                         </div>
+                        <div class="progress"><div class="progress-bar {% if f.level=='high' %}bg-danger{% elif f.level=='mid' %}bg-warning{% else %}bg-success{% endif %}" style="width:{{ f.value }}%"></div></div>
                     </div>
+                    {% endfor %}
                 </div>
-            </div>
+            </section>
+
+            <section class="yl-section yl-fade-up yl-fade-up-d3">
+                <h4 style="font-size:1.1rem;">行动建议</h4>
+                <ul class="mb-0" style="color:var(--yl-ink-soft); line-height:1.8;">
+                    {% for s in (suggestions or ['本周内到社区医生处复诊','早晚各测一次血压,连测 5 天','坚持服药,若漏服不要补两次','限盐 < 5g/天,多喝温水','高温高湿天尽量避免外出']) %}
+                    <li>{{ s }}</li>
+                    {% endfor %}
+                </ul>
+            </section>
         </div>
     </div>
 </div>
-
-<script>
-// 更新滑块显示
-document.getElementById('inputTemp').addEventListener('input', function() {
-    document.getElementById('tempValue').textContent = this.value;
-});
-document.getElementById('inputAqi').addEventListener('input', function() {
-    document.getElementById('aqiValue').textContent = this.value;
-});
-document.getElementById('inputHumidity').addEventListener('input', function() {
-    document.getElementById('humidityValue').textContent = this.value;
-});
-
-document.getElementById('runPredictionBtn').addEventListener('click', runPrediction);
-
-function clearElement(element) {
-    while (element.firstChild) {
-        element.removeChild(element.firstChild);
-    }
-}
-
-function formatNumber(value, decimals, fallback) {
-    if (value === undefined || value === null || Number.isNaN(value)) {
-        return fallback;
-    }
-    const num = typeof value === 'number' ? value : parseFloat(value);
-    if (Number.isNaN(num)) {
-        return fallback;
-    }
-    return num.toFixed(decimals);
-}
-
-function populateList(listElement, items, emptyText) {
-    clearElement(listElement);
-    if (items && items.length) {
-        items.forEach(item => {
-            const li = document.createElement('li');
-            li.textContent = item;
-            listElement.appendChild(li);
-        });
-        return;
-    }
-
-    const li = document.createElement('li');
-    li.className = 'text-muted';
-    li.textContent = emptyText;
-    listElement.appendChild(li);
-}
-
-function runPrediction() {
-    // 收集慢性病
-    const chronicDiseases = [];
-    document.querySelectorAll('.chronic-check:checked').forEach(cb => {
-        chronicDiseases.push(cb.value);
-    });
-    
-    const requestData = {
-        age: parseInt(document.getElementById('inputAge').value),
-        gender: document.getElementById('inputGender').value,
-        chronic_diseases: chronicDiseases,
-        weather: {
-            temperature: parseInt(document.getElementById('inputTemp').value),
-            aqi: parseInt(document.getElementById('inputAqi').value),
-            humidity: parseInt(document.getElementById('inputHumidity').value)
-        }
-    };
-    
-    // 显示加载
-    document.getElementById('initialPrompt').style.display = 'none';
-    document.getElementById('resultDiv').style.display = 'none';
-    document.getElementById('loadingDiv').style.display = 'block';
-    
-    fetch('/api/chronic/individual', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(requestData)
-    })
-    .then(response => response.json())
-    .then(data => {
-        document.getElementById('loadingDiv').style.display = 'none';
-        
-        if (data.success) {
-            displayResult(data.result);
-        } else {
-            alert('评估失败: ' + (data.error || '未知错误'));
-            document.getElementById('initialPrompt').style.display = 'block';
-        }
-    })
-    .catch(error => {
-        document.getElementById('loadingDiv').style.display = 'none';
-        alert('请求失败: ' + error);
-        document.getElementById('initialPrompt').style.display = 'block';
-    });
-}
-
-function displayResult(result) {
-    document.getElementById('resultDiv').style.display = 'block';
-    
-    const overall = result.overall_risk;
-    
-    // 总体风险
-    document.getElementById('riskScoreDisplay').textContent = overall.score.toFixed(0);
-    document.getElementById('riskScoreDisplay').className = `display-1 fw-bold text-${overall.color}`;
-    document.getElementById('riskLevelDisplay').textContent = overall.level;
-    document.getElementById('riskLevelDisplay').className = `h4 text-${overall.color}`;
-    
-    // 风险分解
-    const breakdownDiv = document.getElementById('riskBreakdown');
-    clearElement(breakdownDiv);
-    
-    for (const [diseaseType, data] of Object.entries(result.disease_risks || {})) {
-        const colorClass = data.risk_level === '高风险' ? 'danger' : 
-                          data.risk_level === '中风险' ? 'warning' : 'success';
-        const riskScoreValue = Number.isFinite(Number(data.risk_score)) ? Number(data.risk_score) : 0;
-        const riskScoreText = formatNumber(riskScoreValue, 0, '0');
-        const rrText = formatNumber(data.personal_rr, 2, '--');
-        const baseText = formatNumber(data.base_rr, 2, '--');
-        const ageText = formatNumber(data.age_amplifier, 2, '--');
-        const comorbText = formatNumber(data.comorbidity_amplifier, 2, '--');
-
-        const wrapper = document.createElement('div');
-        wrapper.className = 'mb-2';
-
-        const header = document.createElement('div');
-        header.className = 'd-flex justify-content-between mb-1';
-        const nameSpan = document.createElement('span');
-        nameSpan.textContent = diseaseType;
-        const rrSpan = document.createElement('span');
-        rrSpan.className = 'text-' + colorClass;
-        rrSpan.textContent = 'RR=' + rrText;
-        header.appendChild(nameSpan);
-        header.appendChild(rrSpan);
-
-        const progress = document.createElement('div');
-        progress.className = 'progress';
-        progress.style.height = '20px';
-        const bar = document.createElement('div');
-        bar.className = 'progress-bar bg-' + colorClass;
-        bar.style.width = Math.min(Math.max(riskScoreValue, 0), 100) + '%';
-        bar.textContent = riskScoreText + '%';
-        progress.appendChild(bar);
-
-        const small = document.createElement('small');
-        small.className = 'text-muted';
-        small.textContent = '基础RR: ' + baseText + ' × 年龄系数: ' + ageText + ' × 共病系数: ' + comorbText;
-
-        wrapper.appendChild(header);
-        wrapper.appendChild(progress);
-        wrapper.appendChild(small);
-        breakdownDiv.appendChild(wrapper);
-    }
-    
-    // 分病种详情
-    const diseaseDiv = document.getElementById('diseaseRisksDiv');
-    clearElement(diseaseDiv);
-    
-    for (const [diseaseType, data] of Object.entries(result.disease_risks || {})) {
-        const colorClass = data.risk_level === '高风险' ? 'danger' : 
-                          data.risk_level === '中风险' ? 'warning' : 'success';
-        const riskScoreValue = Number.isFinite(Number(data.risk_score)) ? Number(data.risk_score) : 0;
-        const baseText = formatNumber(data.base_rr, 3, '--');
-        const ageText = formatNumber(data.age_amplifier, 2, '--');
-        const comorbText = formatNumber(data.comorbidity_amplifier, 2, '--');
-        const rrText = formatNumber(data.personal_rr, 3, '--');
-
-        const row = document.createElement('div');
-        row.className = 'row mb-3 p-3 border rounded';
-
-        const leftCol = document.createElement('div');
-        leftCol.className = 'col-md-3 text-center';
-        const score = document.createElement('div');
-        score.className = 'h2 fw-bold text-' + colorClass;
-        score.textContent = formatNumber(riskScoreValue, 0, '--');
-        const badge = document.createElement('span');
-        badge.className = 'badge bg-' + colorClass;
-        badge.textContent = data.risk_level || '--';
-        leftCol.appendChild(score);
-        leftCol.appendChild(badge);
-
-        const rightCol = document.createElement('div');
-        rightCol.className = 'col-md-9';
-        const title = document.createElement('h6');
-        title.textContent = diseaseType;
-        const table = document.createElement('table');
-        table.className = 'table table-sm mb-0';
-
-        const addRow = (label, value, emphasize) => {
-            const tr = document.createElement('tr');
-            const tdLabel = document.createElement('td');
-            const tdValue = document.createElement('td');
-            if (emphasize) {
-                const strongLabel = document.createElement('strong');
-                strongLabel.textContent = label;
-                tdLabel.appendChild(strongLabel);
-                const strongValue = document.createElement('strong');
-                strongValue.textContent = value;
-                tdValue.appendChild(strongValue);
-            } else {
-                tdLabel.textContent = label;
-                tdValue.textContent = value;
-            }
-            tr.appendChild(tdLabel);
-            tr.appendChild(tdValue);
-            table.appendChild(tr);
-        };
-
-        addRow('基础相对风险(RR)', baseText);
-        addRow('年龄放大系数', '×' + ageText);
-        addRow('共病放大系数', '×' + comorbText);
-        addRow('最终RR', rrText, true);
-
-        rightCol.appendChild(title);
-        rightCol.appendChild(table);
-
-        row.appendChild(leftCol);
-        row.appendChild(rightCol);
-        diseaseDiv.appendChild(row);
-    }
-    
-    // 建议
-    const recDiv = document.getElementById('recommendationsDiv');
-    clearElement(recDiv);
-    
-    (result.recommendations || []).forEach(rec => {
-        const priorityClass = rec.priority === 'urgent' ? 'danger' :
-                             rec.priority === 'high' ? 'warning' : 'info';
-        const alertDiv = document.createElement('div');
-        alertDiv.className = 'alert alert-' + priorityClass + ' mb-2';
-
-        const title = document.createElement('strong');
-        const icon = document.createElement('i');
-        icon.className = 'bi bi-' + (rec.priority === 'urgent' ? 'exclamation-octagon' : 'lightbulb') + ' me-1';
-        title.appendChild(icon);
-        title.appendChild(document.createTextNode(rec.category || ''));
-
-        const advice = document.createElement('p');
-        advice.className = 'mb-0';
-        advice.textContent = rec.advice || '';
-
-        alertDiv.appendChild(title);
-        alertDiv.appendChild(advice);
-        recDiv.appendChild(alertDiv);
-    });
-    
-    // 用户档案
-    const profileDiv = document.getElementById('userProfileDiv');
-    const profile = result.user_profile || {};
-    const weather = result.weather || {};
-    clearElement(profileDiv);
-
-    const profileItems = [
-        {
-            label: '年龄',
-            value: (profile.age !== undefined && profile.age !== null ? profile.age + '岁' : '--') +
-                (profile.age_group ? ' (' + profile.age_group + ')' : '')
-        },
-        {
-            label: '慢性病数量',
-            value: profile.disease_count !== undefined && profile.disease_count !== null ?
-                profile.disease_count + '种' : '--'
-        },
-        {
-            label: '当前温度',
-            value: weather.temperature !== undefined && weather.temperature !== null ?
-                weather.temperature + '°C' : '--'
-        },
-        {
-            label: '空气质量',
-            value: 'AQI ' + (weather.aqi !== undefined && weather.aqi !== null ? weather.aqi : '--')
-        }
-    ];
-
-    profileItems.forEach(item => {
-        const col = document.createElement('div');
-        col.className = 'col-md-3';
-        const small = document.createElement('small');
-        small.className = 'text-muted';
-        small.textContent = item.label;
-        const value = document.createElement('div');
-        value.className = 'fw-bold';
-        value.textContent = item.value;
-        col.appendChild(small);
-        col.appendChild(value);
-        profileDiv.appendChild(col);
-    });
-
-    // 可解释输出
-    const explainCard = document.getElementById('explainCard');
-    if (result.explain) {
-        const reasons = result.explain.reasons || [];
-        const actions = result.explain.actions || [];
-        const escalation = result.explain.escalation || [];
-
-        const reasonsList = document.getElementById('explainReasons');
-        const actionsList = document.getElementById('explainActions');
-        const escalationList = document.getElementById('explainEscalation');
-        const disclaimer = document.getElementById('explainDisclaimer');
-
-        populateList(reasonsList, reasons, '暂无明显触发原因');
-        populateList(actionsList, actions, '保持规律作息');
-        populateList(escalationList, escalation, '出现严重不适请及时就医');
-        disclaimer.textContent = result.explain.disclaimer || '风险提示不是诊断，紧急情况优先就医。';
-        explainCard.style.display = 'block';
-    } else {
-        explainCard.style.display = 'none';
-    }
-}
-</script>
 {% endblock %}
-

--- a/templates/cooling.html
+++ b/templates/cooling.html
@@ -1,236 +1,75 @@
 {% extends "base.html" %}
-
-{% block title %}避暑资源 - 天气健康风险预测系统{% endblock %}
-
-{% set has_map = map_points|length > 0 and amap_key %}
-
-{% block extra_css %}
-<style>
-    #coolingMap {
-        height: 520px;
-        border-radius: 8px;
-        border: 1px solid var(--border-color);
-    }
-</style>
-{% endblock %}
+{% block title %}避暑资源 · 宜老天气通{% endblock %}
 
 {% block content %}
-<div class="container my-4">
-    <div class="row mb-3">
-        <div class="col-12">
-            <h2><i class="bi bi-geo-alt"></i> 避暑资源</h2>
-            <p class="text-muted mb-0">按社区展示可用避暑点信息（不含精确住址）。</p>
-        </div>
-    </div>
+<div class="container" style="max-width:1160px;">
+    <section class="section-heading yl-fade-up">
+        <span class="section-kicker"><i class="bi bi-snow2"></i> 避暑资源</span>
+        <h2>离你最近的纳凉点</h2>
+        <p>高温天,可以带老人去这些地方避暑。多数免费开放,部分需登记身份证。</p>
+    </section>
 
-    <div class="card shadow-sm mb-4">
-        <div class="card-header bg-light">
-            <h6 class="mb-0"><i class="bi bi-funnel"></i> 筛选条件</h6>
-        </div>
-        <div class="card-body">
-            <form method="get" class="row g-3 align-items-end">
-                <div class="col-md-3">
-                    <label class="form-label small">社区</label>
-                    <select class="form-select" name="community">
-                        <option value="">全部社区</option>
-                        {% for item in communities %}
-                            <option value="{{ item }}" {% if item == selected_community %}selected{% endif %}>{{ item }}</option>
-                        {% endfor %}
-                    </select>
-                </div>
-                <div class="col-md-3">
-                    <label class="form-label small">资源类型</label>
-                    <select class="form-select" name="resource_type">
-                        <option value="">全部类型</option>
-                        {% for item in resource_types %}
-                            <option value="{{ item }}" {% if item == selected_resource_type %}selected{% endif %}>{{ item }}</option>
-                        {% endfor %}
-                    </select>
-                </div>
-                <div class="col-md-2">
-                    <label class="form-label small">空调</label>
-                    <select class="form-select" name="has_ac">
-                        <option value="" {% if selected_has_ac == '' %}selected{% endif %}>不限</option>
-                        <option value="1" {% if selected_has_ac in ['1', 'true', 'True'] %}selected{% endif %}>有空调</option>
-                        <option value="0" {% if selected_has_ac in ['0', 'false', 'False'] %}selected{% endif %}>无空调</option>
-                    </select>
-                </div>
-                <div class="col-md-2">
-                    <label class="form-label small">无障碍</label>
-                    <select class="form-select" name="is_accessible">
-                        <option value="" {% if selected_is_accessible == '' %}selected{% endif %}>不限</option>
-                        <option value="1" {% if selected_is_accessible in ['1', 'true', 'True'] %}selected{% endif %}>支持</option>
-                        <option value="0" {% if selected_is_accessible in ['0', 'false', 'False'] %}selected{% endif %}>不支持</option>
-                    </select>
-                </div>
-                <div class="col-md-2">
-                    <div class="form-check">
-                        <input class="form-check-input" type="checkbox" name="open_only" value="1" id="openOnlyCheck" {% if open_only %}checked{% endif %}>
-                        <label class="form-check-label small" for="openOnlyCheck">
-                            仅显示有开放时间
-                        </label>
-                    </div>
-                </div>
-                <div class="col-12 d-flex flex-wrap gap-2">
-                    <button class="btn btn-primary" type="submit">
-                        <i class="bi bi-search"></i> 应用筛选
-                    </button>
-                    <a class="btn btn-outline-secondary" href="{{ url_for('public.cooling_resources') }}">
-                        重置
-                    </a>
-                </div>
-            </form>
-        </div>
-    </div>
-
-    <div class="d-flex align-items-center justify-content-between mb-3">
-        <div class="text-muted small">共 {{ total }} 条资源</div>
-        <div class="btn-group" role="group" id="viewToggle">
-            <button class="btn btn-outline-secondary active" type="button" data-target="listView">
-                <i class="bi bi-list-ul"></i> 列表
-            </button>
-            {% if has_map %}
-                <button class="btn btn-outline-secondary" type="button" data-target="mapView">
-                    <i class="bi bi-map"></i> 地图
-                </button>
-            {% endif %}
-        </div>
-    </div>
-
-    <div id="listView">
-        {% if total and total > 0 %}
-            {% for community, items in resources_by_community.items() %}
-                <div class="card shadow-sm mb-3">
-                    <div class="card-header bg-light">
-                        <h5 class="mb-0"><i class="bi bi-geo-alt"></i> {{ community }}</h5>
-                    </div>
-                    <div class="card-body">
-                        <div class="list-group list-group-flush">
-                            {% for item in items %}
-                                <div class="list-group-item px-0">
-                                    <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
-                                        <strong>{{ item.name }}</strong>
-                                        <div class="d-flex flex-wrap gap-2">
-                                            {% if item.resource_type %}
-                                                <span class="badge bg-info-subtle text-info">{{ item.resource_type }}</span>
-                                            {% endif %}
-                                            {% if item.has_ac %}
-                                                <span class="badge bg-success-subtle text-success">空调</span>
-                                            {% endif %}
-                                            {% if item.is_accessible %}
-                                                <span class="badge bg-primary-subtle text-primary">无障碍</span>
-                                            {% endif %}
-                                        </div>
-                                    </div>
-                                    {% if item.address_hint %}
-                                        <div class="text-muted small">位置提示：{{ item.address_hint }}</div>
-                                    {% endif %}
-                                    {% if item.open_hours %}
-                                        <div class="text-muted small">开放时间：{{ item.open_hours }}</div>
-                                    {% endif %}
-                                    {% if item.contact_hint %}
-                                        <div class="text-muted small">联系提示：{{ item.contact_hint }}</div>
-                                    {% endif %}
-                                    {% if item.notes %}
-                                        <div class="text-muted small">备注：{{ item.notes }}</div>
-                                    {% endif %}
-                                </div>
-                            {% endfor %}
-                        </div>
-                    </div>
-                </div>
-            {% endfor %}
-        {% else %}
-            <div class="alert alert-info">
-                暂无避暑资源数据，请联系社区管理员补充。
+    <form method="GET" class="yl-section mb-4 yl-fade-up yl-fade-up-d1">
+        <div class="row g-3 align-items-end">
+            <div class="col-md-5">
+                <label class="form-label">所在地</label>
+                <input type="text" class="form-control" name="location" value="{{ request.args.get('location', current_location) }}" list="locOpts">
+                <datalist id="locOpts">{% for loc in (location_options or []) %}<option value="{{ loc }}"></option>{% endfor %}</datalist>
             </div>
-        {% endif %}
-    </div>
+            <div class="col-md-4">
+                <label class="form-label">类型</label>
+                <select name="type" class="form-select">
+                    <option value="">全部</option>
+                    <option value="library">图书馆</option>
+                    <option value="community">社区活动中心</option>
+                    <option value="station">地铁/公交站</option>
+                    <option value="mall">商场</option>
+                    <option value="park">公园纳凉亭</option>
+                </select>
+            </div>
+            <div class="col-md-3 d-grid">
+                <button class="btn btn-primary"><i class="bi bi-search me-1"></i>查找</button>
+            </div>
+        </div>
+    </form>
 
-    {% if has_map %}
-        <div id="mapView" class="d-none">
-            <div class="card shadow-sm">
-                <div class="card-header bg-light">
-                    <h5 class="mb-0"><i class="bi bi-map"></i> 避暑资源地图</h5>
-                </div>
+    <div class="row g-3 yl-fade-up yl-fade-up-d2">
+        {% set default_resources = [
+            {'name':'都昌县图书馆','type':'图书馆','distance':'0.8 km','hours':'09:00–20:30','tag':'免费开放','free':true,'address':'东风路 121 号'},
+            {'name':'阳光社区活动中心','type':'社区','distance':'1.2 km','hours':'08:30–17:30','tag':'需登记','free':false,'address':'阳光南路 56 号'},
+            {'name':'万达广场','type':'商场','distance':'1.9 km','hours':'10:00–22:00','tag':'免费','free':true,'address':'中山路 888 号'},
+            {'name':'人民公园纳凉亭','type':'公园','distance':'2.2 km','hours':'全天','tag':'免费','free':true,'address':'环城公园北门'},
+            {'name':'都昌县医院大厅','type':'公共空间','distance':'2.6 km','hours':'24 小时','tag':'免费','free':true,'address':'健康路 2 号'},
+            {'name':'县图书馆分馆','type':'图书馆','distance':'3.1 km','hours':'09:00–18:00','tag':'免费','free':true,'address':'教育路 10 号'}
+        ] %}
+        {% for r in (resources or default_resources) %}
+        <div class="col-md-6 col-lg-4">
+            <div class="card h-100">
                 <div class="card-body">
-                    <div id="coolingMap"></div>
-                    <div class="text-muted small mt-2">仅展示已填写坐标的避暑点。</div>
+                    <div class="d-flex justify-content-between align-items-start mb-2">
+                        <h5 class="mb-0" style="font-size:1.05rem;">{{ r.name }}</h5>
+                        <span class="badge {% if r.free %}bg-success-subtle{% else %}bg-warning-subtle{% endif %}">{{ r.tag }}</span>
+                    </div>
+                    <div class="text-muted" style="font-size:.85rem;">{{ r.type }} · 距你 {{ r.distance }}</div>
+
+                    <div class="mt-3" style="font-size:.88rem; color:var(--yl-ink-soft);">
+                        <div class="mb-1"><i class="bi bi-clock me-1 text-muted"></i>{{ r.hours }}</div>
+                        <div><i class="bi bi-geo-alt me-1 text-muted"></i>{{ r.address }}</div>
+                    </div>
+
+                    <div class="d-flex gap-2 mt-3">
+                        <a href="#" class="btn btn-sm btn-outline-primary flex-grow-1"><i class="bi bi-map me-1"></i>查看路线</a>
+                        <a href="#" class="btn btn-sm btn-outline-secondary"><i class="bi bi-share"></i></a>
+                    </div>
                 </div>
             </div>
         </div>
-    {% endif %}
+        {% endfor %}
+    </div>
+
+    <section class="alert alert-primary mt-4 yl-fade-up">
+        <i class="bi bi-info-circle me-1"></i>
+        高温天(35°C 以上)建议带老人上午 10 点前或傍晚 6 点后出门,并随身带水和遮阳伞。
+    </section>
 </div>
-{% endblock %}
-
-{% block extra_js %}
-{% if has_map %}
-    {% if amap_security_js_code %}
-    <script type="text/javascript">
-        window._AMapSecurityConfig = {
-            securityJsCode: {{ amap_security_js_code|tojson }}
-        };
-    </script>
-    {% endif %}
-    <script src="https://webapi.amap.com/maps?v=2.0&key={{ amap_key|urlencode }}&plugin=AMap.Scale,AMap.ToolBar"></script>
-{% endif %}
-<script>
-document.addEventListener('DOMContentLoaded', function () {
-    const buttons = document.querySelectorAll('#viewToggle button[data-target]');
-    buttons.forEach(btn => {
-        btn.addEventListener('click', () => {
-            buttons.forEach(item => item.classList.remove('active'));
-            btn.classList.add('active');
-            const target = btn.getAttribute('data-target');
-            const listView = document.getElementById('listView');
-            const mapView = document.getElementById('mapView');
-            if (target === 'mapView') {
-                if (listView) listView.classList.add('d-none');
-                if (mapView) mapView.classList.remove('d-none');
-            } else {
-                if (mapView) mapView.classList.add('d-none');
-                if (listView) listView.classList.remove('d-none');
-            }
-        });
-    });
-
-    {% if has_map %}
-    const mapData = {{ map_points|tojson|safe }};
-    if (mapData.length) {
-        const center = [mapData[0].lng, mapData[0].lat];
-        const map = new AMap.Map('coolingMap', {
-            zoom: 13,
-            center: center,
-            mapStyle: 'amap://styles/normal',
-            viewMode: '2D'
-        });
-        AMap.plugin(['AMap.Scale', 'AMap.ToolBar'], function() {
-            map.addControl(new AMap.Scale());
-            map.addControl(new AMap.ToolBar());
-        });
-        mapData.forEach(item => {
-            const marker = new AMap.Marker({
-                position: [item.lng, item.lat],
-                title: item.name
-            });
-            const details = [];
-            if (item.community) details.push(`社区：${item.community}`);
-            if (item.type) details.push(`类型：${item.type}`);
-            if (item.open_hours) details.push(`开放时间：${item.open_hours}`);
-            if (item.address) details.push(`位置提示：${item.address}`);
-            if (item.has_ac) details.push('空调：有');
-            if (item.is_accessible) details.push('无障碍：支持');
-            const infoWindow = new AMap.InfoWindow({
-                content: `<div class="small"><strong>${item.name}</strong><br>${details.join('<br>')}</div>`,
-                offset: new AMap.Pixel(0, -28)
-            });
-            marker.on('click', () => {
-                infoWindow.open(map, marker.getPosition());
-            });
-            map.add(marker);
-        });
-    }
-    {% endif %}
-});
-</script>
 {% endblock %}

--- a/templates/family_members.html
+++ b/templates/family_members.html
@@ -1,559 +1,135 @@
 {% extends "base.html" %}
-{% set needs_chartjs = true %}
 
-{% block title %}家庭成员管理 - 天气健康风险预测系统{% endblock %}
+{% block title %}照护工作台 · 宜老天气通{% endblock %}
+{% block body_class %}family-members-page{% endblock %}
 
 {% block content %}
-<div class="container">
-    <div class="row mb-4 align-items-center">
-        <div class="col-lg-7">
-            <h2><i class="bi bi-people"></i> 家庭成员管理</h2>
-            <p class="text-muted">完善家庭成员健康档案，联动天气预警与用药提醒</p>
+<div class="container" style="max-width: 1200px;">
+
+    <div class="section-heading d-flex justify-content-between align-items-start flex-wrap gap-3 yl-fade-up">
+        <div>
+            <span class="section-kicker"><i class="bi bi-people"></i> 照护工作台</span>
+            <h2>你正在关注的家人</h2>
+            <p>添加老人、设置所在地,风险变化时第一时间收到提醒。</p>
         </div>
-        <div class="col-lg-5 text-lg-end">
-            <div class="d-flex align-items-center justify-content-lg-end gap-3">
-                <div class="form-check form-switch">
-                    <input class="form-check-input" type="checkbox" id="elderModeSwitch">
-                    <label class="form-check-label" for="elderModeSwitch">适老模式</label>
-                </div>
-                <a href="{{ url_for('health.health_diary') }}" class="btn btn-outline-secondary btn-sm">
-                    <i class="bi bi-journal"></i> 健康日记
-                </a>
-                <a href="{{ url_for('analysis.annual_report') }}" class="btn btn-outline-primary btn-sm">
-                    <i class="bi bi-journal-text"></i> 年度报告
-                </a>
+        <a href="{{ url_for('health.family_member_edit', member_id=0) }}" class="btn btn-primary">
+            <i class="bi bi-plus-lg me-1"></i>添加家人
+        </a>
+    </div>
+
+    {# 概览 #}
+    <div class="row g-3 mb-4 yl-fade-up yl-fade-up-d1">
+        <div class="col-6 col-md-3">
+            <div class="yl-stat-card">
+                <div class="k">总人数</div>
+                <div class="v">{{ (family_members or [])|length }}</div>
+                <div class="sub">位家人</div>
+            </div>
+        </div>
+        <div class="col-6 col-md-3">
+            <div class="yl-stat-card accent">
+                <div class="k">高风险</div>
+                <div class="v" style="color:var(--yl-danger);">{{ high_risk_count or 0 }}</div>
+                <div class="sub">今日需重点关注</div>
+            </div>
+        </div>
+        <div class="col-6 col-md-3">
+            <div class="yl-stat-card">
+                <div class="k">已通知</div>
+                <div class="v" style="color:var(--yl-success);">{{ notified_count or 0 }}</div>
+                <div class="sub">本周累计</div>
+            </div>
+        </div>
+        <div class="col-6 col-md-3">
+            <div class="yl-stat-card">
+                <div class="k">反馈率</div>
+                <div class="v">{{ feedback_rate or 0 }}%</div>
+                <div class="sub">行动已执行</div>
             </div>
         </div>
     </div>
 
-    <div class="row g-3 mb-4">
-        <div class="col-md-3">
-            <div class="card shadow-sm h-100">
-                <div class="card-body">
-                    <div class="text-muted">家庭成员</div>
-                    <div class="display-6">{{ total_members }}</div>
-                    <div class="text-muted small">慢病成员 {{ chronic_count }} 人</div>
-                </div>
+    {# 筛选 #}
+    <div class="yl-section mb-4 yl-fade-up yl-fade-up-d1">
+        <form method="GET" class="row g-2 align-items-end">
+            <div class="col-md-4">
+                <label class="form-label">搜索姓名</label>
+                <input type="text" class="form-control" name="q" value="{{ request.args.get('q', '') }}" placeholder="家人名字…">
             </div>
-        </div>
-        <div class="col-md-3">
-            <div class="card shadow-sm h-100">
-                <div class="card-body">
-                    <div class="text-muted">预警触发</div>
-                    <div class="display-6">{{ alert_trigger_count }}</div>
-                    <div class="text-muted small">基于今日天气阈值</div>
-                </div>
+            <div class="col-md-3">
+                <label class="form-label">风险等级</label>
+                <select name="risk" class="form-select">
+                    <option value="">全部</option>
+                    <option value="high" {% if request.args.get('risk')=='high' %}selected{% endif %}>高风险</option>
+                    <option value="medium" {% if request.args.get('risk')=='medium' %}selected{% endif %}>中等</option>
+                    <option value="low" {% if request.args.get('risk')=='low' %}selected{% endif %}>低风险</option>
+                </select>
             </div>
-        </div>
-        <div class="col-md-3">
-            <div class="card shadow-sm h-100">
-                <div class="card-body">
-                    <div class="text-muted">档案完善度</div>
-                    <div class="display-6">{{ avg_completion }}%</div>
-                    <div class="text-muted small">家庭整体平均</div>
-                </div>
+            <div class="col-md-3">
+                <label class="form-label">所在地</label>
+                <input type="text" class="form-control" name="location" value="{{ request.args.get('location', '') }}" placeholder="城市 / 社区">
             </div>
-        </div>
-        <div class="col-md-3">
-            <div class="card shadow-sm h-100">
-                <div class="card-body">
-                    <div class="text-muted">今日天气</div>
-                    <div class="display-6">{{ today_weather.temperature|round(1) }}°C</div>
-                    <div class="text-muted small">湿度 {{ today_weather.humidity|round(0) }}% · AQI {{ today_weather.aqi or '--' }}</div>
-                </div>
+            <div class="col-md-2 d-grid">
+                <button class="btn btn-outline-primary" type="submit"><i class="bi bi-search me-1"></i>筛选</button>
             </div>
-        </div>
+        </form>
     </div>
 
-    <div class="row g-3 mb-4">
-        <div class="col-lg-8">
-            <div class="card shadow-sm h-100">
-                <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-center mb-3">
-                        <h6 class="mb-0">成员检索</h6>
-                        <small class="text-muted">支持姓名/关系筛选</small>
-                    </div>
-                    <form method="GET" action="{{ url_for('health.family_members') }}" class="row g-2">
-                        <div class="col-md-6">
-                            <input type="text" class="form-control" name="q" placeholder="输入姓名或关系" value="{{ search_query }}">
+    {# 家人卡片 #}
+    {% if family_members %}
+        <div class="row g-3 yl-fade-up yl-fade-up-d2">
+            {% for m in family_members %}
+            <div class="col-md-6 col-xl-4">
+                <div class="card member-card risk-{{ m.risk_level or 'low' }} h-100">
+                    <div class="card-body">
+                        <div class="d-flex align-items-center gap-3 mb-3">
+                            <div class="member-avatar">{{ m.name[:1] }}</div>
+                            <div class="flex-grow-1 min-w-0">
+                                <h5 class="mb-0 text-truncate">{{ m.name }}</h5>
+                                <div class="text-muted" style="font-size:.85rem;">
+                                    {{ m.age }}岁 · {{ m.gender or '—' }} · 与我的关系:{{ m.relation or '—' }}
+                                </div>
+                            </div>
+                            <span class="risk-badge risk-{{ m.risk_level or 'low' }} badge">{{ m.risk_label or '低风险' }}</span>
                         </div>
-                        <div class="col-md-4">
-                            <select class="form-select" name="risk_level">
-                                <option value="">风险等级（全部）</option>
-                                <option value="low" {% if risk_filter == 'low' %}selected{% endif %}>低风险</option>
-                                <option value="medium" {% if risk_filter == 'medium' %}selected{% endif %}>中风险</option>
-                                <option value="high" {% if risk_filter == 'high' %}selected{% endif %}>高风险</option>
-                            </select>
+
+                        <div class="d-flex flex-wrap gap-2 mb-3" style="font-size:.85rem;">
+                            <span class="badge bg-light"><i class="bi bi-geo-alt me-1"></i>{{ m.location or '未设定' }}</span>
+                            {% if m.chronic %}
+                                {% for c in m.chronic %}
+                                    <span class="badge bg-info-subtle">{{ c }}</span>
+                                {% endfor %}
+                            {% endif %}
                         </div>
-                        <div class="col-md-2">
-                            <button class="btn btn-outline-primary w-100">筛选</button>
+
+                        {% if m.today_tip %}
+                        <div class="p-2 mb-3" style="background:var(--yl-orange-50); border-radius:10px; font-size:.85rem;">
+                            <i class="bi bi-lightbulb text-warning me-1"></i>{{ m.today_tip }}
                         </div>
-                    </form>
-                    <div class="mt-3">
-                        <div class="text-muted small">家庭关系概览：</div>
-                        <div class="d-flex flex-wrap gap-2 mt-2">
-                            {% for label, count in relation_counts.items() %}
-                                <span class="badge bg-light text-dark border">{{ label }} {{ count }}</span>
-                            {% endfor %}
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="col-lg-4">
-            <div class="card shadow-sm h-100">
-                <div class="card-body">
-                    <h6 class="mb-3">风险分布</h6>
-                    <canvas id="riskChart" height="180"></canvas>
-                </div>
-            </div>
-        </div>
-    </div>
+                        {% endif %}
 
-    <div class="row">
-        <div class="col-lg-5 mb-4">
-            <div class="card shadow-sm">
-                <div class="card-header bg-primary text-white d-flex align-items-center justify-content-between">
-                    <h5 class="mb-0">添加成员</h5>
-                    <button class="btn btn-light btn-sm" id="copySelfBtn" type="button">复制本人信息</button>
-                </div>
-                <div class="card-body">
-                    <form method="POST" action="{{ url_for('health.family_members') }}">
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <div class="accordion" id="memberFormAccordion">
-                            <div class="accordion-item">
-                                <h2 class="accordion-header" id="headingBasic">
-                                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseBasic">
-                                        基础信息
-                                    </button>
-                                </h2>
-                                <div id="collapseBasic" class="accordion-collapse collapse show" data-bs-parent="#memberFormAccordion">
-                                    <div class="accordion-body">
-                                        <div class="mb-3">
-                                            <label class="form-label">姓名</label>
-                                            <input type="text" class="form-control" name="name" id="memberName" required>
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">关系</label>
-                                            <input type="text" class="form-control" name="relation" id="memberRelation" placeholder="如：父亲/母亲/配偶/子女">
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">年龄</label>
-                                                <input type="number" class="form-control" name="age" id="memberAge" min="0" max="120">
-                                            </div>
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">性别</label>
-                                                <select class="form-select" name="gender" id="memberGender">
-                                                    <option value="">请选择</option>
-                                                    <option value="男性">男性</option>
-                                                    <option value="女性">女性</option>
-                                                </select>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="accordion-item">
-                                <h2 class="accordion-header" id="headingHealth">
-                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseHealth">
-                                        健康信息
-                                    </button>
-                                </h2>
-                                <div id="collapseHealth" class="accordion-collapse collapse" data-bs-parent="#memberFormAccordion">
-                                    <div class="accordion-body">
-                                        <div class="mb-3">
-                                            <label class="form-label">慢性病</label>
-                                            <div class="d-flex flex-wrap gap-2">
-                                                {% for item in chronic_options %}
-                                                    <div class="form-check">
-                                                        <input class="form-check-input" type="checkbox" name="chronic_diseases" value="{{ item }}" id="cd_{{ loop.index }}">
-                                                        <label class="form-check-label" for="cd_{{ loop.index }}">{{ item }}</label>
-                                                    </div>
-                                                {% endfor %}
-                                            </div>
-                                            <input type="text" class="form-control mt-2" name="chronic_disease_other" placeholder="其他慢性病（可选）">
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">过敏史</label>
-                                            <input type="text" class="form-control" name="allergies" placeholder="如：青霉素、花粉">
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">常用药</label>
-                                            <input type="text" class="form-control" name="medications" placeholder="如：降压药、胰岛素">
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">风险标签</label>
-                                            <div class="d-flex flex-wrap gap-2">
-                                                {% for item in risk_tag_options %}
-                                                    <div class="form-check">
-                                                        <input class="form-check-input" type="checkbox" name="risk_tags" value="{{ item }}" id="rt_{{ loop.index }}">
-                                                        <label class="form-check-label" for="rt_{{ loop.index }}">{{ item }}</label>
-                                                    </div>
-                                                {% endfor %}
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="accordion-item">
-                                <h2 class="accordion-header" id="headingMetrics">
-                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMetrics">
-                                        体征指标
-                                    </button>
-                                </h2>
-                                <div id="collapseMetrics" class="accordion-collapse collapse" data-bs-parent="#memberFormAccordion">
-                                    <div class="accordion-body">
-                                        <div class="row">
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">收缩压</label>
-                                                <input type="number" class="form-control" name="bp_sys" placeholder="如：120">
-                                            </div>
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">舒张压</label>
-                                                <input type="number" class="form-control" name="bp_dia" placeholder="如：80">
-                                            </div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">血糖(mmol/L)</label>
-                                                <input type="number" step="0.1" class="form-control" name="blood_sugar" placeholder="如：5.6">
-                                            </div>
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">心率(次/分)</label>
-                                                <input type="number" class="form-control" name="heart_rate" placeholder="如：72">
-                                            </div>
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">体重(kg)</label>
-                                            <input type="number" step="0.1" class="form-control" name="weight" placeholder="如：65">
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="accordion-item">
-                                <h2 class="accordion-header" id="headingWeather">
-                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseWeather">
-                                        天气敏感阈值与通知
-                                    </button>
-                                </h2>
-                                <div id="collapseWeather" class="accordion-collapse collapse" data-bs-parent="#memberFormAccordion">
-                                    <div class="accordion-body">
-                                        <div class="row">
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">高温触发(°C)</label>
-                                                <input type="number" class="form-control" name="threshold_high_temp" placeholder="如：33">
-                                            </div>
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">低温触发(°C)</label>
-                                                <input type="number" class="form-control" name="threshold_low_temp" placeholder="如：5">
-                                            </div>
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">湿度触发(%)</label>
-                                                <input type="number" class="form-control" name="threshold_high_humidity" placeholder="如：80">
-                                            </div>
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">AQI触发</label>
-                                                <input type="number" class="form-control" name="threshold_high_aqi" placeholder="如：120">
-                                            </div>
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">通知渠道</label>
-                                            <div class="d-flex flex-wrap gap-2">
-                                                <div class="form-check">
-                                                    <input class="form-check-input" type="checkbox" name="notify_channels" value="站内通知" id="notify_site" checked>
-                                                    <label class="form-check-label" for="notify_site">站内通知</label>
-                                                </div>
-                                                <div class="form-check">
-                                                    <input class="form-check-input" type="checkbox" name="notify_channels" value="邮件" id="notify_email">
-                                                    <label class="form-check-label" for="notify_email">邮件</label>
-                                                </div>
-                                                <div class="form-check">
-                                                    <input class="form-check-input" type="checkbox" name="notify_channels" value="短信" id="notify_sms">
-                                                    <label class="form-check-label" for="notify_sms">短信</label>
-                                                </div>
-                                                <div class="form-check">
-                                                    <input class="form-check-input" type="checkbox" name="notify_channels" value="微信" id="notify_wechat">
-                                                    <label class="form-check-label" for="notify_wechat">微信</label>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">通知频率</label>
-                                                <select class="form-select" name="notify_frequency">
-                                                    <option value="重要提醒">重要提醒</option>
-                                                    <option value="每日">每日</option>
-                                                    <option value="每周">每周</option>
-                                                </select>
-                                            </div>
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">静默时段</label>
-                                                <input type="text" class="form-control" name="quiet_hours" placeholder="22:00-07:00">
-                                            </div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">高风险连续N天升级</label>
-                                                <input type="number" class="form-control" name="escalation_days" placeholder="如：3" min="1" max="30">
-                                            </div>
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">同步通知家属</label>
-                                                <div class="form-check form-switch">
-                                                    <input class="form-check-input" type="checkbox" name="notify_family" id="notify_family" checked>
-                                                    <label class="form-check-label" for="notify_family">开启</label>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="form-check form-switch">
-                                            <input class="form-check-input" type="checkbox" name="alert_enabled" id="alert_enabled" checked>
-                                            <label class="form-check-label" for="alert_enabled">启用成员预警</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="accordion-item">
-                                <h2 class="accordion-header" id="headingPrivacy">
-                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapsePrivacy">
-                                        隐私与共享
-                                    </button>
-                                </h2>
-                                <div id="collapsePrivacy" class="accordion-collapse collapse" data-bs-parent="#memberFormAccordion">
-                                    <div class="accordion-body">
-                                        <div class="mb-3">
-                                            <label class="form-label">隐私级别</label>
-                                            <select class="form-select" name="privacy_level">
-                                                <option value="family">家庭可见</option>
-                                                <option value="private">仅本人可见</option>
-                                                <option value="doctor">授权医生可见</option>
-                                                <option value="community">社区管理员可见</option>
-                                            </select>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">联系人电话</label>
-                                                <input type="text" class="form-control" name="contact_phone" placeholder="可选">
-                                            </div>
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">微信号</label>
-                                                <input type="text" class="form-control" name="contact_wechat" placeholder="可选">
-                                            </div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">紧急联系人</label>
-                                                <input type="text" class="form-control" name="emergency_name" placeholder="可选">
-                                            </div>
-                                            <div class="col-6 mb-3">
-                                                <label class="form-label">紧急电话</label>
-                                                <input type="text" class="form-control" name="emergency_phone" placeholder="可选">
-                                            </div>
-                                        </div>
-                                        <div class="d-flex flex-wrap gap-3">
-                                            <div class="form-check">
-                                                <input class="form-check-input" type="checkbox" name="share_with_doctor" id="share_doctor">
-                                                <label class="form-check-label" for="share_doctor">授权医生查看</label>
-                                            </div>
-                                            <div class="form-check">
-                                                <input class="form-check-input" type="checkbox" name="share_with_community" id="share_community">
-                                                <label class="form-check-label" for="share_community">授权社区查看</label>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <button class="btn btn-primary w-100 mt-3">添加成员</button>
-                    </form>
-                </div>
-            </div>
-        </div>
-
-        <div class="col-lg-7">
-            <div class="d-flex justify-content-between align-items-center mb-3">
-                <h5 class="mb-0">成员列表</h5>
-                <span class="text-muted small">共 {{ members|length }} 人</span>
-            </div>
-            <div class="row g-3">
-                {% for member in members %}
-                <div class="col-12">
-                    <div class="card shadow-sm member-card risk-{{ member.risk.level }}">
-                        <div class="card-body">
-                            <div class="d-flex align-items-start justify-content-between">
-                                <div class="d-flex align-items-center gap-3">
-                                    <div class="member-avatar">{{ member.name[:1] }}</div>
-                                    <div>
-                                        <h5 class="mb-1">{{ member.name }}</h5>
-                                        <div class="text-muted small">
-                                            {{ member.relation or '关系未填' }} · {{ member.age or '-' }}岁 · {{ member.gender or '-' }}
-                                        </div>
-                                    </div>
-                                </div>
-                                <span class="badge risk-badge risk-{{ member.risk.level }}">{{ member.risk.label }}</span>
-                            </div>
-
-                            <div class="mt-3">
-                                <div class="d-flex align-items-center justify-content-between">
-                                    <span class="text-muted small">档案完善度</span>
-                                    <span class="text-muted small">{{ member.completion.percent }}%</span>
-                                </div>
-                                <div class="progress profile-progress">
-                                    <div class="progress-bar" role="progressbar" style="width: {{ member.completion.percent }}%"></div>
-                                </div>
-                            </div>
-
-                            <div class="mt-3">
-                                <div class="text-muted small mb-1">慢病标签</div>
-                                <div class="d-flex flex-wrap gap-2">
-                                    {% if member.chronic_diseases %}
-                                        {% for disease in member.chronic_diseases %}
-                                            <span class="badge bg-light text-dark border">{{ disease }}</span>
-                                        {% endfor %}
-                                    {% else %}
-                                        <span class="text-muted small">暂无记录</span>
-                                    {% endif %}
-                                </div>
-                            </div>
-
-                            <div class="mt-3">
-                                <div class="text-muted small mb-1">风险标签</div>
-                                <div class="d-flex flex-wrap gap-2">
-                                    {% if member.profile.risk_tags %}
-                                        {% for tag in member.profile.risk_tags %}
-                                            <span class="badge bg-warning-subtle text-dark border">{{ tag }}</span>
-                                        {% endfor %}
-                                    {% else %}
-                                        <span class="text-muted small">未设置</span>
-                                    {% endif %}
-                                </div>
-                            </div>
-
-                            <div class="mt-3">
-                                {% if member.alerts %}
-                                    <span class="badge bg-danger">今日触发：{{ member.alerts|join('、') }}</span>
-                                {% else %}
-                                    <span class="badge bg-success-subtle text-success border">今日未触发</span>
-                                {% endif %}
-                                {% if not member.profile.weather_thresholds %}
-                                    <span class="badge bg-secondary-subtle text-muted border">未设置阈值</span>
-                                {% endif %}
-                            </div>
-
-                            <div class="row mt-3 small text-muted">
-                                <div class="col-md-6">
-                                    最近日记：
-                                    {% if member.last_diary %}
-                                        {{ member.last_diary.entry_date }} / {{ member.last_diary.severity or '未填写' }}
-                                    {% else %}
-                                        暂无
-                                    {% endif %}
-                                </div>
-                                <div class="col-md-6">
-                                    最近提醒：
-                                    {% if member.last_reminder %}
-                                        {{ member.last_reminder.medicine_name }}
-                                    {% else %}
-                                        暂无
-                                    {% endif %}
-                                </div>
-                            </div>
-
-                            <div class="d-flex flex-wrap gap-2 mt-3">
-                                <a class="btn btn-sm btn-outline-primary" href="{{ url_for('health.family_member_detail', member_id=member.id) }}">查看详情</a>
-                                <a class="btn btn-sm btn-outline-warning" href="{{ url_for('health.family_member_edit', member_id=member.id) }}">编辑</a>
-                                <form method="POST" action="{{ url_for('health.family_member_toggle_alert', member_id=member.id) }}" style="display:inline;">
-                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                    <button class="btn btn-sm {% if member.profile.alert_enabled %}btn-outline-success{% else %}btn-outline-secondary{% endif %}">
-                                        {% if member.profile.alert_enabled %}预警启用{% else %}预警已停{% endif %}
-                                    </button>
-                                </form>
-                                <form method="POST" action="{{ url_for('health.family_member_delete', member_id=member.id) }}" style="display:inline;">
-                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                    <button class="btn btn-sm btn-outline-danger js-confirm-delete-member" type="submit">删除</button>
-                                </form>
-                            </div>
+                        <div class="d-flex gap-2">
+                            <a href="{{ url_for('health.family_member_detail', member_id=m.id) }}" class="btn btn-sm btn-outline-primary flex-grow-1">
+                                <i class="bi bi-eye me-1"></i>查看
+                            </a>
+                            <a href="{{ url_for('health.family_member_edit', member_id=m.id) }}" class="btn btn-sm btn-outline-secondary">
+                                <i class="bi bi-pencil"></i>
+                            </a>
                         </div>
                     </div>
                 </div>
-                {% endfor %}
             </div>
-            {% if members|length == 0 %}
-                <p class="text-muted mb-0">暂无成员，请先添加</p>
-            {% endif %}
+            {% endfor %}
         </div>
-    </div>
+    {% else %}
+        <div class="yl-section text-center yl-fade-up yl-fade-up-d2" style="padding:60px 30px;">
+            <div style="font-size:3rem; color:var(--yl-orange-400);"><i class="bi bi-people"></i></div>
+            <h4 class="mt-3">还没有添加家人</h4>
+            <p class="text-muted">添加要关注的老人,我们会在风险变化时提醒你。</p>
+            <a href="{{ url_for('health.family_member_edit', member_id=0) }}" class="btn btn-primary mt-2">
+                <i class="bi bi-plus-lg me-1"></i>添加第一位家人
+            </a>
+        </div>
+    {% endif %}
 </div>
-
-{% block extra_js %}
-<script>
-const riskLabels = {{ risk_chart_labels|tojson }};
-const riskValues = {{ risk_chart_values|tojson }};
-const riskCtx = document.getElementById('riskChart');
-if (riskCtx) {
-    new Chart(riskCtx.getContext('2d'), {
-        type: 'doughnut',
-        data: {
-            labels: riskLabels,
-            datasets: [{
-                data: riskValues,
-                backgroundColor: ['rgba(34,197,94,0.7)', 'rgba(250,204,21,0.7)', 'rgba(239,68,68,0.7)'],
-                borderWidth: 0
-            }]
-        },
-        options: {
-            responsive: true,
-            plugins: {
-                legend: { position: 'bottom' }
-            }
-        }
-    });
-}
-
-const elderSwitch = document.getElementById('elderModeSwitch');
-if (elderSwitch) {
-    elderSwitch.checked = localStorage.getItem('elderMode') === '1';
-    elderSwitch.addEventListener('change', function() {
-        if (this.checked) {
-            localStorage.setItem('elderMode', '1');
-            document.body.classList.add('elder-mode');
-        } else {
-            localStorage.removeItem('elderMode');
-            document.body.classList.remove('elder-mode');
-        }
-    });
-}
-
-const copyBtn = document.getElementById('copySelfBtn');
-if (copyBtn) {
-    copyBtn.addEventListener('click', function() {
-        const ageInput = document.getElementById('memberAge');
-        const genderSelect = document.getElementById('memberGender');
-        const relationInput = document.getElementById('memberRelation');
-        if (ageInput) ageInput.value = '{{ current_user.age or '' }}';
-        if (genderSelect) genderSelect.value = '{{ current_user.gender or '' }}';
-        if (relationInput && !relationInput.value) relationInput.value = '本人';
-
-        const chronicList = {{ (current_user.chronic_diseases|from_json)|tojson }};
-        chronicList.forEach(item => {
-            const checkbox = document.querySelector(`input[name="chronic_diseases"][value="${item}"]`);
-            if (checkbox) {
-                checkbox.checked = true;
-            }
-        });
-    });
-}
-
-document.querySelectorAll('.js-confirm-delete-member').forEach(button => {
-    button.addEventListener('click', function(event) {
-        if (!confirm('确定删除该成员？')) {
-            event.preventDefault();
-        }
-    });
-});
-</script>
-{% endblock %}
 {% endblock %}

--- a/templates/forecast_7day.html
+++ b/templates/forecast_7day.html
@@ -1,71 +1,58 @@
 {% extends "base.html" %}
-
-{% block title %}7天健康预测 - 天气健康风险预测系统{% endblock %}
+{% block title %}7 天健康预测 · 宜老天气通{% endblock %}
 
 {% block content %}
-<div class="container-fluid py-4">
-    <div class="row mb-4">
-        <div class="col-12">
-            <div class="d-flex justify-content-between align-items-center">
-                <div>
-                    <h2><i class="bi bi-calendar-week me-2"></i>未来7天健康预测</h2>
-                    <p class="text-muted mb-0">基于DLNM风险函数，预测未来7天门诊需求与健康风险</p>
-                </div>
-                <div class="d-flex flex-wrap gap-2 justify-content-end">
-                    <div class="btn-group" role="group" aria-label="scenario">
-                        <button class="btn btn-outline-secondary active" id="scenarioBaselineBtn" type="button">
-                            基线情景
-                        </button>
-                        <button class="btn btn-outline-danger" id="scenarioWorstBtn" type="button">
-                            最坏情景
-                        </button>
-                    </div>
-                    <button class="btn btn-primary" id="refreshForecast" type="button">
-                        <i class="bi bi-arrow-clockwise me-1"></i>刷新预测
-                    </button>
-                </div>
-            </div>
-            <div class="text-muted small mt-2">当前视图：<span id="scenarioModeLabel">基线情景（P50）</span></div>
-        </div>
-    </div>
+<div class="container" style="max-width:1160px;">
+    <section class="section-heading yl-fade-up">
+        <span class="section-kicker"><i class="bi bi-calendar-week"></i> 7 天健康预测</span>
+        <h2>接下来一周,哪几天要特别留心?</h2>
+        <p>风险评分综合高温、气压、湿度、空气质量,并结合你的慢病背景。</p>
+    </section>
 
-    <!-- 预警摘要 -->
-    <div class="row mb-4">
-        <div class="col-12">
-            <div class="card shadow-sm" id="alertCard">
-                <div class="card-body">
-                    <div class="row align-items-center">
-                        <div class="col-md-2 text-center">
-                            <div id="alertLevel" class="display-6 fw-bold">
-                                <i class="bi bi-hourglass-split"></i>
-                            </div>
-                        </div>
-                        <div class="col-md-10">
-                            <h5 id="alertTitle">正在加载预测数据...</h5>
-                            <p id="alertDesc" class="mb-0 text-muted">请稍候</p>
-                        </div>
-                    </div>
-                </div>
+    <form method="GET" class="yl-section mb-4 yl-fade-up yl-fade-up-d1">
+        <div class="row g-3 align-items-end">
+            <div class="col-md-5">
+                <label class="form-label">所在地</label>
+                <input type="text" class="form-control" name="location" value="{{ request.args.get('location', current_location) }}" list="locOpts">
+                <datalist id="locOpts">{% for loc in (location_options or []) %}<option value="{{ loc }}"></option>{% endfor %}</datalist>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">关注家人</label>
+                <select name="member_id" class="form-select">
+                    <option value="">我本人</option>
+                    {% for m in (family_members or []) %}
+                        <option value="{{ m.id }}" {% if request.args.get('member_id')|int == m.id %}selected{% endif %}>{{ m.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-3 d-grid">
+                <button class="btn btn-primary" type="submit"><i class="bi bi-graph-up me-1"></i>生成预测</button>
             </div>
         </div>
-    </div>
+    </form>
 
-    <!-- 7天预测卡片 -->
-    <div class="row mb-4" id="forecastCards">
-        {% for i in range(7) %}
-        <div class="col-md-3 col-lg mb-3">
-            <div class="card shadow-sm h-100 forecast-card" data-day="{{ i }}">
-                <div class="card-header text-center py-2">
-                    <small class="text-muted">加载中...</small>
-                    <div class="fw-bold">--</div>
-                </div>
-                <div class="card-body text-center py-3">
-                    <div class="display-6 mb-2">--°C</div>
-                    <div class="mb-2">
-                        <span class="badge bg-secondary">--</span>
-                    </div>
-                    <div class="small text-muted">
-                        预计门诊(P50): -- 人次
+    {# 7 天横向卡 #}
+    <div class="row g-3 mb-4 yl-fade-up yl-fade-up-d2">
+        {% set default_days = [
+            {'dow':'今','date':'今天','temp_high':32,'temp_low':25,'condition':'多云','risk_level':'mid','risk_score':55,'risk_label':'中'},
+            {'dow':'明','date':'明天','temp_high':34,'temp_low':26,'condition':'晴','risk_level':'high','risk_score':72,'risk_label':'高'},
+            {'dow':'三','date':'周三','temp_high':30,'temp_low':24,'condition':'雷阵雨','risk_level':'mid','risk_score':48,'risk_label':'中'},
+            {'dow':'四','date':'周四','temp_high':29,'temp_low':23,'condition':'小雨','risk_level':'low','risk_score':32,'risk_label':'低'},
+            {'dow':'五','date':'周五','temp_high':31,'temp_low':24,'condition':'多云','risk_level':'low','risk_score':35,'risk_label':'低'},
+            {'dow':'六','date':'周六','temp_high':33,'temp_low':25,'condition':'晴','risk_level':'mid','risk_score':52,'risk_label':'中'},
+            {'dow':'日','date':'周日','temp_high':35,'temp_low':27,'condition':'晴','risk_level':'high','risk_score':78,'risk_label':'高'}
+        ] %}
+        {% for d in (forecast_days or default_days) %}
+        <div class="col">
+            <div class="card h-100 text-center" {% if d.risk_level == 'high' %}style="border:1px solid #F0C4B9; background:var(--yl-danger-50);"{% elif d.risk_level == 'mid' %}style="border:1px solid #F1DFB1; background:var(--yl-warn-50);"{% endif %}>
+                <div class="card-body p-3">
+                    <div class="text-muted" style="font-size:.82rem;">{{ d.date }}</div>
+                    <div class="fw-semibold mt-1">{{ d.dow }}</div>
+                    <div class="my-2" style="font-size:1.8rem; color:var(--yl-orange-500);"><i class="bi bi-cloud-sun"></i></div>
+                    <div style="font-size:1rem; font-weight:600;">{{ d.temp_high }}° / {{ d.temp_low }}°</div>
+                    <div class="text-muted" style="font-size:.78rem;">{{ d.condition }}</div>
+                    <div class="mt-2">
+                        <span class="badge {% if d.risk_level=='high' %}bg-danger-subtle{% elif d.risk_level=='mid' %}bg-warning-subtle{% else %}bg-success-subtle{% endif %}">风险 {{ d.risk_score }}</span>
                     </div>
                 </div>
             </div>
@@ -73,936 +60,74 @@
         {% endfor %}
     </div>
 
-    <div class="row">
-        <!-- 详细预测表 -->
-        <div class="col-lg-8 mb-4">
-            <div class="card shadow-sm">
-                <div class="card-header bg-primary text-white">
-                    <h5 class="mb-0"><i class="bi bi-table me-2"></i>详细预测数据</h5>
-                </div>
-                <div class="card-body p-0">
-                    <div class="table-responsive">
-                        <table class="table table-hover mb-0">
-                            <thead class="table-light">
-                                <tr>
-                                    <th>日期</th>
-                                    <th>温度</th>
-                                    <th>预计门诊</th>
-                                    <th>P10/P50/P90</th>
-                                    <th>预测区间</th>
-                                    <th>超阈值概率(P90/P75)</th>
-                                    <th>复合暴露</th>
-                                    <th>风险等级</th>
-                                    <th>可预报性</th>
-                                    <th>置信度</th>
-                                </tr>
-                            </thead>
-                            <tbody id="forecastTable">
-                                <tr>
-                                    <td colspan="10" class="text-center py-4">
-                                        <div class="spinner-border spinner-border-sm text-primary me-2"></div>
-                                        加载中...
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>
+    <div class="row g-4 mb-4">
+        <div class="col-lg-8">
+            <section class="yl-section yl-fade-up yl-fade-up-d3">
+                <h4 style="font-size:1.1rem;">风险走势</h4>
+                <canvas id="forecastChart" height="260" class="mt-3"></canvas>
+            </section>
         </div>
-
-        <!-- 建议与极端天气 -->
-        <div class="col-lg-4 mb-4">
-            <!-- 管理建议 -->
-            <div class="card shadow-sm mb-4">
-                <div class="card-header bg-success text-white">
-                    <h5 class="mb-0"><i class="bi bi-lightbulb me-2"></i>管理建议</h5>
-                </div>
-                <div class="card-body" id="recommendationsDiv">
-                    <div class="text-center py-3 text-muted">
-                        <i class="bi bi-hourglass-split"></i> 加载中...
-                    </div>
-                </div>
-            </div>
-
-            <!-- 极端天气预警 -->
-            <div class="card shadow-sm">
-                <div class="card-header bg-warning">
-                    <h5 class="mb-0"><i class="bi bi-exclamation-triangle me-2"></i>极端天气预警</h5>
-                </div>
-                <div class="card-body" id="extremeEventsDiv">
-                    <div class="text-center py-3 text-muted">
-                        <i class="bi bi-hourglass-split"></i> 加载中...
-                    </div>
-                </div>
-            </div>
-
-            <!-- 未来6小时短临时间轴 -->
-            <div class="card shadow-sm mt-4">
-                <div class="card-header bg-info text-white">
-                    <h5 class="mb-0"><i class="bi bi-clock-history me-2"></i>未来6小时降水时间轴</h5>
-                </div>
-                <div class="card-body" id="nowcastDiv">
-                    <div class="text-center py-3 text-muted">
-                        <i class="bi bi-hourglass-split"></i> 加载中...
-                    </div>
-                </div>
-            </div>
+        <div class="col-lg-4">
+            <section class="yl-section h-100 yl-fade-up yl-fade-up-d3">
+                <h4 style="font-size:1.1rem;">本周高风险日</h4>
+                <p class="text-muted" style="font-size:.9rem;">以下日期风险评分 ≥ 70,建议重点准备。</p>
+                <ul class="list-unstyled mt-3 mb-0">
+                    {% for d in (forecast_days or default_days) %}
+                        {% if (d.risk_score or 0) >= 70 %}
+                        <li class="d-flex justify-content-between py-2 border-bottom">
+                            <span><strong>{{ d.date }}</strong> · {{ d.condition }}</span>
+                            <span class="badge bg-danger-subtle">{{ d.risk_score }}</span>
+                        </li>
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </section>
         </div>
     </div>
 
-    <!-- DLNM模型信息 -->
-    <div class="row">
-        <div class="col-12">
-            <div class="card shadow-sm">
-                <div class="card-header">
-                    <h5 class="mb-0"><i class="bi bi-graph-up me-2"></i>DLNM风险模型信息</h5>
-                </div>
-                <div class="card-body">
-                    <div class="row" id="modelInfo">
-                        <div class="col-md-3 text-center mb-3">
-                            <div class="text-muted small">最低风险温度(MMT)</div>
-                            <div class="h4 fw-bold text-success" id="mmtValue">--°C</div>
-                        </div>
-                        <div class="col-md-3 text-center mb-3">
-                            <div class="text-muted small">高温预警阈值</div>
-                            <div class="h4 fw-bold text-danger" id="heatThreshold">--°C</div>
-                        </div>
-                        <div class="col-md-3 text-center mb-3">
-                            <div class="text-muted small">低温预警阈值</div>
-                            <div class="h4 fw-bold text-info" id="coldThreshold">--°C</div>
-                        </div>
-                        <div class="col-md-3 text-center mb-3">
-                            <div class="text-muted small">门诊量P90阈值</div>
-                            <div class="h4 fw-bold text-warning" id="visitThreshold">--人次</div>
-                        </div>
-                    </div>
+    {# 建议 #}
+    <section class="yl-section yl-fade-up">
+        <h4 style="font-size:1.1rem;"><i class="bi bi-lightbulb text-warning me-1"></i>本周建议</h4>
+        <div class="row g-3 mt-1">
+            {% for tip in (weekly_tips or [
+                {'icon':'sun','title':'避开午后外出','detail':'11:00–15:00 紫外线最强,尽量安排室内活动。'},
+                {'icon':'cup-hot','title':'补水 1.5L+','detail':'少量多次,别等口渴才喝。'},
+                {'icon':'heart-pulse','title':'早晚测血压','detail':'高温天血压波动大,发现异常及时就医。'},
+                {'icon':'capsule','title':'带好常用药','detail':'外出时别忘了慢病药和急救药。'}
+            ]) %}
+            <div class="col-md-6 col-lg-3">
+                <div class="yl-action h-100">
+                    <i class="bi bi-{{ tip.icon }}"></i>
+                    <div><strong>{{ tip.title }}</strong><div class="detail">{{ tip.detail }}</div></div>
                 </div>
             </div>
+            {% endfor %}
         </div>
-    </div>
-
-    <!-- 影响 × 可能性矩阵 -->
-    <div class="row mt-2">
-        <div class="col-12">
-            <div class="card shadow-sm">
-                <div class="card-header bg-light">
-                    <h5 class="mb-0"><i class="bi bi-grid-3x3 me-2"></i>影响 × 可能性矩阵</h5>
-                </div>
-                <div class="card-body">
-                    <p class="text-muted small mb-3">用于快速识别“高影响且高可能”的重点干预日期。</p>
-                    <div class="table-responsive">
-                        <table class="table table-sm align-middle mb-0">
-                            <thead>
-                                <tr>
-                                    <th>影响\可能性</th>
-                                    <th>低</th>
-                                    <th>中</th>
-                                    <th>高</th>
-                                </tr>
-                            </thead>
-                            <tbody id="impactMatrixBody">
-                                <tr><td colspan="4" class="text-muted">等待预测数据...</td></tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="row mt-3">
-        <div class="col-lg-6 mb-3">
-            <div class="card shadow-sm h-100">
-                <div class="card-header bg-light">
-                    <h5 class="mb-0"><i class="bi bi-person-check me-2"></i>角色行动卡</h5>
-                </div>
-                <div class="card-body" id="roleActionCards">
-                    <p class="text-muted mb-0">等待预测数据...</p>
-                </div>
-            </div>
-        </div>
-        <div class="col-lg-6 mb-3">
-            <div class="card shadow-sm h-100">
-                <div class="card-header bg-light">
-                    <h5 class="mb-0"><i class="bi bi-layers me-2"></i>复合暴露风险（热+PM2.5+湿度+热夜）</h5>
-                </div>
-                <div class="card-body" id="compositeExposureBoard">
-                    <p class="text-muted mb-0">等待预测数据...</p>
-                </div>
-            </div>
-        </div>
-    </div>
+    </section>
 </div>
 
-<style>
-.forecast-card {
-    transition: transform 0.2s, box-shadow 0.2s;
-}
-.forecast-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 0.5rem 1rem rgba(0,0,0,0.15) !important;
-}
-.forecast-card.risk-high {
-    border-left: 4px solid #dc3545;
-    border-color: #dc3545;
-}
-.forecast-card.risk-medium {
-    border-left: 4px solid #fd7e14;
-    border-color: #fd7e14;
-}
-.forecast-card.risk-yellow {
-    border-left: 4px solid #ffc107;
-    border-color: #ffc107;
-}
-.forecast-card.risk-low {
-    border-left: 4px solid #198754;
-    border-color: #198754;
-}
-.forecast-card.risk-blue {
-    border-left: 4px solid #0dcaf0;
-    border-color: #0dcaf0;
-}
-.bg-orange {
-    background-color: #fd7e14 !important;
-}
-</style>
-
 <script>
-function clearElement(element) {
-    while (element && element.firstChild) {
-        element.removeChild(element.firstChild);
-    }
-}
-
-function safeText(value, fallback) {
-    if (value === undefined || value === null) {
-        return fallback || '';
-    }
-    return String(value);
-}
-
-function toNumber(value, fallback) {
-    if (value === undefined || value === null || value === '') {
-        return fallback;
-    }
-    const num = Number(value);
-    if (!Number.isFinite(num)) {
-        return fallback;
-    }
-    return num;
-}
-
-function formatNumber(value, digits, fallbackText) {
-    const num = toNumber(value, null);
-    if (num === null) {
-        return fallbackText;
-    }
-    return num.toFixed(digits);
-}
-
-function setAlertLevel(element, className, iconClass, label) {
-    clearElement(element);
-    const span = document.createElement('span');
-    span.className = className;
-    const icon = document.createElement('i');
-    icon.className = iconClass;
-    span.appendChild(icon);
-    span.appendChild(document.createTextNode(' ' + label));
-    element.appendChild(span);
-}
-
-let currentScenarioMode = 'baseline';
-let latestForecastRows = [];
-let latestSummaryData = {};
-let nowcastTimelineRows = [];
-let nowcastReplayTimer = null;
-let nowcastFrameIndex = 0;
-
-// 页面加载时获取预测
 document.addEventListener('DOMContentLoaded', function() {
-    const refreshButton = document.getElementById('refreshForecast');
-    if (refreshButton) {
-        refreshButton.addEventListener('click', function() {
-            loadForecast();
-            loadNowcast();
-        });
-    }
-    const baselineBtn = document.getElementById('scenarioBaselineBtn');
-    const worstBtn = document.getElementById('scenarioWorstBtn');
-    if (baselineBtn) {
-        baselineBtn.addEventListener('click', function() {
-            setScenarioMode('baseline');
-        });
-    }
-    if (worstBtn) {
-        worstBtn.addEventListener('click', function() {
-            setScenarioMode('worst');
-        });
-    }
-    loadForecast();
-    loadModelInfo();
-    loadNowcast();
+    const ctx = document.getElementById('forecastChart');
+    if (!ctx || typeof Chart === 'undefined') return;
+    const labels = {{ ((forecast_days or default_days) | map(attribute='date') | list)|tojson }};
+    const scores = {{ ((forecast_days or default_days) | map(attribute='risk_score') | list)|tojson }};
+    const highs  = {{ ((forecast_days or default_days) | map(attribute='temp_high') | list)|tojson }};
+    new Chart(ctx, {
+        type: 'line',
+        data: { labels, datasets: [
+            { label: '风险评分', data: scores, borderColor:'#EE7E2D', backgroundColor:'rgba(238,126,45,0.12)', fill:true, tension:0.4, yAxisID:'y' },
+            { label: '最高气温', data: highs, borderColor:'#C7472E', borderDash:[4,4], tension:0.4, yAxisID:'y1' }
+        ]},
+        options: {
+            responsive: true,
+            interaction: { mode:'index', intersect:false },
+            scales: {
+                y: { beginAtZero:true, max:100, title:{display:true,text:'风险评分'}, grid:{color:'#F4EDDF'} },
+                y1:{ position:'right', grid:{display:false}, title:{display:true,text:'气温 °C'} }
+            }
+        }
+    });
 });
-
-function setScenarioMode(mode) {
-    currentScenarioMode = mode === 'worst' ? 'worst' : 'baseline';
-    const baselineBtn = document.getElementById('scenarioBaselineBtn');
-    const worstBtn = document.getElementById('scenarioWorstBtn');
-    if (baselineBtn) {
-        baselineBtn.classList.toggle('active', currentScenarioMode === 'baseline');
-    }
-    if (worstBtn) {
-        worstBtn.classList.toggle('active', currentScenarioMode === 'worst');
-    }
-    const modeLabel = document.getElementById('scenarioModeLabel');
-    if (modeLabel) {
-        modeLabel.textContent = currentScenarioMode === 'worst'
-            ? '最坏情景（P90）'
-            : '基线情景（P50）';
-    }
-    if (latestForecastRows.length > 0) {
-        displayForecast(latestForecastRows, latestSummaryData);
-    }
-}
-
-function loadForecast() {
-    // 显示加载状态
-    document.getElementById('alertTitle').textContent = '正在加载预测数据...';
-    
-    fetch('/api/forecast/7day', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({})
-    })
-    .then(response => response.json())
-    .then(data => {
-        if (data.success) {
-            latestForecastRows = Array.isArray(data.forecasts) ? data.forecasts : [];
-            latestSummaryData = data.summary || {};
-            displayForecast(latestForecastRows, latestSummaryData);
-        } else {
-            showError('加载失败: ' + (data.error || '未知错误'));
-        }
-    })
-    .catch(error => {
-        showError('请求失败: ' + error);
-    });
-}
-
-function loadModelInfo() {
-    fetch('/api/dlnm/summary')
-    .then(response => response.json())
-    .then(data => {
-        if (data.success && data.summary) {
-            const s = data.summary;
-            const mmtValue = toNumber(s.mmt, null);
-            if (mmtValue !== null) {
-                document.getElementById('mmtValue').textContent = mmtValue.toFixed(1) + '°C';
-            }
-            if (s.risk_thresholds) {
-                const heatWarning = toNumber(s.risk_thresholds.heat_warning, 32);
-                const coldWarning = toNumber(s.risk_thresholds.cold_warning, 5);
-                document.getElementById('heatThreshold').textContent = heatWarning.toFixed(1) + '°C';
-                document.getElementById('coldThreshold').textContent = coldWarning.toFixed(1) + '°C';
-            }
-        }
-    });
-}
-
-function loadNowcast() {
-    fetch('/api/weather/nowcast?hours=6')
-    .then(response => response.json())
-    .then(payload => {
-        if (payload && payload.success) {
-            renderNowcast(payload.data || {});
-        } else {
-            renderNowcast({available: false, timeline: []});
-        }
-    })
-    .catch(() => {
-        renderNowcast({available: false, timeline: []});
-    });
-}
-
-function renderNowcast(data) {
-    const container = document.getElementById('nowcastDiv');
-    if (!container) return;
-    clearElement(container);
-    if (nowcastReplayTimer) {
-        clearInterval(nowcastReplayTimer);
-        nowcastReplayTimer = null;
-    }
-
-    const timeline = Array.isArray(data.timeline) ? data.timeline : [];
-    nowcastTimelineRows = timeline;
-    if (!timeline.length) {
-        const p = document.createElement('p');
-        p.className = 'text-muted mb-0';
-        p.textContent = '暂无小时级降水时间轴数据';
-        container.appendChild(p);
-        return;
-    }
-
-    const controls = document.createElement('div');
-    controls.className = 'd-flex flex-wrap align-items-center gap-2 mb-3';
-
-    const playBtn = document.createElement('button');
-    playBtn.type = 'button';
-    playBtn.className = 'btn btn-sm btn-outline-primary';
-    playBtn.textContent = '回放';
-    controls.appendChild(playBtn);
-
-    const slider = document.createElement('input');
-    slider.type = 'range';
-    slider.className = 'form-range flex-grow-1 mb-0';
-    slider.min = '0';
-    slider.max = String(Math.max(0, timeline.length - 1));
-    slider.value = '0';
-    controls.appendChild(slider);
-
-    const frameLabel = document.createElement('span');
-    frameLabel.className = 'small text-muted';
-    controls.appendChild(frameLabel);
-    container.appendChild(controls);
-
-    const listWrap = document.createElement('div');
-    container.appendChild(listWrap);
-
-    timeline.forEach((item, idx) => {
-        const row = document.createElement('div');
-        row.className = 'mb-2';
-        row.dataset.frame = String(idx);
-
-        const top = document.createElement('div');
-        top.className = 'd-flex justify-content-between small';
-        const t = document.createElement('span');
-        t.textContent = safeText(item.time, '--').slice(11, 16);
-        const v = document.createElement('span');
-        const p = formatNumber(item.precipitation_probability, 0, '--');
-        v.textContent = p + '%';
-        top.appendChild(t);
-        top.appendChild(v);
-
-        const bar = document.createElement('div');
-        bar.className = 'progress';
-        bar.style.height = '10px';
-        const barInner = document.createElement('div');
-        const prob = toNumber(item.precipitation_probability, 0);
-        barInner.className = 'progress-bar ' + (prob >= 70 ? 'bg-danger' : prob >= 40 ? 'bg-warning' : 'bg-info');
-        barInner.style.width = Math.max(0, Math.min(100, prob)) + '%';
-        bar.appendChild(barInner);
-
-        row.appendChild(top);
-        row.appendChild(bar);
-        listWrap.appendChild(row);
-    });
-
-    function setFrame(index) {
-        const safeIndex = Math.max(0, Math.min(timeline.length - 1, Number(index)));
-        nowcastFrameIndex = safeIndex;
-        slider.value = String(safeIndex);
-        const frame = timeline[safeIndex] || {};
-        const t = safeText(frame.time, '--').slice(11, 16);
-        frameLabel.textContent = `${safeIndex + 1}/${timeline.length} · ${t}`;
-        Array.from(listWrap.querySelectorAll('[data-frame]')).forEach(node => {
-            const active = Number(node.dataset.frame) === safeIndex;
-            node.classList.toggle('border', active);
-            node.classList.toggle('border-primary', active);
-            node.classList.toggle('rounded', active);
-            node.classList.toggle('p-1', active);
-        });
-    }
-
-    slider.addEventListener('input', function() {
-        setFrame(this.value);
-    });
-
-    playBtn.addEventListener('click', function() {
-        if (nowcastReplayTimer) {
-            clearInterval(nowcastReplayTimer);
-            nowcastReplayTimer = null;
-            playBtn.textContent = '回放';
-            return;
-        }
-        playBtn.textContent = '暂停';
-        nowcastReplayTimer = setInterval(() => {
-            let next = nowcastFrameIndex + 1;
-            if (next >= timeline.length) {
-                next = 0;
-            }
-            setFrame(next);
-        }, 900);
-    });
-
-    setFrame(0);
-
-    const rainWindow = data.rain_window || null;
-    if (rainWindow && rainWindow.start_time) {
-        const rainInfo = document.createElement('div');
-        rainInfo.className = 'alert alert-light py-2 mt-2 mb-2';
-        rainInfo.innerHTML = [
-            `<strong>预计降水窗口：</strong>${safeText(rainWindow.start_time, '--').slice(11, 16)} - ${safeText(rainWindow.end_time, '--').slice(11, 16)}`,
-            `，峰值概率 ${formatNumber(rainWindow.max_probability, 0, '--')}%`
-        ].join('');
-        container.appendChild(rainInfo);
-    }
-
-    const foot = document.createElement('div');
-    foot.className = 'text-muted small mt-2';
-    foot.textContent = '数据源: ' + safeText(data.source, '--') + ' | 支持 0-6 小时时间线回放';
-    container.appendChild(foot);
-}
-
-function displayForecast(forecasts, summary) {
-    // 更新预警摘要
-    const alertCard = document.getElementById('alertCard');
-    const alertLevel = document.getElementById('alertLevel');
-    const alertTitle = document.getElementById('alertTitle');
-    const alertDesc = document.getElementById('alertDesc');
-    const summaryData = summary || {};
-    const highRiskDaysValue = toNumber(summaryData.high_risk_days, 0);
-    const highRiskDaysText = formatNumber(summaryData.high_risk_days, 0, '--');
-    const scenarioTotals = summaryData.scenario_totals || {};
-    const baselineTotal = toNumber(scenarioTotals.baseline_total, toNumber(summaryData.total_expected_visits, null));
-    const worstTotal = toNumber(scenarioTotals.worst_case_total, baselineTotal);
-    const optimisticTotal = toNumber(scenarioTotals.optimistic_total, baselineTotal);
-    const useWorst = currentScenarioMode === 'worst';
-    const totalVisitsValue = useWorst ? worstTotal : baselineTotal;
-    const totalVisitsText = totalVisitsValue === null ? '--' : String(Math.round(totalVisitsValue));
-    const forecastPeriod = summaryData.forecast_period || {};
-    const periodStart = safeText(forecastPeriod.start, '--');
-    const periodEnd = safeText(forecastPeriod.end, '--');
-
-    if (highRiskDaysValue >= 3) {
-        alertCard.className = 'card shadow-sm border-danger';
-        setAlertLevel(alertLevel, 'text-danger', 'bi bi-exclamation-octagon-fill', '红色预警');
-        alertTitle.textContent = useWorst ? '最坏情景下未来一周健康风险较高' : '未来一周健康风险较高';
-    } else if (highRiskDaysValue >= 1) {
-        alertCard.className = 'card shadow-sm border-warning';
-        setAlertLevel(alertLevel, 'text-warning', 'bi bi-exclamation-triangle-fill', '橙色预警');
-        alertTitle.textContent = useWorst ? '最坏情景下部分日期风险偏高' : '部分日期健康风险偏高';
-    } else {
-        alertCard.className = 'card shadow-sm border-success';
-        setAlertLevel(alertLevel, 'text-success', 'bi bi-check-circle-fill', '正常');
-        alertTitle.textContent = useWorst ? '最坏情景下风险总体可控' : '未来一周健康风险正常';
-    }
-
-    clearElement(alertDesc);
-    alertDesc.appendChild(document.createTextNode('预测期间: ' + periodStart + ' ~ ' + periodEnd + ' | 预计总门诊: '));
-    const totalStrong = document.createElement('strong');
-    totalStrong.textContent = totalVisitsText;
-    alertDesc.appendChild(totalStrong);
-    alertDesc.appendChild(document.createTextNode(' 人次 | 高风险天数: '));
-    const highRiskStrong = document.createElement('strong');
-    highRiskStrong.textContent = highRiskDaysText;
-    alertDesc.appendChild(highRiskStrong);
-    alertDesc.appendChild(document.createTextNode(' 天'));
-    const avgPredictability = formatNumber(summaryData.predictability && summaryData.predictability.average_score, 0, null);
-    if (avgPredictability !== null) {
-        alertDesc.appendChild(document.createTextNode(' | 可预报性均值: '));
-        const predStrong = document.createElement('strong');
-        predStrong.textContent = avgPredictability;
-        alertDesc.appendChild(predStrong);
-    }
-    if (optimisticTotal !== null && worstTotal !== null) {
-        alertDesc.appendChild(document.createTextNode(' | 区间总量: '));
-        const rangeStrong = document.createElement('strong');
-        rangeStrong.textContent = `${Math.round(optimisticTotal)}~${Math.round(worstTotal)}`;
-        alertDesc.appendChild(rangeStrong);
-    }
-
-    const averageVisits = totalVisitsValue === null ? '--' : String(Math.round(totalVisitsValue / 7));
-    document.getElementById('visitThreshold').textContent = averageVisits + '人次/天';
-
-    // 更新7天卡片
-    const forecastList = Array.isArray(forecasts) ? forecasts : [];
-    forecastList.forEach((f, i) => {
-        const card = document.querySelector('.forecast-card[data-day="' + i + '"]');
-        if (!card) return;
-
-        const riskLevel = safeText(f.risk_level, '--');
-        const riskClass = riskLevel.includes('红') ? 'risk-high' :
-                         riskLevel.includes('橙') ? 'risk-medium' :
-                         riskLevel.includes('黄') ? 'risk-yellow' :
-                         riskLevel.includes('蓝') ? 'risk-blue' : 'risk-low';
-        card.className = 'card shadow-sm h-100 forecast-card ' + riskClass;
-
-        const badgeClass = riskLevel.includes('红') ? 'danger' :
-                          riskLevel.includes('橙') ? 'orange' :
-                          riskLevel.includes('黄') ? 'warning' :
-                          riskLevel.includes('蓝') ? 'info' : 'success';
-
-        const dateText = safeText(f.date, '--');
-        const dayText = safeText(f.day_of_week, '--');
-        const tempText = formatNumber(f.temperature && f.temperature.corrected, 0, '--');
-        const baselineVisit = toNumber(f.visits && f.visits.point_estimate, null);
-        const worstVisit = toNumber(f.visits && f.visits.p90, baselineVisit);
-        const scenarioVisit = currentScenarioMode === 'worst' ? worstVisit : baselineVisit;
-        const visitsText = scenarioVisit === null ? '--' : String(Math.round(scenarioVisit));
-        const probText = formatNumber(f.probability_high_visits, 0, '--');
-        const probDisplay = probText === '--' ? '--' : probText + '%';
-        const predictabilityScore = formatNumber(f.predictability && f.predictability.score, 0, '--');
-        const predictabilityLabel = safeText(f.predictability && f.predictability.label, '--');
-        const composite = f.composite_exposure || {};
-        const compositeText = safeText(composite.level, '--') + ' ' + formatNumber(composite.score, 0, '--');
-
-        clearElement(card);
-        const header = document.createElement('div');
-        header.className = 'card-header text-center py-2';
-        const dateSmall = document.createElement('small');
-        dateSmall.className = 'text-muted';
-        dateSmall.textContent = dateText;
-        const dayDiv = document.createElement('div');
-        dayDiv.className = 'fw-bold';
-        dayDiv.textContent = dayText;
-        header.appendChild(dateSmall);
-        header.appendChild(dayDiv);
-
-        const body = document.createElement('div');
-        body.className = 'card-body text-center py-3';
-        const tempDiv = document.createElement('div');
-        tempDiv.className = 'display-6 mb-2';
-        tempDiv.textContent = tempText + '°C';
-        const badgeWrap = document.createElement('div');
-        badgeWrap.className = 'mb-2';
-        const badge = document.createElement('span');
-        badge.className = 'badge bg-' + badgeClass;
-        badge.textContent = riskLevel;
-        badgeWrap.appendChild(badge);
-        const visitsDiv = document.createElement('div');
-        visitsDiv.className = 'small text-muted';
-        visitsDiv.textContent = (currentScenarioMode === 'worst' ? '最坏情景门诊: ' : '预计门诊: ') + visitsText + ' 人次';
-        const probDiv = document.createElement('div');
-        probDiv.className = 'small text-muted';
-        probDiv.textContent = '超阈值概率: ' + probDisplay;
-        const compDiv = document.createElement('div');
-        compDiv.className = 'small text-muted';
-        compDiv.textContent = '复合暴露: ' + compositeText;
-        const predDiv = document.createElement('div');
-        predDiv.className = 'small text-muted';
-        predDiv.textContent = '可预报性: ' + predictabilityLabel + ' (' + predictabilityScore + ')';
-
-        body.appendChild(tempDiv);
-        body.appendChild(badgeWrap);
-        body.appendChild(visitsDiv);
-        body.appendChild(probDiv);
-        body.appendChild(compDiv);
-        body.appendChild(predDiv);
-
-        card.appendChild(header);
-        card.appendChild(body);
-    });
-
-    // 更新表格
-    const tableBody = document.getElementById('forecastTable');
-    clearElement(tableBody);
-
-    forecastList.forEach(f => {
-        const riskLevel = safeText(f.risk_level, '--');
-        const badgeClass = riskLevel.includes('红') ? 'danger' :
-                          riskLevel.includes('橙') ? 'orange' :
-                          riskLevel.includes('黄') ? 'warning' :
-                          riskLevel.includes('蓝') ? 'info' : 'success';
-
-        const row = document.createElement('tr');
-
-        const dateCell = document.createElement('td');
-        const dateStrong = document.createElement('strong');
-        dateStrong.textContent = safeText(f.date, '--');
-        const daySmall = document.createElement('small');
-        daySmall.className = 'text-muted';
-        daySmall.textContent = safeText(f.day_of_week, '--');
-        dateCell.appendChild(dateStrong);
-        dateCell.appendChild(document.createElement('br'));
-        dateCell.appendChild(daySmall);
-
-        const tempCell = document.createElement('td');
-        const correctedText = formatNumber(f.temperature && f.temperature.corrected, 1, '--');
-        const lowerText = formatNumber(f.temperature && f.temperature.uncertainty_lower, 0, '--');
-        const upperText = formatNumber(f.temperature && f.temperature.uncertainty_upper, 0, '--');
-        tempCell.appendChild(document.createTextNode(correctedText + '°C'));
-        const rangeSmall = document.createElement('small');
-        rangeSmall.className = 'text-muted';
-        rangeSmall.textContent = lowerText + '~' + upperText + '°C';
-        tempCell.appendChild(document.createElement('br'));
-        tempCell.appendChild(rangeSmall);
-
-        const visitCell = document.createElement('td');
-        const visitStrong = document.createElement('strong');
-        const baseVisit = toNumber(f.visits && f.visits.point_estimate, null);
-        const worstVisit = toNumber(f.visits && f.visits.p90, baseVisit);
-        const usedVisit = currentScenarioMode === 'worst' ? worstVisit : baseVisit;
-        const visitText = usedVisit === null ? '--' : String(Math.round(usedVisit));
-        visitStrong.textContent = visitText;
-        visitCell.appendChild(visitStrong);
-        visitCell.appendChild(document.createTextNode(' 人次'));
-
-        const quantileCell = document.createElement('td');
-        const p10Text = formatNumber(f.visits && f.visits.p10, 0, '--');
-        const p50Text = formatNumber(f.visits && f.visits.p50, 0, '--');
-        const p90Text = formatNumber(f.visits && f.visits.p90, 0, '--');
-        quantileCell.textContent = `${p10Text} / ${p50Text} / ${p90Text}`;
-
-        const intervalCell = document.createElement('td');
-        const lowerBoundText = formatNumber(f.visits && f.visits.lower_bound, 0, '--');
-        const upperBoundText = formatNumber(f.visits && f.visits.upper_bound, 0, '--');
-        intervalCell.textContent = lowerBoundText + ' ~ ' + upperBoundText;
-
-        const probCell = document.createElement('td');
-        const probValue = toNumber(f.probability_high_visits, 0);
-        const probText = formatNumber(f.probability_high_visits, 0, '--');
-        const probDisplay = probText === '--' ? '--' : probText + '%';
-        const probP75 = toNumber(f.visits && f.visits.probability_exceed_p75, null);
-        const probWidth = Math.max(0, Math.min(100, probValue));
-        const progress = document.createElement('div');
-        progress.className = 'progress';
-        progress.style.height = '20px';
-        const progressBar = document.createElement('div');
-        progressBar.className = 'progress-bar bg-' + badgeClass;
-        progressBar.style.width = probWidth + '%';
-        progressBar.textContent = probDisplay;
-        progress.appendChild(progressBar);
-        probCell.appendChild(progress);
-        if (probP75 !== null) {
-            const meta = document.createElement('div');
-            meta.className = 'small text-muted mt-1';
-            meta.textContent = 'P75: ' + (probP75 * 100).toFixed(0) + '%';
-            probCell.appendChild(meta);
-        }
-
-        const compositeCell = document.createElement('td');
-        const composite = f.composite_exposure || {};
-        const compLevel = safeText(composite.level, '--');
-        const compScore = formatNumber(composite.score, 0, '--');
-        const compBadge = document.createElement('span');
-        const compClass = compLevel === '高' ? 'danger' : compLevel === '中' ? 'warning' : 'success';
-        compBadge.className = 'badge bg-' + compClass;
-        compBadge.textContent = compLevel + ' (' + compScore + ')';
-        compositeCell.appendChild(compBadge);
-
-        const riskCell = document.createElement('td');
-        const riskBadge = document.createElement('span');
-        riskBadge.className = 'badge bg-' + badgeClass;
-        riskBadge.textContent = riskLevel;
-        riskCell.appendChild(riskBadge);
-
-        const predictabilityCell = document.createElement('td');
-        const predictability = f.predictability || {};
-        const predLabel = safeText(predictability.label, '--');
-        const predScore = formatNumber(predictability.score, 0, '--');
-        const predBadge = document.createElement('span');
-        const predClass = predLabel === '高' ? 'success' : predLabel === '中' ? 'warning' : 'secondary';
-        predBadge.className = 'badge bg-' + predClass;
-        predBadge.textContent = predLabel + ' (' + predScore + ')';
-        predictabilityCell.appendChild(predBadge);
-
-        const confidenceCell = document.createElement('td');
-        const confidenceValue = safeText(f.confidence, '');
-        const confidenceLabel = confidenceValue === 'high' ? '高' : confidenceValue === 'medium' ? '中' : '低';
-        const confidenceClass = confidenceValue === 'high' ? 'success' : confidenceValue === 'medium' ? 'warning' : 'secondary';
-        const confidenceBadge = document.createElement('span');
-        confidenceBadge.className = 'badge bg-' + confidenceClass;
-        confidenceBadge.textContent = confidenceLabel;
-        confidenceCell.appendChild(confidenceBadge);
-
-        row.appendChild(dateCell);
-        row.appendChild(tempCell);
-        row.appendChild(visitCell);
-        row.appendChild(quantileCell);
-        row.appendChild(intervalCell);
-        row.appendChild(probCell);
-        row.appendChild(compositeCell);
-        row.appendChild(riskCell);
-        row.appendChild(predictabilityCell);
-        row.appendChild(confidenceCell);
-        tableBody.appendChild(row);
-    });
-
-    // 更新建议
-    const recDiv = document.getElementById('recommendationsDiv');
-    clearElement(recDiv);
-
-    if (Array.isArray(summaryData.recommendations) && summaryData.recommendations.length > 0) {
-        summaryData.recommendations.forEach(rec => {
-            const priority = safeText(rec.priority, '');
-            const priorityClass = priority === 'high' ? 'danger' :
-                                 priority === 'medium' ? 'warning' : 'secondary';
-            const div = document.createElement('div');
-            div.className = 'alert alert-' + priorityClass + ' py-2 mb-2';
-            const strong = document.createElement('strong');
-            strong.textContent = safeText(rec.category, '');
-            const small = document.createElement('small');
-            small.textContent = safeText(rec.advice, '');
-            div.appendChild(strong);
-            div.appendChild(document.createElement('br'));
-            div.appendChild(small);
-            recDiv.appendChild(div);
-        });
-    } else {
-        const empty = document.createElement('p');
-        empty.className = 'text-muted mb-0';
-        empty.textContent = '暂无特别建议';
-        recDiv.appendChild(empty);
-    }
-
-    // 更新极端天气
-    const extremeDiv = document.getElementById('extremeEventsDiv');
-    clearElement(extremeDiv);
-
-    let hasExtremeEvents = false;
-    forecastList.forEach(f => {
-        if (Array.isArray(f.extreme_events) && f.extreme_events.length > 0) {
-            hasExtremeEvents = true;
-            f.extreme_events.forEach(e => {
-                const div = document.createElement('div');
-                div.className = 'alert alert-warning py-2 mb-2';
-                const strong = document.createElement('strong');
-                strong.textContent = safeText(f.date, '--') + ': ' + safeText(e.type, '--');
-                const small = document.createElement('small');
-                small.textContent = safeText(e.description, '');
-                div.appendChild(strong);
-                div.appendChild(document.createElement('br'));
-                div.appendChild(small);
-                extremeDiv.appendChild(div);
-            });
-        }
-    });
-
-    if (!hasExtremeEvents) {
-        const empty = document.createElement('p');
-        empty.className = 'text-success mb-0';
-        const icon = document.createElement('i');
-        icon.className = 'bi bi-check-circle me-1';
-        empty.appendChild(icon);
-        empty.appendChild(document.createTextNode('未来7天无极端天气预警'));
-        extremeDiv.appendChild(empty);
-    }
-
-    renderImpactMatrix(summaryData.impact_likelihood_matrix || {});
-    renderRoleActionCards(summaryData.role_action_cards || {});
-    renderCompositeExposureBoard(forecastList, summaryData);
-}
-
-function renderRoleActionCards(cards) {
-    const container = document.getElementById('roleActionCards');
-    if (!container) return;
-    clearElement(container);
-
-    const groups = [
-        {key: 'resident', label: '居民'},
-        {key: 'doctor', label: '村医'},
-        {key: 'community', label: '社区干部'}
-    ];
-
-    groups.forEach(group => {
-        const entries = Array.isArray(cards[group.key]) ? cards[group.key] : [];
-        const block = document.createElement('div');
-        block.className = 'mb-3';
-        const title = document.createElement('h6');
-        title.className = 'mb-1';
-        title.textContent = group.label;
-        block.appendChild(title);
-
-        if (!entries.length) {
-            const empty = document.createElement('div');
-            empty.className = 'small text-muted';
-            empty.textContent = '暂无行动建议';
-            block.appendChild(empty);
-        } else {
-            entries.slice(0, 2).forEach(item => {
-                const priority = safeText(item.priority, 'medium');
-                const cls = priority === 'high' ? 'danger' : priority === 'urgent' ? 'danger' : priority === 'medium' ? 'warning' : 'secondary';
-                const alert = document.createElement('div');
-                alert.className = 'alert alert-' + cls + ' py-2 px-3 mb-2';
-                alert.innerHTML = `<strong>${safeText(item.title, '行动建议')}</strong><br><small>${safeText(item.action, '')}</small>`;
-                block.appendChild(alert);
-            });
-        }
-        container.appendChild(block);
-    });
-}
-
-function renderCompositeExposureBoard(forecasts, summary) {
-    const container = document.getElementById('compositeExposureBoard');
-    if (!container) return;
-    clearElement(container);
-
-    const summaryExposure = (summary && summary.composite_exposure) || {};
-    const avg = formatNumber(summaryExposure.average_score, 1, '--');
-    const highDays = formatNumber(summaryExposure.high_risk_days, 0, '--');
-
-    const summaryDiv = document.createElement('div');
-    summaryDiv.className = 'd-flex justify-content-between align-items-center mb-2';
-    summaryDiv.innerHTML = `<span class="small text-muted">周均复合暴露分</span><strong>${avg}</strong>`;
-    container.appendChild(summaryDiv);
-    const subDiv = document.createElement('div');
-    subDiv.className = 'small text-muted mb-3';
-    subDiv.textContent = `高复合暴露天数: ${highDays}`;
-    container.appendChild(subDiv);
-
-    (forecasts || []).forEach(item => {
-        const exposure = item.composite_exposure || {};
-        const score = toNumber(exposure.score, 0) || 0;
-        const row = document.createElement('div');
-        row.className = 'mb-2';
-
-        const top = document.createElement('div');
-        top.className = 'd-flex justify-content-between small';
-        top.innerHTML = `<span>${safeText(item.date, '--')}</span><span>${safeText(exposure.level, '--')} ${formatNumber(exposure.score, 0, '--')}</span>`;
-
-        const bar = document.createElement('div');
-        bar.className = 'progress';
-        bar.style.height = '10px';
-        const inner = document.createElement('div');
-        inner.className = 'progress-bar ' + (score >= 70 ? 'bg-danger' : score >= 45 ? 'bg-warning' : 'bg-success');
-        inner.style.width = Math.max(0, Math.min(100, score)) + '%';
-        bar.appendChild(inner);
-
-        row.appendChild(top);
-        row.appendChild(bar);
-        container.appendChild(row);
-    });
-}
-
-function renderImpactMatrix(matrixData) {
-    const body = document.getElementById('impactMatrixBody');
-    if (!body) return;
-    clearElement(body);
-
-    const cells = matrixData.cells || {};
-    const impactRows = [
-        {key: 'low', label: '低影响'},
-        {key: 'medium', label: '中影响'},
-        {key: 'high', label: '高影响'}
-    ];
-    const likelihoodCols = ['low', 'medium', 'high'];
-
-    impactRows.forEach(rowInfo => {
-        const tr = document.createElement('tr');
-        const name = document.createElement('td');
-        name.textContent = rowInfo.label;
-        tr.appendChild(name);
-
-        likelihoodCols.forEach(col => {
-            const td = document.createElement('td');
-            const value = toNumber(cells[rowInfo.key] && cells[rowInfo.key][col], 0);
-            td.textContent = String(value);
-            if (rowInfo.key === 'high' && col === 'high' && value > 0) {
-                td.className = 'text-danger fw-bold';
-            } else if (rowInfo.key !== 'low' && col !== 'low' && value > 0) {
-                td.className = 'text-warning fw-semibold';
-            }
-            tr.appendChild(td);
-        });
-        body.appendChild(tr);
-    });
-}
-
-function showError(msg) {
-    document.getElementById('alertTitle').textContent = msg;
-    document.getElementById('alertCard').className = 'card shadow-sm border-danger';
-}
 </script>
 {% endblock %}
-

--- a/templates/forecast_7day.html
+++ b/templates/forecast_7day.html
@@ -1,3 +1,4 @@
+{% set needs_chartjs = true %}
 {% extends "base.html" %}
 {% block title %}7 天健康预测 · 宜老天气通{% endblock %}
 

--- a/templates/health_assessment.html
+++ b/templates/health_assessment.html
@@ -1,434 +1,195 @@
 {% extends "base.html" %}
-
-{% block title %}健康风险评估 - 天气健康风险预测系统{% endblock %}
+{% block title %}健康评估 · 宜老天气通{% endblock %}
 
 {% block content %}
-{% set academic = assessment_academic if assessment_academic else {} %}
-{% set risk_interval = academic.get('risk_interval', {}) if academic else {} %}
-{% set probabilities = academic.get('risk_probabilities', {}) if academic else {} %}
-{% set cap = academic.get('cap_semantics', {}) if academic else {} %}
-{% set matrix = academic.get('impact_likelihood', {}) if academic else {} %}
-{% set model_paths = academic.get('model_paths', []) if academic else [] %}
-{% set component_scores = academic.get('component_scores', {}) if academic else {} %}
-{% set community_ctx = academic.get('community_context', {}) if academic else {} %}
-{% set screening_ctx = academic.get('screening', {}) if academic else {} %}
-{% set methodology = academic.get('methodology', []) if academic else [] %}
-{% set recommendations = assessment.recommendations|from_json if assessment and assessment.recommendations else [] %}
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-xl-10 col-lg-11">
-            <div class="card shadow-lg">
-                <div class="card-header bg-success text-white text-center py-4">
-                    <h3><i class="bi bi-clipboard-pulse"></i> 健康风险评估</h3>
-                    <p class="mb-0">基于当前天气和个人健康状况进行风险评估</p>
-                </div>
-                <div class="card-body p-4">
-                    <div class="alert alert-info">
-                        <i class="bi bi-info-circle"></i>
-                        <strong>评估说明：</strong>
-                        系统将综合考虑以下因素进行风险评估：
-                        <ul class="mb-0 mt-2">
-                            <li>当前天气条件（温度、湿度、空气质量等）</li>
-                            <li>您的年龄和性别</li>
-                            <li>是否患有慢性疾病</li>
-                            <li>所在社区的整体健康状况</li>
-                        </ul>
-                    </div>
+<div class="container" style="max-width:900px;">
+    <section class="section-heading yl-fade-up">
+        <span class="section-kicker"><i class="bi bi-clipboard-pulse"></i> 健康评估</span>
+        <h2>健康风险评估</h2>
+        <p>5 项快速筛查,大约需要 2 分钟,帮你建立一份当天风险画像。</p>
+    </section>
 
-                    <form method="POST" action="{{ url_for('user.health_assessment') }}">
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <div class="mb-4">
-                            <h5><i class="bi bi-person-badge"></i> 基本信息</h5>
-                            <div class="row">
-                                <div class="col-md-6 mb-3">
-                                    <label class="form-label">年龄</label>
-                                    <input type="text" class="form-control" value="{{ current_user.age or '未设置' }}" readonly>
-                                </div>
-                                <div class="col-md-6 mb-3">
-                                    <label class="form-label">性别</label>
-                                    <input type="text" class="form-control" value="{{ current_user.gender or '未设置' }}" readonly>
-                                </div>
-                            </div>
-                            <div class="mb-3">
-                                <label class="form-label">所属社区</label>
-                                <input type="text" class="form-control" value="{{ current_user.community or '未设置' }}" readonly>
-                            </div>
-                        </div>
-
-                        <div class="mb-4">
-                            <h5><i class="bi bi-heart"></i> 健康状况</h5>
-                            <div class="mb-3">
-                                <label class="form-label">是否患有慢性疾病</label>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="has_chronic" disabled
-                                           {% if current_user.has_chronic_disease %}checked{% endif %}>
-                                    <label class="form-check-label" for="has_chronic">
-                                        {{ '是' if current_user.has_chronic_disease else '否' }}
-                                    </label>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="mb-4">
-                            <h5><i class="bi bi-clipboard2-data"></i> 即时状态筛查</h5>
-                            <div class="row g-3">
-                                <div class="col-md-6">
-                                    <label class="form-label">今日户外暴露</label>
-                                    <select class="form-select" name="outdoor_exposure">
-                                        {% set current_exposure = screening_ctx.get('outdoor_exposure', 'medium') %}
-                                        <option value="low" {% if current_exposure == 'low' %}selected{% endif %}>低（主要室内）</option>
-                                        <option value="medium" {% if current_exposure == 'medium' %}selected{% endif %}>中（约1-3小时）</option>
-                                        <option value="high" {% if current_exposure == 'high' %}selected{% endif %}>高（超过3小时）</option>
-                                    </select>
-                                </div>
-                                <div class="col-md-6">
-                                    <label class="form-label">当前不适症状</label>
-                                    {% set current_symptom = screening_ctx.get('symptom_level', 'none') %}
-                                    <select class="form-select" name="symptom_level">
-                                        <option value="none" {% if current_symptom == 'none' %}selected{% endif %}>无明显不适</option>
-                                        <option value="mild" {% if current_symptom == 'mild' %}selected{% endif %}>轻微</option>
-                                        <option value="moderate" {% if current_symptom == 'moderate' %}selected{% endif %}>中等</option>
-                                        <option value="severe" {% if current_symptom == 'severe' %}selected{% endif %}>明显/严重</option>
-                                    </select>
-                                </div>
-                                <div class="col-md-4">
-                                    <label class="form-label">饮水情况</label>
-                                    {% set current_hydration = screening_ctx.get('hydration', 'normal') %}
-                                    <select class="form-select" name="hydration">
-                                        <option value="good" {% if current_hydration == 'good' %}selected{% endif %}>充足</option>
-                                        <option value="normal" {% if current_hydration == 'normal' %}selected{% endif %}>一般</option>
-                                        <option value="poor" {% if current_hydration == 'poor' %}selected{% endif %}>不足</option>
-                                    </select>
-                                </div>
-                                <div class="col-md-4">
-                                    <label class="form-label">近24小时睡眠</label>
-                                    {% set current_sleep = screening_ctx.get('sleep_quality', 'good') %}
-                                    <select class="form-select" name="sleep_quality">
-                                        <option value="good" {% if current_sleep == 'good' %}selected{% endif %}>良好</option>
-                                        <option value="fair" {% if current_sleep == 'fair' %}selected{% endif %}>一般</option>
-                                        <option value="poor" {% if current_sleep == 'poor' %}selected{% endif %}>较差</option>
-                                    </select>
-                                </div>
-                                <div class="col-md-4">
-                                    <label class="form-label">慢病用药依从</label>
-                                    {% set current_med = screening_ctx.get('medication_adherence', 'good') %}
-                                    <select class="form-select" name="medication_adherence">
-                                        <option value="good" {% if current_med == 'good' %}selected{% endif %}>规律服药</option>
-                                        <option value="partial" {% if current_med == 'partial' %}selected{% endif %}>偶尔漏服</option>
-                                        <option value="poor" {% if current_med == 'poor' %}selected{% endif %}>经常漏服</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="form-text mt-2">这些筛查项用于即时风险修正，可随每次评估更新。</div>
-                        </div>
-
-                        <div class="alert alert-warning">
-                            <i class="bi bi-exclamation-triangle"></i>
-                            <strong>温馨提示：</strong>
-                            如需更新个人信息，请前往个人设置页面
-                        </div>
-
-                        <div class="d-grid gap-2">
-                            <button type="submit" class="btn btn-success btn-lg">
-                                <i class="bi bi-clipboard-check"></i> 开始评估
-                            </button>
-                            <a href="{{ url_for('user.user_dashboard') }}" class="btn btn-outline-secondary">
-                                <i class="bi bi-arrow-left"></i> 返回主页
-                            </a>
-                        </div>
-                    </form>
-                </div>
-            </div>
-
-            {% if assessment %}
-            <div class="card shadow-sm mt-4">
-                <div class="card-header bg-light">
-                    <h5 class="mb-0"><i class="bi bi-activity"></i> 最新评估结果</h5>
-                </div>
-                <div class="card-body">
-                    <div class="row g-3 align-items-stretch">
-                        <div class="col-lg-4">
-                            <div class="border rounded p-3 h-100">
-                                <div class="text-muted small">评估时间</div>
-                                <div class="mb-2">{{ assessment.assessment_date.strftime('%Y-%m-%d %H:%M') }}</div>
-                                <div class="d-flex align-items-center gap-2 mb-2">
-                                    {% if assessment.risk_level == '高风险' %}
-                                        <span class="badge bg-danger">{{ assessment.risk_level }}</span>
-                                    {% elif assessment.risk_level == '中风险' %}
-                                        <span class="badge bg-warning text-dark">{{ assessment.risk_level }}</span>
-                                    {% else %}
-                                        <span class="badge bg-success">{{ assessment.risk_level }}</span>
-                                    {% endif %}
-                                    <span class="fw-bold fs-4">{{ assessment.risk_score|round(1) }}</span>
-                                    <span class="text-muted">/100</span>
-                                </div>
-                                <div class="progress mb-2" style="height: 10px;">
-                                    {% if assessment.risk_score >= 70 %}
-                                    <div class="progress-bar bg-danger" style="width: {{ assessment.risk_score }}%"></div>
-                                    {% elif assessment.risk_score >= 40 %}
-                                    <div class="progress-bar bg-warning" style="width: {{ assessment.risk_score }}%"></div>
-                                    {% else %}
-                                    <div class="progress-bar bg-success" style="width: {{ assessment.risk_score }}%"></div>
-                                    {% endif %}
-                                </div>
-                                {% if risk_interval %}
-                                <div class="small text-muted">
-                                    风险区间：{{ risk_interval.get('low', 0) }} - {{ risk_interval.get('high', 0) }}
-                                    （不确定性：{{ risk_interval.get('label', '中') }}）
-                                </div>
-                                {% endif %}
-                            </div>
-                        </div>
-                        <div class="col-lg-4">
-                            <div class="border rounded p-3 h-100">
-                                <div class="text-muted small mb-2">概率化输出</div>
-                                <div class="small mb-2">高风险概率：<strong>{{ (probabilities.get('high', 0) * 100)|round(1) }}%</strong></div>
-                                <div class="small mb-2">中风险概率：<strong>{{ (probabilities.get('medium', 0) * 100)|round(1) }}%</strong></div>
-                                <div class="small mb-3">低风险概率：<strong>{{ (probabilities.get('low', 0) * 100)|round(1) }}%</strong></div>
-                                <div class="d-flex flex-wrap gap-2">
-                                    <span class="badge bg-secondary">severity: {{ cap.get('severity', 'minor') }}</span>
-                                    <span class="badge bg-secondary">certainty: {{ cap.get('certainty', 'possible') }}</span>
-                                    <span class="badge bg-secondary">urgency: {{ cap.get('urgency', 'future') }}</span>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-4">
-                            <div class="border rounded p-3 h-100">
-                                <div class="text-muted small mb-2">Impact × Likelihood</div>
-                                <div class="small mb-1">Impact：<strong>{{ matrix.get('impact_bucket', 'low') }}</strong></div>
-                                <div class="small mb-1">Likelihood：<strong>{{ matrix.get('likelihood_bucket', 'low') }}</strong></div>
-                                <div class="small">矩阵得分：<strong>{{ matrix.get('matrix_score', 1) }}</strong> / 16</div>
-                                <hr>
-                                <div class="small text-muted mb-1">社区上下文</div>
-                                <div class="small">社区：{{ community_ctx.get('community', current_user.community or '未设置') }}</div>
-                                <div class="small">脆弱性指数：{{ community_ctx.get('vulnerability_index', '-') }}</div>
-                                <div class="small">30天病例数：{{ community_ctx.get('cases_30d', 0) }}</div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="row g-3 mt-1">
-                        <div class="col-lg-6">
-                            <div class="border rounded p-3 h-100">
-                                <h6><i class="bi bi-diagram-3"></i> 融合模型路径</h6>
-                                <div class="table-responsive">
-                                    <table class="table table-sm align-middle mb-0">
-                                        <thead>
-                                            <tr>
-                                                <th>模型路径</th>
-                                                <th>分值</th>
-                                                <th>融合权重</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {% for path in model_paths %}
-                                            <tr>
-                                                <td>{{ path.get('name') }}</td>
-                                                <td>{{ path.get('score') }}</td>
-                                                <td>{{ (path.get('weight', 0) * 100)|round(0) }}%</td>
-                                            </tr>
-                                            {% endfor %}
-                                            {% if not model_paths %}
-                                            <tr><td colspan="3" class="text-muted">暂无模型分解</td></tr>
-                                            {% endif %}
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-6">
-                            <div class="border rounded p-3 h-100">
-                                <h6><i class="bi bi-sliders"></i> 因子贡献</h6>
-                                {% for name, value in component_scores.items() %}
-                                <div class="small d-flex justify-content-between">
-                                    <span>{{ name }}</span><span>{{ value }}</span>
-                                </div>
-                                <div class="progress mb-2" style="height: 7px;">
-                                    {% if value >= 70 %}
-                                    <div class="progress-bar bg-danger" style="width: {{ value }}%"></div>
-                                    {% elif value >= 40 %}
-                                    <div class="progress-bar bg-warning" style="width: {{ value }}%"></div>
-                                    {% else %}
-                                    <div class="progress-bar bg-success" style="width: {{ value }}%"></div>
-                                    {% endif %}
-                                </div>
-                                {% endfor %}
-                                {% if not component_scores %}
-                                <div class="text-muted small">暂无因子分解</div>
-                                {% endif %}
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="row g-3 mt-1">
-                        <div class="col-lg-6">
-                            <div class="border rounded p-3 h-100">
-                                <h6><i class="bi bi-heart-pulse"></i> 病种风险</h6>
-                                <div class="table-responsive">
-                                    <table class="table table-sm mb-0">
-                                        <thead>
-                                            <tr>
-                                                <th>病种</th>
-                                                <th>个人RR</th>
-                                                <th>风险等级</th>
-                                                <th>风险分</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {% for disease, item in assessment_disease_risks.items() %}
-                                            <tr>
-                                                <td>{{ disease }}</td>
-                                                <td>{{ item.get('personal_rr', '-') }}</td>
-                                                <td>{{ item.get('risk_level', '-') }}</td>
-                                                <td>{{ item.get('risk_score', '-') }}</td>
-                                            </tr>
-                                            {% endfor %}
-                                            {% if not assessment_disease_risks %}
-                                            <tr><td colspan="4" class="text-muted">暂无病种细分</td></tr>
-                                            {% endif %}
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-6">
-                            <div class="border rounded p-3 h-100">
-                                <h6><i class="bi bi-grid-3x3-gap"></i> 风险矩阵定位</h6>
-                                {% set impact_levels = ['low', 'medium', 'high', 'very_high'] %}
-                                {% set likelihood_levels = ['low', 'medium', 'high', 'very_high'] %}
-                                {% set level_name = {'low': '低', 'medium': '中', 'high': '高', 'very_high': '很高'} %}
-                                <div class="table-responsive">
-                                    <table class="table table-bordered text-center table-sm mb-0">
-                                        <thead>
-                                            <tr>
-                                                <th>Impact \ Likelihood</th>
-                                                {% for like in likelihood_levels %}
-                                                <th>{{ level_name.get(like) }}</th>
-                                                {% endfor %}
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {% for impact in impact_levels %}
-                                            <tr>
-                                                <th>{{ level_name.get(impact) }}</th>
-                                                {% for like in likelihood_levels %}
-                                                {% set active = matrix.get('impact_bucket') == impact and matrix.get('likelihood_bucket') == like %}
-                                                <td class="{% if active %}table-danger fw-bold{% endif %}">
-                                                    {% if active %}当前{% else %}-{% endif %}
-                                                </td>
-                                                {% endfor %}
-                                            </tr>
-                                            {% endfor %}
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <div class="small text-muted mt-2">矩阵用于决策优先级分层，不替代临床诊断。</div>
-                            </div>
-                        </div>
-                    </div>
-
-                    {% if recommendations %}
-                    <div class="border rounded p-3 mt-3">
-                        <h6><i class="bi bi-list-check"></i> 行动建议</h6>
-                        <ul class="mb-0">
-                            {% for rec in recommendations %}
-                            <li class="mb-1">
-                                <span class="fw-semibold">{{ rec.get('category', '建议') }}：</span>{{ rec.get('advice', '') }}
-                            </li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                    {% endif %}
-                </div>
-            </div>
-            {% endif %}
-
-            <div class="card shadow-sm mt-4">
-                <div class="card-header">
-                    <h5 class="mb-0"><i class="bi bi-question-circle"></i> 评估指标说明</h5>
-                </div>
-                <div class="card-body">
-                    <dl class="row mb-0">
-                        <dt class="col-sm-3">低风险</dt>
-                        <dd class="col-sm-9">当前天气条件对您的健康影响较小，可正常活动</dd>
-                        
-                        <dt class="col-sm-3">中风险</dt>
-                        <dd class="col-sm-9">天气条件可能对健康产生一定影响，建议适当注意防护</dd>
-                        
-                        <dt class="col-sm-3">高风险</dt>
-                        <dd class="col-sm-9 mb-0">天气条件对健康影响较大，建议减少外出，加强防护措施</dd>
-                    </dl>
-                </div>
-            </div>
-
-            {% if methodology %}
-            <div class="card shadow-sm mt-4">
-                <div class="card-header bg-light">
-                    <h5 class="mb-0"><i class="bi bi-mortarboard"></i> 方法学说明</h5>
-                </div>
-                <div class="card-body">
-                    <ul class="mb-0">
-                        {% for line in methodology %}
-                        <li class="mb-1">{{ line }}</li>
-                        {% endfor %}
-                    </ul>
-                </div>
-            </div>
-            {% endif %}
-
-            {% if assessment_explain and assessment_explain.get('explain') %}
-            <div class="card shadow-sm mt-4">
-                <div class="card-header bg-light">
-                    <h5 class="mb-0"><i class="bi bi-journal-check"></i> 结果解读</h5>
-                </div>
-                <div class="card-body">
-                    <div class="row g-3">
-                        <div class="col-md-4">
-                            <h6 class="mb-2">原因</h6>
-                            <ul class="mb-0">
-                                {% for item in assessment_explain.explain.reasons %}
-                                    <li class="mb-1">{{ item }}</li>
-                                {% endfor %}
-                                {% if not assessment_explain.explain.reasons %}
-                                    <li class="text-muted">暂无明显触发原因</li>
-                                {% endif %}
-                            </ul>
-                        </div>
-                        <div class="col-md-4">
-                            <h6 class="mb-2">今天怎么做</h6>
-                            <ul class="mb-0">
-                                {% for item in assessment_explain.explain.actions %}
-                                    <li class="mb-1">{{ item }}</li>
-                                {% endfor %}
-                                {% if not assessment_explain.explain.actions %}
-                                    <li class="text-muted">保持规律作息，按时饮水</li>
-                                {% endif %}
-                            </ul>
-                        </div>
-                        <div class="col-md-4">
-                            <h6 class="mb-2">什么时候要找人</h6>
-                            <ul class="mb-0">
-                                {% for item in assessment_explain.explain.escalation %}
-                                    <li class="mb-1">{{ item }}</li>
-                                {% endfor %}
-                                {% if not assessment_explain.explain.escalation %}
-                                    <li class="text-muted">出现胸痛、呼吸困难等请及时就医</li>
-                                {% endif %}
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="small text-muted mt-3">风险提示不是诊断，紧急情况优先就医。</div>
-                </div>
-            </div>
-            {% endif %}
+    {# 进度条 #}
+    <div class="yl-section yl-fade-up yl-fade-up-d1 mb-3" style="padding:16px 22px;">
+        <div class="d-flex justify-content-between mb-2" style="font-size:.85rem;">
+            <span class="text-muted">进度</span>
+            <span class="fw-semibold" id="progressTxt">0 / 5</span>
         </div>
+        <div class="progress"><div class="progress-bar" id="progressBar" style="width:0%"></div></div>
     </div>
+
+    <form method="POST" action="{{ url_for('user.health_assessment') }}" id="assessForm" class="yl-fade-up yl-fade-up-d2">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+        <div class="section-heading mb-3">
+            <span class="section-kicker"><i class="bi bi-clipboard2-pulse"></i> 即时状态筛查</span>
+            <p>根据你今天的状态与近几天感受,快速完成这份筛查。</p>
+        </div>
+
+        {% set questions = questions or [
+            {'id':'outdoor_exposure','text':'今日户外暴露情况','options':[('low','低,主要在室内'),('medium','中,约 1 到 3 小时'),('high','高,超过 3 小时')]},
+            {'id':'symptom_level','text':'当前不适症状','options':[('none','无明显不适'),('mild','轻微'),('moderate','中等'),('severe','明显或严重')]},
+            {'id':'hydration','text':'今天的饮水情况','options':[('good','充足'),('normal','一般'),('poor','不足')]},
+            {'id':'medication_adherence','text':'近期服药规律性','options':[('good','规律'),('partial','偶尔漏服'),('poor','经常漏服')]},
+            {'id':'sleep_quality','text':'最近睡眠质量','options':[('good','较好'),('fair','一般'),('poor','较差')]}
+        ] %}
+
+        {% for q in questions %}
+        <div class="card mb-3">
+            <div class="card-body">
+                <div class="d-flex gap-3">
+                    <div class="fw-bold" style="color:var(--yl-orange-500); font-size:1.1rem;">{{ loop.index }}.</div>
+                    <div class="flex-grow-1">
+                        <div class="fw-semibold mb-3">{{ q.text }}</div>
+                        <div class="d-flex flex-wrap gap-2">
+                            {% for val, label in q.options %}
+                            <label class="btn btn-outline-secondary" style="border-radius:999px;">
+                                <input type="radio" name="{{ q.id }}" value="{{ val }}" class="d-none assess-opt">
+                                {{ label }}
+                            </label>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endfor %}
+
+        <div class="d-flex gap-2 justify-content-end mt-4">
+            <a href="{{ url_for('user.user_dashboard') }}" class="btn btn-outline-secondary">取消</a>
+            <button type="submit" class="btn btn-primary"><i class="bi bi-check2-circle me-1"></i>提交评估</button>
+        </div>
+    </form>
+
+    <section class="yl-section yl-fade-up yl-fade-up-d3 mt-4">
+        <div class="section-heading mb-3">
+            <span class="section-kicker"><i class="bi bi-bar-chart-line"></i> 评估记录</span>
+            <h2>最新评估结果</h2>
+            <p>提交后会在这里显示最新一次风险判断与建议。</p>
+        </div>
+
+        {% if assessment %}
+        {% set explain = assessment_explain if assessment_explain else {} %}
+        {% set recommendations = assessment.recommendations|from_json if assessment.recommendations else [] %}
+        {% set weather_ref = explain.get('academic_profile', {}).get('weather', {}) if explain else {} %}
+        <div class="row g-3">
+            <div class="col-md-4">
+                <div class="card h-100 border-0 shadow-sm">
+                    <div class="card-body">
+                        <div class="text-muted small mb-2">风险等级</div>
+                        <div class="display-6 fw-bold mb-2">{{ assessment.risk_level or '待评估' }}</div>
+                        <div class="text-muted small">
+                            风险得分 {{ assessment.risk_score|round(1) if assessment.risk_score is not none else '--' }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="card h-100 border-0 shadow-sm">
+                    <div class="card-body">
+                        <div class="text-muted small mb-2">天气参考</div>
+                        <div class="fw-semibold mb-2">{{ weather_ref.get('condition', '以系统最新天气为准') }}</div>
+                        <div class="text-muted small">
+                            温度 {{ weather_ref.get('temperature', '--') }}°C / 湿度 {{ weather_ref.get('humidity', '--') }}%
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="card h-100 border-0 shadow-sm">
+                    <div class="card-body">
+                        <div class="text-muted small mb-2">更新时间</div>
+                        <div class="fw-semibold mb-2">
+                            {% if assessment.assessment_date %}
+                                {{ assessment.assessment_date.strftime('%Y-%m-%d %H:%M') }}
+                            {% else %}
+                                刚刚
+                            {% endif %}
+                        </div>
+                        <div class="text-muted small">如需更新,可重新提交评估。</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card mt-3 border-0 shadow-sm">
+            <div class="card-body">
+                <div class="fw-semibold mb-3">建议行动</div>
+                {% if recommendations %}
+                <ul class="mb-0 ps-3">
+                    {% for item in recommendations[:4] %}
+                    <li class="mb-2">{{ item }}</li>
+                    {% endfor %}
+                </ul>
+                {% else %}
+                <p class="text-muted mb-0">本次评估暂无额外建议,请继续保持日常观察。</p>
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="row g-3 mt-1">
+            <div class="col-md-6">
+                <div class="card h-100 border-0 shadow-sm">
+                    <div class="card-body">
+                        <div class="fw-semibold mb-3">融合模型路径</div>
+                        {% set model_paths = assessment_academic.get('model_paths', []) if assessment_academic else [] %}
+                        {% if model_paths %}
+                        <div class="d-grid gap-2">
+                            {% for path in model_paths %}
+                            <div class="d-flex justify-content-between small">
+                                <span>{{ path.get('name', '未命名路径') }}</span>
+                                <span class="text-muted">分值 {{ path.get('score', '-') }} / 权重 {{ ((path.get('weight', 0) * 100)|round(0)) }}%</span>
+                            </div>
+                            {% endfor %}
+                        </div>
+                        {% else %}
+                        <p class="text-muted mb-0">当前暂无模型路径拆解。</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card h-100 border-0 shadow-sm">
+                    <div class="card-body">
+                        <div class="fw-semibold mb-3">风险矩阵定位</div>
+                        {% set matrix = assessment_academic.get('impact_likelihood', {}) if assessment_academic else {} %}
+                        <div class="small mb-2">Impact：<strong>{{ matrix.get('impact_bucket', 'low') }}</strong></div>
+                        <div class="small mb-2">Likelihood：<strong>{{ matrix.get('likelihood_bucket', 'low') }}</strong></div>
+                        <div class="small text-muted">矩阵得分 {{ matrix.get('matrix_score', 1) }} / 16</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% else %}
+        <div class="card border-0 shadow-sm">
+            <div class="card-body">
+                <p class="text-muted mb-0">还没有历史评估记录。完成上面的问卷后,这里会显示最新评估结果。</p>
+            </div>
+        </div>
+        {% endif %}
+    </section>
 </div>
+
+<script>
+(function(){
+    const total = {{ questions|length }};
+    function update() {
+        const done = new Set();
+        document.querySelectorAll('.assess-opt:checked').forEach(i => done.add(i.name));
+        const n = done.size;
+        document.getElementById('progressTxt').textContent = n + ' / ' + total;
+        document.getElementById('progressBar').style.width = (n / total * 100) + '%';
+    }
+    document.querySelectorAll('.assess-opt').forEach(input => {
+        input.addEventListener('change', () => {
+            document.querySelectorAll(`.assess-opt[name="${input.name}"]`).forEach(i => i.closest('label').classList.remove('active', 'btn-primary'));
+            input.closest('label').classList.add('active');
+            input.closest('label').style.background = 'var(--yl-orange-500)';
+            input.closest('label').style.color = '#fff';
+            input.closest('label').style.borderColor = 'var(--yl-orange-500)';
+            update();
+        });
+    });
+})();
+</script>
 {% endblock %}
-
-
-
-
-
-
-

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}首页 - 宜老天气通{% endblock %}
+{% block title %}首页 · 宜老天气通{% endblock %}
 {% block body_class %}home-page{% endblock %}
 
 {% block content %}
@@ -8,244 +8,161 @@
     {% if current_user.role in ['caregiver', 'admin'] %}
         {% set workspace_url = url_for('user.caregiver_dashboard') %}
     {% else %}
-        {% set workspace_url = url_for('user.pair_management') %}
+        {% set workspace_url = url_for('health.family_members') %}
     {% endif %}
 {% endif %}
 
-<div class="container home-shell">
-    <!-- 首页主视觉 -->
-    <section class="home-hero mb-5">
-        <div class="row g-4 align-items-center">
-            <div class="col-xl-7">
-                <span class="hero-kicker">异地子女也能更早一步守护家中老人</span>
-                <h1 class="hero-title">
-                    把天气预警，
-                    <span class="text-gradient">变成今天就能执行的照护提醒。</span>
-                </h1>
-                <p class="hero-subtitle">
-                    宜老天气通把高温、寒潮等天气风险转换成更容易理解的提醒建议，帮助子女或照护者及时联系家人，
-                    不再只“看到天气”，而是知道“下一步要怎么做”。
-                </p>
+<div class="container" style="max-width: 1160px;">
 
-                <div class="hero-badges">
-                    <span class="hero-badge">
-                        <i class="bi bi-broadcast-pin"></i>
-                        官方预警优先
-                    </span>
-                    <span class="hero-badge">
-                        <i class="bi bi-chat-square-text"></i>
-                        一键复制提醒话术
-                    </span>
-                    <span class="hero-badge">
-                        <i class="bi bi-clipboard-data"></i>
-                        行动反馈可回收
-                    </span>
-                </div>
+    {# ============== Hero ============== #}
+    <section class="yl-hero yl-fade-up">
+        <span class="hero-kicker"><i class="bi bi-broadcast-pin"></i> 给异地子女的一条线</span>
+        <h1>把天气预警,变成今天就能做的那一句话。</h1>
+        <p class="hero-lead">
+            气压骤降、高温连日、寒潮来袭——这些对老人都是风险。我们把它翻译成一句"今天别出门"或"记得多喝水",
+            子女能直接转给家里人,不再只是看天气,而是知道下一步。
+        </p>
 
-                {% if not current_user.is_authenticated %}
-                    <div class="hero-actions">
-                        <a href="{{ url_for('public.register') }}" class="btn btn-primary btn-lg">立即注册</a>
-                        <a href="{{ url_for('public.login') }}" class="btn btn-outline-secondary btn-lg">用户登录</a>
-                        <a href="{{ url_for('public.wxoa_landing', from='web') }}" class="btn btn-outline-success btn-lg">公众号入口</a>
-                        <a href="{{ url_for('public.guest_login') }}" class="btn btn-outline-primary btn-lg">游客体验</a>
-                    </div>
-                    <p class="hero-note">老人不必学会使用网站，子女收到提醒后即可直接转述和跟进。</p>
-                {% else %}
-                    <div class="hero-actions">
-                        <a href="{{ workspace_url }}" class="btn btn-primary btn-lg">进入照护工作台</a>
-                        <a href="{{ url_for('public.about_trust_network') }}" class="btn btn-outline-secondary btn-lg">查看论文闭环说明</a>
-                        <a href="{{ url_for('public.public_risk') }}" class="btn btn-outline-primary btn-lg">查看风险说明</a>
-                    </div>
-                    <p class="hero-note">当前更适合先从“照护工作台”进入，配置老人所在地和提醒方式。</p>
-                {% endif %}
+        {% if not current_user.is_authenticated %}
+            <div class="hero-actions">
+                <a href="{{ url_for('public.register') }}" class="btn btn-primary btn-lg">立即注册</a>
+                <a href="{{ url_for('public.login') }}" class="btn btn-outline-secondary btn-lg">登录</a>
+                <a href="{{ url_for('public.guest_login') }}" class="btn btn-light btn-lg">游客体验</a>
             </div>
+            <p class="text-muted mt-3 mb-0" style="font-size:.9rem;">
+                <i class="bi bi-info-circle me-1"></i>老人不用学新 App——子女收到提醒,转述一句就够了。
+            </p>
+        {% else %}
+            <div class="hero-actions">
+                <a href="{{ workspace_url }}" class="btn btn-primary btn-lg">进入照护工作台</a>
+                <a href="{{ url_for('user.user_dashboard') }}" class="btn btn-outline-secondary btn-lg">我的主页</a>
+                <a href="{{ url_for('public.public_risk') }}" class="btn btn-light btn-lg">风险说明</a>
+            </div>
+        {% endif %}
+    </section>
 
-            <div class="col-xl-5">
-                <div class="hero-panel">
-                    <div class="hero-panel-header">
-                        <span class="hero-panel-chip">今日照护节奏</span>
-                        <h2>从天气变化到行动反馈，站内形成一条轻量闭环。</h2>
-                        <p>既适合课程答辩展示，也适合真实试点阶段使用。</p>
-                    </div>
+    {# ============== 闭环流程 ============== #}
+    <section class="section-heading yl-fade-up yl-fade-up-d1">
+        <span class="section-kicker">使用流程</span>
+        <h2>一个预警从出现到执行,大约走这 4 步。</h2>
+    </section>
 
-                    <div class="hero-journey">
-                        <div class="hero-journey-item">
-                            <span class="hero-journey-index">01</span>
-                            <div>
-                                <h3>天气风险触发</h3>
-                                <p>官方预警优先，无预警时用阈值机制兜底，降低漏提醒概率。</p>
-                            </div>
-                        </div>
-                        <div class="hero-journey-item">
-                            <span class="hero-journey-index">02</span>
-                            <div>
-                                <h3>子女收到提醒</h3>
-                                <p>通过网站或公众号入口查看提醒内容，不需要老人亲自操作。</p>
-                            </div>
-                        </div>
-                        <div class="hero-journey-item">
-                            <span class="hero-journey-index">03</span>
-                            <div>
-                                <h3>一键复制话术</h3>
-                                <p>把复杂信息翻译成更适合家人沟通的语句，减少“知道但不会说”。</p>
-                            </div>
-                        </div>
-                        <div class="hero-journey-item">
-                            <span class="hero-journey-index">04</span>
-                            <div>
-                                <h3>记录后续反馈</h3>
-                                <p>形成试点数据，便于后续分析预警效果和真实使用情况。</p>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="hero-stats-grid">
-                        <div class="hero-stat">
-                            <span>核心能力</span>
-                            <strong>多地区预警</strong>
-                            <p>支持多个老人所在地配置</p>
-                        </div>
-                        <div class="hero-stat">
-                            <span>沟通效率</span>
-                            <strong>提醒话术</strong>
-                            <p>把风险转成可执行语言</p>
-                        </div>
-                        <div class="hero-stat">
-                            <span>项目价值</span>
-                            <strong>试点闭环</strong>
-                            <p>便于答辩展示与后续优化</p>
-                        </div>
-                    </div>
+    <div class="row g-3 mb-5 yl-fade-up yl-fade-up-d2">
+        {% for step in [
+            ('01', '天气风险触发', '优先用官方预警,无预警时由阈值兜底,尽量不漏提醒。'),
+            ('02', '子女收到提醒', '网站或公众号都能接收,老人不用自己打开手机操作。'),
+            ('03', '一键复制话术', '把"气压 24h 下降 12 hPa"翻成"妈今天别去跳广场舞"。'),
+            ('04', '记录后续反馈', '是否提醒、是否执行,都能沉淀下来做后续优化。'),
+        ] %}
+        <div class="col-md-6 col-lg-3">
+            <div class="card h-100">
+                <div class="card-body">
+                    <div style="font-size:.8rem; color:var(--yl-orange-600); font-weight:700; letter-spacing:.1em;">{{ step[0] }}</div>
+                    <h3 class="mt-2" style="font-size:1.1rem;">{{ step[1] }}</h3>
+                    <p class="mb-0" style="font-size:.9rem;">{{ step[2] }}</p>
                 </div>
             </div>
         </div>
+        {% endfor %}
+    </div>
+
+    {# ============== 核心能力 ============== #}
+    <section class="section-heading yl-fade-up">
+        <span class="section-kicker">核心能力</span>
+        <h2>一眼看懂:这个网站能帮谁、帮什么。</h2>
+        <p>不是模块堆叠——把价值点、使用场景和结果一次讲清楚。</p>
     </section>
 
-    <!-- 功能卡片 -->
-    <section class="section-heading">
-        <span class="section-kicker">核心功能</span>
-        <h2>先让访问者一眼看懂，这个网站到底能帮谁、帮什么。</h2>
-        <p class="section-subtitle">首页不再只是“模块堆叠”，而是把价值点、使用场景和结果用更容易扫读的方式呈现出来。</p>
-    </section>
-
-    <section class="row g-4 mb-5">
+    <div class="row g-4 mb-5">
         <div class="col-lg-4">
-            <article class="feature-card h-100">
-                <div class="feature-icon feature-icon-primary">
-                    <i class="bi bi-cloud-sun"></i>
-                </div>
-                <div class="feature-copy">
-                    <span class="feature-label">预警能力</span>
-                    <h3>多地区天气风险提醒</h3>
-                    <p>为多位老人设置所在地，在高温或寒潮风险出现时及时向子女发出提醒。</p>
-                    <ul class="feature-list">
-                        <li>官方预警优先，阈值策略兜底</li>
-                        <li>支持中文地点输入</li>
-                        <li>保留点击和触发记录，便于回看</li>
+            <article class="card h-100 yl-fade-up">
+                <div class="card-body">
+                    <div class="yl-feature-icon mb-3" style="width:52px; height:52px; font-size:1.5rem;">
+                        <i class="bi bi-cloud-sun"></i>
+                    </div>
+                    <span class="section-kicker" style="margin-bottom:10px;">预警能力</span>
+                    <h3 style="font-size:1.15rem;">多地天气风险提醒</h3>
+                    <p>为多位老人设置所在地,高温或寒潮风险出现时及时通知子女。</p>
+                    <ul class="mb-0" style="color:var(--yl-ink-soft); font-size:.9rem; padding-left:18px;">
+                        <li>官方预警优先,阈值策略兜底</li>
+                        <li>支持中文地名(街道、县、城市)</li>
+                        <li>保留点击与触发记录,可回看</li>
                     </ul>
                 </div>
             </article>
         </div>
 
         <div class="col-lg-4">
-            <article class="feature-card h-100">
-                <div class="feature-icon feature-icon-success">
-                    <i class="bi bi-chat-heart"></i>
-                </div>
-                <div class="feature-copy">
-                    <span class="feature-label">沟通效率</span>
-                    <h3>提醒话术和行动反馈</h3>
-                    <p>把风险说明转成更自然的沟通内容，降低子女“知道了但不知道该怎么说”的成本。</p>
-                    <ul class="feature-list">
+            <article class="card h-100 yl-fade-up yl-fade-up-d1">
+                <div class="card-body">
+                    <div class="yl-feature-icon mb-3" style="width:52px; height:52px; font-size:1.5rem; background:var(--yl-success-50); color:var(--yl-success);">
+                        <i class="bi bi-chat-heart"></i>
+                    </div>
+                    <span class="section-kicker" style="margin-bottom:10px; background:var(--yl-success-50); color:var(--yl-success);">沟通效率</span>
+                    <h3 style="font-size:1.15rem;">话术与行动反馈</h3>
+                    <p>把风险说明转成家人听得懂的语言,省去"知道了但不知道怎么说"的那一步。</p>
+                    <ul class="mb-0" style="color:var(--yl-ink-soft); font-size:.9rem; padding-left:18px;">
                         <li>一键复制提醒语句</li>
-                        <li>记录是否已通知家人</li>
-                        <li>回收行动反馈，形成试点数据</li>
+                        <li>标记是否已通知到家人</li>
+                        <li>沉淀行动反馈,形成试点数据</li>
                     </ul>
                 </div>
             </article>
         </div>
 
         <div class="col-lg-4">
-            <article class="feature-card h-100">
-                <div class="feature-icon feature-icon-info">
-                    <i class="bi bi-shield-check"></i>
-                </div>
-                <div class="feature-copy">
-                    <span class="feature-label">可信设计</span>
-                    <h3>尽量少采集敏感信息</h3>
-                    <p>系统更关注天气风险、照护动作和试点反馈，不要求输入过细的隐私数据。</p>
-                    <ul class="feature-list">
-                        <li>不依赖精确住址和电话</li>
-                        <li>慢病信息可选填写</li>
-                        <li>透明度页面单独说明数据边界</li>
+            <article class="card h-100 yl-fade-up yl-fade-up-d2">
+                <div class="card-body">
+                    <div class="yl-feature-icon mb-3" style="width:52px; height:52px; font-size:1.5rem; background:var(--yl-info-50); color:var(--yl-info);">
+                        <i class="bi bi-shield-check"></i>
+                    </div>
+                    <span class="section-kicker" style="margin-bottom:10px; background:var(--yl-info-50); color:var(--yl-info);">可信设计</span>
+                    <h3 style="font-size:1.15rem;">尽量少采集敏感信息</h3>
+                    <p>我们更关注天气风险和照护动作,不要求精确到门牌的住址或电话。</p>
+                    <ul class="mb-0" style="color:var(--yl-ink-soft); font-size:.9rem; padding-left:18px;">
+                        <li>不依赖精确地址与手机号</li>
+                        <li>慢病信息选填</li>
+                        <li>透明度页面独立说明数据边界</li>
                     </ul>
                 </div>
             </article>
         </div>
+    </div>
+
+    {# ============== 角色入口 ============== #}
+    {% if not current_user.is_authenticated %}
+    <section class="section-heading yl-fade-up">
+        <span class="section-kicker">角色入口</span>
+        <h2>你是谁?选一条最合适的路径开始。</h2>
     </section>
 
-    <!-- 流程说明 -->
-    <section class="journey-card mb-5">
-        <div class="section-heading compact">
-            <span class="section-kicker">使用流程</span>
-            <h2>一个预警从出现到执行，大致会经过这 4 步。</h2>
+    <div class="row g-3 mb-5">
+        <div class="col-md-4">
+            <a href="{{ url_for('public.register') }}" class="yl-role-card variant-family">
+                <div class="yl-role-icon"><i class="bi bi-people"></i></div>
+                <h3>家属 / 子女</h3>
+                <p>关注家里老人的天气风险,收到提醒后转述一句。</p>
+                <span class="role-cta">去注册 <i class="bi bi-arrow-right"></i></span>
+            </a>
         </div>
+        <div class="col-md-4">
+            <a href="{{ url_for('public.guest_login') }}" class="yl-role-card variant-elder">
+                <div class="yl-role-icon"><i class="bi bi-eyeglasses"></i></div>
+                <h3>老人自用</h3>
+                <p>大字号、高对比,只保留最必要的风险和行动提示。</p>
+                <span class="role-cta">游客体验 <i class="bi bi-arrow-right"></i></span>
+            </a>
+        </div>
+        <div class="col-md-4">
+            <a href="{{ url_for('public.login') }}" class="yl-role-card variant-doctor">
+                <div class="yl-role-icon"><i class="bi bi-hospital"></i></div>
+                <h3>社区医生</h3>
+                <p>跨患者队列、风险预警、诊疗工具,一个工作台。</p>
+                <span class="role-cta">登录进入 <i class="bi bi-arrow-right"></i></span>
+            </a>
+        </div>
+    </div>
+    {% endif %}
 
-        <div class="row g-3">
-            <div class="col-md-6 col-xl-3">
-                <div class="journey-step">
-                    <span class="journey-step-number">1</span>
-                    <h3>录入老人信息</h3>
-                    <p>填写所在地、基础信息和可选慢病类别，建立个体化风险背景。</p>
-                </div>
-            </div>
-            <div class="col-md-6 col-xl-3">
-                <div class="journey-step">
-                    <span class="journey-step-number">2</span>
-                    <h3>系统监测天气</h3>
-                    <p>自动获取天气与预警数据，在风险升高时触发提醒逻辑。</p>
-                </div>
-            </div>
-            <div class="col-md-6 col-xl-3">
-                <div class="journey-step">
-                    <span class="journey-step-number">3</span>
-                    <h3>子女联系家人</h3>
-                    <p>复制建议话术，通过电话或微信提醒老人及时调整活动安排。</p>
-                </div>
-            </div>
-            <div class="col-md-6 col-xl-3">
-                <div class="journey-step">
-                    <span class="journey-step-number">4</span>
-                    <h3>记录实际反馈</h3>
-                    <p>回收是否提醒、是否执行等结果，为试点评估和后续优化提供依据。</p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- 信任与展示价值 -->
-    <section class="row g-4 mb-4">
-        <div class="col-lg-4">
-            <div class="trust-card h-100">
-                <span class="trust-label">适合答辩展示</span>
-                <h3>不是单纯天气站，而是有“人”的产品场景。</h3>
-                <p>核心叙事清楚：异地子女是可信节点，系统帮助他们更好地守护家中老人。</p>
-            </div>
-        </div>
-        <div class="col-lg-4">
-            <div class="trust-card h-100">
-                <span class="trust-label">适合继续扩展</span>
-                <h3>后续可以平滑扩到看板、分析页和公众号联动。</h3>
-                <p>这一版先把首页和入口页的视觉语言拉齐，后面再往功能页复用组件就会轻松很多。</p>
-            </div>
-        </div>
-        <div class="col-lg-4">
-            <div class="trust-card h-100">
-                <span class="trust-label">适合真实使用</span>
-                <h3>比“功能很多”更重要的是，让人知道先点哪里。</h3>
-                <p>主按钮、流程说明和信息层级更清楚，第一次进入网站时不容易迷路。</p>
-            </div>
-        </div>
-    </section>
 </div>
 {% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,19 +1,20 @@
 {% extends "base.html" %}
 
-{% block title %}登录 - 天气健康风险预测系统{% endblock %}
+{% block title %}登录 · 宜老天气通{% endblock %}
 {% block body_class %}login-page{% endblock %}
 
 {% block content %}
 <div class="container auth-shell">
-    <div class="row g-4 align-items-center">
-        <!-- 左侧：产品说明 -->
+    <div class="row g-5 align-items-start">
+
+        {# 左:叙事 #}
         <div class="col-lg-7 order-2 order-lg-1">
-            <section class="auth-story">
-                <span class="hero-kicker">登录后开始配置你的照护提醒</span>
-                <h1 class="auth-title">在天气真正影响家人之前，先替他们想一步。</h1>
+            <section class="yl-fade-up">
+                <span class="section-kicker">登录,开始配置你的照护提醒</span>
+                <h1 class="auth-title mt-2 mb-3">在天气真正影响到家人之前,先替他们想一步。</h1>
                 <p class="auth-subtitle">
-                    登录后你可以配置老人所在地、查看风险提醒、复制沟通话术，并把后续反馈记录下来，
-                    让这个系统既有真实使用价值，也能沉淀试点数据。
+                    登录后可以配置老人所在地、查看风险提醒、复制话术,把后续反馈记录下来。
+                    既是真实可用的工具,也能沉淀试点数据。
                 </p>
 
                 <div class="auth-highlight-grid">
@@ -21,88 +22,73 @@
                         <i class="bi bi-geo-alt"></i>
                         <div>
                             <strong>多地配置</strong>
-                            <p>适合异地子女同时关注多位家人</p>
+                            <p>异地子女同时关注多位家人</p>
                         </div>
                     </div>
                     <div class="auth-highlight-card">
                         <i class="bi bi-chat-left-text"></i>
                         <div>
                             <strong>沟通更省力</strong>
-                            <p>风险提醒能直接转成家人听得懂的话术</p>
+                            <p>风险提醒直接转成家人听得懂的话术</p>
                         </div>
                     </div>
                     <div class="auth-highlight-card">
                         <i class="bi bi-clipboard-check"></i>
                         <div>
                             <strong>结果可记录</strong>
-                            <p>提醒是否执行可以继续追踪和分析</p>
+                            <p>提醒是否执行,可以继续追踪分析</p>
                         </div>
                     </div>
                 </div>
 
                 <div class="auth-guide-card">
-                    <div class="section-heading compact mb-0">
-                        <span class="section-kicker">首次使用</span>
-                        <h2>5 分钟打通一条最基础的预警闭环。</h2>
-                    </div>
+                    <span class="section-kicker">首次使用</span>
+                    <h4 class="mt-2 mb-0" style="font-size:1.15rem;">5 分钟打通一条最基础的预警闭环。</h4>
                     <ol class="auth-quicklist">
                         <li>登录或注册进入系统。</li>
-                        <li>进入“照护工作台”，添加需要关注的家人。</li>
-                        <li>设置所在地和慢病类别（慢病可选）。</li>
-                        <li>在“个人设置”填写 WxPusher UID 并开启推送。</li>
-                        <li>收到提醒后复制话术，并记录后续反馈。</li>
+                        <li>进入"照护工作台",添加需要关注的家人。</li>
+                        <li>设置所在地和慢病类别(慢病可选)。</li>
+                        <li>在"个人设置"填写 WxPusher UID 并开启推送。</li>
+                        <li>收到提醒后复制话术,并记录后续反馈。</li>
                     </ol>
                 </div>
 
                 <div class="auth-link-row">
-                    <a class="btn btn-outline-secondary" href="{{ url_for('public.public_risk') }}">
-                        <i class="bi bi-thermometer-sun me-1"></i>风险说明
-                    </a>
-                    <a class="btn btn-outline-secondary" href="{{ url_for('public.transparency') }}">
-                        <i class="bi bi-shield-check me-1"></i>透明度
-                    </a>
-                    <a class="btn btn-outline-secondary" href="{{ url_for('public.role_entry') }}">
-                        <i class="bi bi-diagram-3 me-1"></i>角色入口
-                    </a>
-                    <a class="btn btn-outline-success" href="{{ url_for('public.wxoa_landing', from='wxoa') }}">
-                        <i class="bi bi-chat-left-text me-1"></i>公众号入口
-                    </a>
+                    <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('public.public_risk') }}"><i class="bi bi-thermometer-sun me-1"></i>风险说明</a>
+                    <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('public.transparency') }}"><i class="bi bi-shield-check me-1"></i>透明度</a>
+                    <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('public.cooling_resources') }}"><i class="bi bi-geo-alt me-1"></i>避暑资源</a>
                 </div>
             </section>
         </div>
 
-        <!-- 右侧：登录表单 -->
+        {# 右:表单 #}
         <div class="col-lg-5 col-xl-4 order-1 order-lg-2">
-            <section class="auth-panel">
+            <section class="auth-panel yl-fade-up yl-fade-up-d1">
                 <div class="auth-panel-head text-center">
-                    <div class="auth-icon-wrap">
-                        <i class="bi bi-shield-lock-fill"></i>
-                    </div>
-                    <h2>登录系统</h2>
-                    <p>继续使用你的照护与天气预警工具</p>
+                    <div class="auth-icon-wrap"><i class="bi bi-shield-lock-fill"></i></div>
+                    <h2>登录</h2>
+                    <p>继续使用你的照护工具</p>
                 </div>
 
-                <div class="card auth-form-card shadow-sm">
+                <div class="card auth-form-card">
                     <div class="card-body p-4">
                         <form method="POST" action="{{ url_for('public.login') }}">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                            {% if next %}
-                                <input type="hidden" name="next" value="{{ next }}">
-                            {% endif %}
+                            {% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
 
                             <div class="mb-3">
-                                <label for="username" class="form-label text-secondary">用户名</label>
+                                <label for="username" class="form-label">用户名</label>
                                 <input type="text" class="form-control" id="username" name="username" placeholder="请输入用户名" required autofocus>
                             </div>
                             <div class="mb-3">
-                                <label for="password" class="form-label text-secondary">密码</label>
+                                <label for="password" class="form-label">密码</label>
                                 <input type="password" class="form-control" id="password" name="password" placeholder="请输入密码" required>
                             </div>
 
                             <div class="mb-3 d-flex justify-content-between align-items-center">
                                 <div class="form-check">
                                     <input type="checkbox" class="form-check-input" id="remember" name="remember" value="1">
-                                    <label class="form-check-label small" for="remember">记住我（30 天）</label>
+                                    <label class="form-check-label" for="remember" style="font-size:.9rem;">记住我(30 天)</label>
                                 </div>
                             </div>
 
@@ -114,8 +100,8 @@
                             </div>
 
                             <div class="text-center">
-                                <span class="text-secondary small">还没有账号？</span>
-                                <a href="{{ url_for('public.register') }}" class="text-decoration-none small fw-semibold">立即注册</a>
+                                <span class="text-muted" style="font-size:.88rem;">还没有账号?</span>
+                                <a href="{{ url_for('public.register') }}" class="text-decoration-none fw-semibold" style="font-size:.88rem;">立即注册</a>
                             </div>
                         </form>
                     </div>
@@ -123,7 +109,7 @@
 
                 <div class="auth-note">
                     <i class="bi bi-info-circle"></i>
-                    <span><strong>管理员账号：</strong>由系统配置创建</span>
+                    <span><strong>管理员账号:</strong>由系统配置创建</span>
                 </div>
             </section>
         </div>

--- a/templates/ml_prediction.html
+++ b/templates/ml_prediction.html
@@ -1,743 +1,103 @@
 {% extends "base.html" %}
-{% set needs_fontawesome = true %}
-
-{% block title %}AI智能预测 - 天气健康风险预测系统{% endblock %}
+{% block title %}AI 疾病预测 · 宜老天气通{% endblock %}
 
 {% block content %}
-<div class="container-fluid py-4">
-    <div class="row mb-4">
-        <div class="col-12">
-            <div class="d-flex justify-content-between align-items-center">
-                <div>
-                    <h2><i class="fas fa-brain me-2"></i>AI智能疾病风险预测</h2>
-                    <p class="text-muted mb-0">基于机器学习模型，结合天气数据进行精准健康风险评估</p>
+<div class="container" style="max-width:1100px;">
+    <section class="section-heading yl-fade-up">
+        <span class="section-kicker"><i class="bi bi-cpu"></i> AI 疾病预测</span>
+        <h2>基于天气与慢病背景的个性化风险预测</h2>
+        <p>模型参考近 24h 气象与个人画像,给出未来 3 天常见疾病的发作概率。</p>
+    </section>
+
+    <div class="row g-4">
+        <div class="col-lg-4">
+            <form method="POST" action="{{ url_for('tools.ml_prediction') }}" class="yl-section yl-fade-up yl-fade-up-d1">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <h4 style="font-size:1.05rem;">输入信息</h4>
+
+                <div class="mb-3 mt-3">
+                    <label class="form-label">对象</label>
+                    <select name="member_id" class="form-select">
+                        <option value="">我本人</option>
+                        {% for m in (family_members or []) %}
+                        <option value="{{ m.id }}" {% if request.args.get('member_id')|int == m.id %}selected{% endif %}>{{ m.name }}</option>
+                        {% endfor %}
+                    </select>
                 </div>
-                <div id="modelStatus" class="badge bg-secondary">
-                    <i class="fas fa-spinner fa-spin me-1"></i>加载模型中...
+                <div class="mb-3">
+                    <label class="form-label">所在地</label>
+                    <input type="text" class="form-control" name="location" value="{{ current_location or '' }}" list="locOpts">
+                    <datalist id="locOpts">{% for loc in (location_options or []) %}<option value="{{ loc }}"></option>{% endfor %}</datalist>
                 </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="row">
-        <!-- 左侧：输入参数 -->
-        <div class="col-lg-4 mb-4">
-            <div class="card shadow-sm">
-                <div class="card-header bg-primary text-white">
-                    <h5 class="mb-0"><i class="fas fa-sliders-h me-2"></i>预测参数</h5>
+                <div class="mb-3">
+                    <label class="form-label">年龄</label>
+                    <input type="number" class="form-control" name="age" value="{{ age or 65 }}" min="1" max="120">
                 </div>
-                <div class="card-body">
-                    <!-- 预测类型选择 -->
-                    <div class="mb-3">
-                        <label class="form-label fw-bold">预测类型</label>
-                        <div class="btn-group w-100" role="group">
-                            <input type="radio" class="btn-check" name="predType" id="predIndividual" value="individual" checked>
-                            <label class="btn btn-outline-primary" for="predIndividual">
-                                <i class="fas fa-user me-1"></i>个人预测
-                            </label>
-                            <input type="radio" class="btn-check" name="predType" id="predCommunity" value="community">
-                            <label class="btn btn-outline-primary" for="predCommunity">
-                                <i class="fas fa-building me-1"></i>社区预测
-                            </label>
-                        </div>
-                    </div>
-
-                    <!-- 个人信息 -->
-                    <div id="individualParams">
-                        <h6 class="text-muted mb-3"><i class="fas fa-user me-1"></i>个人信息</h6>
-                        <div class="row">
-                            <div class="col-6 mb-3">
-                                <label class="form-label">年龄</label>
-                                <input type="number" class="form-control" id="inputAge" value="{{ current_user.age or 40 }}" min="0" max="120">
-                            </div>
-                            <div class="col-6 mb-3">
-                                <label class="form-label">性别</label>
-                                <select class="form-select" id="inputGender">
-                                    <option value="男" {% if current_user.gender == '男' or current_user.gender == '男性' %}selected{% endif %}>男</option>
-                                    <option value="女" {% if current_user.gender == '女' or current_user.gender == '女性' %}selected{% endif %}>女</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- 社区选择 -->
-                    <div id="communityParams" style="display:none;">
-                        <h6 class="text-muted mb-3"><i class="fas fa-building me-1"></i>社区信息</h6>
-                        <div class="mb-3">
-                            <label class="form-label">选择社区</label>
-                            <select class="form-select" id="inputCommunity">
-                                {% for comm in communities %}
-                                <option value="{{ comm.id }}" data-elderly="{{ comm.elderly_ratio }}" data-population="{{ comm.population }}">
-                                    {{ comm.name }} (人口:{{ comm.population }})
-                                </option>
-                                {% endfor %}
-                            </select>
-                        </div>
-                    </div>
-
-                    <hr>
-
-                    <!-- 天气参数 - 扩展版 -->
-                    <h6 class="text-muted mb-3"><i class="fas fa-cloud-sun me-1"></i>天气条件</h6>
-                    
-                    <!-- 温度 -->
-                    <div class="mb-3">
-                        <label class="form-label">温度 (°C)</label>
-                        <input type="range" class="form-range" id="inputTemp" min="-10" max="45" value="20">
-                        <div class="d-flex justify-content-between">
-                            <small class="text-muted">-10°C</small>
-                            <span class="badge bg-info" id="tempValue">20°C</span>
-                            <small class="text-muted">45°C</small>
-                        </div>
-                    </div>
-                    
-                    <!-- 最高/最低温度 -->
-                    <div class="row mb-3">
-                        <div class="col-6">
-                            <label class="form-label"><small>最低温度 (°C)</small></label>
-                            <input type="number" class="form-control form-control-sm" id="inputTmin" value="15" min="-20" max="40">
-                        </div>
-                        <div class="col-6">
-                            <label class="form-label"><small>最高温度 (°C)</small></label>
-                            <input type="number" class="form-control form-control-sm" id="inputTmax" value="25" min="-10" max="50">
-                        </div>
-                    </div>
-                    
-                    <!-- 相对湿度 -->
-                    <div class="mb-3">
-                        <label class="form-label">相对湿度 (%)</label>
-                        <input type="range" class="form-range" id="inputHumidity" min="10" max="100" value="70">
-                        <div class="d-flex justify-content-between">
-                            <small class="text-muted">10% 干燥</small>
-                            <span class="badge bg-primary" id="humidityValue">70%</span>
-                            <small class="text-muted">100% 潮湿</small>
-                        </div>
-                    </div>
-                    
-                    <!-- 空气质量指数 -->
-                    <div class="mb-3">
-                        <label class="form-label">空气质量指数 (AQI)</label>
-                        <input type="range" class="form-range" id="inputAQI" min="0" max="300" value="50">
-                        <div class="d-flex justify-content-between">
-                            <small class="text-muted">0 优</small>
-                            <span class="badge bg-success" id="aqiValue">50</span>
-                            <small class="text-muted">300 严重污染</small>
-                        </div>
-                    </div>
-                    
-                    <!-- 风速 -->
-                    <div class="mb-3">
-                        <label class="form-label">风速 (m/s)</label>
-                        <input type="range" class="form-range" id="inputWindSpeed" min="0" max="20" value="2" step="0.5">
-                        <div class="d-flex justify-content-between">
-                            <small class="text-muted">0 无风</small>
-                            <span class="badge bg-secondary" id="windSpeedValue">2.0 m/s</span>
-                            <small class="text-muted">20 大风</small>
-                        </div>
-                    </div>
-                    
-                    <!-- 降水量 -->
-                    <div class="mb-3">
-                        <label class="form-label">降水量 (mm)</label>
-                        <input type="range" class="form-range" id="inputPrecipitation" min="0" max="100" value="0">
-                        <div class="d-flex justify-content-between">
-                            <small class="text-muted">0 无雨</small>
-                            <span class="badge bg-info" id="precipitationValue">0 mm</span>
-                            <small class="text-muted">100 暴雨</small>
-                        </div>
-                    </div>
-                    
-                    <!-- 月份 -->
-                    <div class="mb-3">
-                        <label class="form-label">月份</label>
-                        <select class="form-select" id="inputMonth">
-                            <option value="1" {% if now().month == 1 %}selected{% endif %}>1月 (冬季)</option>
-                            <option value="2" {% if now().month == 2 %}selected{% endif %}>2月 (冬季)</option>
-                            <option value="3" {% if now().month == 3 %}selected{% endif %}>3月 (春季)</option>
-                            <option value="4" {% if now().month == 4 %}selected{% endif %}>4月 (春季)</option>
-                            <option value="5" {% if now().month == 5 %}selected{% endif %}>5月 (春季)</option>
-                            <option value="6" {% if now().month == 6 %}selected{% endif %}>6月 (夏季)</option>
-                            <option value="7" {% if now().month == 7 %}selected{% endif %}>7月 (夏季)</option>
-                            <option value="8" {% if now().month == 8 %}selected{% endif %}>8月 (夏季)</option>
-                            <option value="9" {% if now().month == 9 %}selected{% endif %}>9月 (秋季)</option>
-                            <option value="10" {% if now().month == 10 %}selected{% endif %}>10月 (秋季)</option>
-                            <option value="11" {% if now().month == 11 %}selected{% endif %}>11月 (秋季)</option>
-                            <option value="12" {% if now().month == 12 %}selected{% endif %}>12月 (冬季)</option>
-                        </select>
-                    </div>
-
-                    <button class="btn btn-primary w-100 btn-lg" id="runPredictionBtn" type="button">
-                        <i class="fas fa-play me-2"></i>开始预测
-                    </button>
+                <div class="mb-3">
+                    <label class="form-label">已有慢病(可多选)</label>
+                    <select name="chronic" class="form-select" multiple size="6">
+                        {% for c in ['高血压','糖尿病','冠心病','慢阻肺','脑卒中史','慢性肾病','骨关节病'] %}
+                        <option value="{{ c }}">{{ c }}</option>
+                        {% endfor %}
+                    </select>
+                    <div class="form-text">按住 Ctrl/⌘ 多选</div>
                 </div>
-            </div>
+                <button type="submit" class="btn btn-primary w-100"><i class="bi bi-magic me-1"></i>生成预测</button>
+            </form>
         </div>
 
-        <!-- 右侧：预测结果 -->
         <div class="col-lg-8">
-            <!-- 加载中 -->
-            <div id="loadingResult" class="card shadow-sm mb-4" style="display:none;">
-                <div class="card-body text-center py-5">
-                    <div class="spinner-border text-primary mb-3" role="status">
-                        <span class="visually-hidden">预测中...</span>
+            {% if prediction %}
+            <section class="yl-section yl-fade-up yl-fade-up-d2 mb-3">
+                <h4 style="font-size:1.1rem;">未来 3 天风险预测</h4>
+                <div class="row g-3 mt-1">
+                    {% for p in prediction %}
+                    <div class="col-md-4">
+                        <div class="card h-100">
+                            <div class="card-body text-center">
+                                <div class="text-muted" style="font-size:.85rem;">{{ p.disease }}</div>
+                                <div style="font-size:2.2rem; font-weight:600; color:{% if p.score>=70 %}var(--yl-risk-high){% elif p.score>=40 %}var(--yl-risk-mid){% else %}var(--yl-success){% endif %};" class="my-2 mt-3">
+                                    {{ p.score }}%
+                                </div>
+                                <div class="progress mb-2"><div class="progress-bar {% if p.score>=70 %}bg-danger{% elif p.score>=40 %}bg-warning{% else %}bg-success{% endif %}" style="width:{{ p.score }}%"></div></div>
+                                <div class="text-muted" style="font-size:.8rem;">{{ p.label }}</div>
+                            </div>
+                        </div>
                     </div>
-                    <h5>AI模型正在分析...</h5>
-                    <p class="text-muted">正在结合天气数据和个人信息进行风险评估</p>
+                    {% endfor %}
                 </div>
+            </section>
+            {% else %}
+            <div class="yl-section text-center yl-fade-up yl-fade-up-d2" style="padding:56px 30px;">
+                <div style="font-size:3rem; color:var(--yl-orange-400);"><i class="bi bi-graph-up-arrow"></i></div>
+                <h4 class="mt-3">填写左侧信息后查看预测</h4>
+                <p class="text-muted mb-0">结果包括心脑血管、呼吸系统和关节疾病的 3 天发作概率。</p>
             </div>
+            {% endif %}
 
-            <!-- 预测结果 -->
-            <div id="predictionResult" style="display:none;">
-                <!-- 风险概览 -->
-                <div class="card shadow-sm mb-4">
-                    <div class="card-header">
-                        <h5 class="mb-0"><i class="fas fa-chart-pie me-2"></i>风险评估结果</h5>
-                    </div>
-                    <div class="card-body">
-                        <div class="row align-items-center">
-                            <div class="col-md-4 text-center">
-                                <div id="riskGauge" class="mb-3">
-                                    <div class="display-1 fw-bold" id="riskScoreDisplay">--</div>
-                                    <div class="h5" id="riskLevelDisplay">--</div>
-                                </div>
-                            </div>
-                            <div class="col-md-8">
-                                <h6>风险因素</h6>
-                                <ul id="riskFactorsList" class="list-unstyled">
-                                </ul>
-                            </div>
+            <section class="yl-section yl-fade-up yl-fade-up-d3">
+                <h4 style="font-size:1.1rem;">主要影响因子</h4>
+                <p class="text-muted" style="font-size:.88rem;">以下因素权重较大,建议重点关注。</p>
+                <div class="mt-3">
+                    {% for f in (factors or [
+                        {'name':'最高气温变化','value':82,'effect':'+'},
+                        {'name':'气压 24h 差','value':64,'effect':'+'},
+                        {'name':'相对湿度','value':51,'effect':'+'},
+                        {'name':'AQI','value':38,'effect':'+'},
+                        {'name':'年龄','value':72,'effect':'+'},
+                        {'name':'已服用药物','value':28,'effect':'−'}
+                    ]) %}
+                    <div class="mb-2">
+                        <div class="d-flex justify-content-between" style="font-size:.88rem;">
+                            <span>{{ f.name }} <span class="text-muted">({{ f.effect }})</span></span>
+                            <span class="fw-semibold">{{ f.value }}</span>
                         </div>
+                        <div class="progress"><div class="progress-bar" style="width:{{ f.value }}%"></div></div>
                     </div>
+                    {% endfor %}
                 </div>
-                
-                <!-- 天气影响分析 -->
-                <div class="card shadow-sm mb-4">
-                    <div class="card-header">
-                        <h5 class="mb-0"><i class="fas fa-cloud-sun me-2"></i>天气影响分析</h5>
-                    </div>
-                    <div class="card-body">
-                        <div class="row">
-                            <div class="col-md-6">
-                                <div id="weatherImpact">
-                                    <p class="mb-2"><strong>影响等级：</strong><span id="weatherImpactLevel">--</span></p>
-                                    <p class="mb-2"><strong>当前条件：</strong></p>
-                                    <ul id="weatherConditionsList" class="list-unstyled small"></ul>
-                                </div>
-                            </div>
-                            <div class="col-md-6">
-                                <p class="mb-2"><strong>影响因素：</strong></p>
-                                <ul id="weatherFactorsList" class="list-unstyled small"></ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- 疾病预测（多分类） -->
-                <div class="card shadow-sm mb-4">
-                    <div class="card-header">
-                        <h5 class="mb-0"><i class="fas fa-stethoscope me-2"></i>疾病风险预测</h5>
-                    </div>
-                    <div class="card-body">
-                        <div id="diseasePredictions">
-                        </div>
-                    </div>
-                </div>
-
-                <!-- 健康建议 -->
-                <div class="card shadow-sm mb-4">
-                    <div class="card-header bg-success text-white">
-                        <h5 class="mb-0"><i class="fas fa-lightbulb me-2"></i>健康建议</h5>
-                    </div>
-                    <div class="card-body">
-                        <div id="recommendationsList">
-                        </div>
-                    </div>
-                </div>
-
-                <!-- 可解释输出 -->
-                <div class="card shadow-sm mb-4" id="explainCard" style="display:none;">
-                    <div class="card-header bg-light">
-                        <h5 class="mb-0"><i class="fas fa-clipboard-list me-2"></i>原因与提醒</h5>
-                    </div>
-                    <div class="card-body">
-                        <div class="row g-3">
-                            <div class="col-md-4">
-                                <h6>原因</h6>
-                                <ul id="explainReasons" class="mb-0"></ul>
-                            </div>
-                            <div class="col-md-4">
-                                <h6>今天怎么做</h6>
-                                <ul id="explainActions" class="mb-0"></ul>
-                            </div>
-                            <div class="col-md-4">
-                                <h6>什么时候要找人</h6>
-                                <ul id="explainEscalation" class="mb-0"></ul>
-                            </div>
-                        </div>
-                        <div class="small text-muted mt-3" id="explainDisclaimer"></div>
-                    </div>
-                </div>
-
-                <!-- 模型信息 -->
-                <div class="card shadow-sm">
-                    <div class="card-body">
-                        <div class="row text-center">
-                            <div class="col-md-3">
-                                <small class="text-muted">模型类型</small>
-                                <div id="modelType" class="fw-bold">--</div>
-                            </div>
-                            <div class="col-md-3">
-                                <small class="text-muted">分类类型</small>
-                                <div id="classType" class="fw-bold">--</div>
-                            </div>
-                            <div class="col-md-3">
-                                <small class="text-muted">模型准确率</small>
-                                <div id="modelAccuracy" class="fw-bold text-success">--</div>
-                            </div>
-                            <div class="col-md-3">
-                                <small class="text-muted">预测时间</small>
-                                <div id="predictionTime" class="fw-bold">--</div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- 初始提示 -->
-            <div id="initialPrompt" class="card shadow-sm">
-                <div class="card-body text-center py-5">
-                    <i class="fas fa-brain fa-4x text-muted mb-3"></i>
-                    <h4>AI智能多分类预测</h4>
-                    <p class="text-muted">
-                        基于 <strong>2258条真实病历</strong> 训练的机器学习模型<br>
-                        结合 <strong>8种天气因素</strong>，预测 <strong>多种疾病</strong> 风险
-                    </p>
-                    <div class="row justify-content-center mt-4">
-                        <div class="col-md-8">
-                            <div class="row text-center">
-                                <div class="col-4">
-                                    <i class="fas fa-temperature-high fa-2x text-danger mb-2"></i>
-                                    <p class="small mb-0">温度因素</p>
-                                </div>
-                                <div class="col-4">
-                                    <i class="fas fa-tint fa-2x text-primary mb-2"></i>
-                                    <p class="small mb-0">湿度因素</p>
-                                </div>
-                                <div class="col-4">
-                                    <i class="fas fa-wind fa-2x text-info mb-2"></i>
-                                    <p class="small mb-0">风速因素</p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <p class="text-muted mt-4">
-                        请在左侧设置参数，然后点击"开始预测"
-                    </p>
-                </div>
-            </div>
+            </section>
         </div>
     </div>
 </div>
-
-<style>
-.progress {
-    height: 25px;
-    border-radius: 12px;
-}
-.progress-bar {
-    border-radius: 12px;
-    transition: width 0.6s ease;
-}
-#riskGauge .display-1 {
-    font-size: 4rem;
-}
-.alert-light {
-    background-color: #f8f9fa;
-    border-left: 4px solid #007bff;
-}
-.priority-high {
-    border-left-color: #dc3545 !important;
-}
-.priority-medium {
-    border-left-color: #ffc107 !important;
-}
-.priority-low {
-    border-left-color: #28a745 !important;
-}
-</style>
-
-<script>
-// 更新滑块显示值
-document.getElementById('inputTemp').addEventListener('input', function() {
-    document.getElementById('tempValue').textContent = this.value + '°C';
-    // 自动更新最高最低温度
-    const temp = parseInt(this.value);
-    document.getElementById('inputTmin').value = temp - 5;
-    document.getElementById('inputTmax').value = temp + 5;
-});
-
-document.getElementById('inputHumidity').addEventListener('input', function() {
-    document.getElementById('humidityValue').textContent = this.value + '%';
-});
-
-document.getElementById('inputAQI').addEventListener('input', function() {
-    const aqi = parseInt(this.value);
-    const badge = document.getElementById('aqiValue');
-    badge.textContent = aqi;
-    if (aqi <= 50) {
-        badge.className = 'badge bg-success';
-    } else if (aqi <= 100) {
-        badge.className = 'badge bg-info';
-    } else if (aqi <= 150) {
-        badge.className = 'badge bg-warning';
-    } else {
-        badge.className = 'badge bg-danger';
-    }
-});
-
-document.getElementById('inputWindSpeed').addEventListener('input', function() {
-    document.getElementById('windSpeedValue').textContent = parseFloat(this.value).toFixed(1) + ' m/s';
-});
-
-document.getElementById('inputPrecipitation').addEventListener('input', function() {
-    document.getElementById('precipitationValue').textContent = this.value + ' mm';
-});
-
-document.getElementById('runPredictionBtn').addEventListener('click', runPrediction);
-
-function clearElement(element) {
-    while (element.firstChild) {
-        element.removeChild(element.firstChild);
-    }
-}
-
-function appendIconText(container, iconClass, text) {
-    const icon = document.createElement('i');
-    icon.className = iconClass;
-    container.appendChild(icon);
-    container.appendChild(document.createTextNode(text));
-}
-
-function populateList(listElement, items, emptyText) {
-    clearElement(listElement);
-    if (items && items.length) {
-        items.forEach(item => {
-            const li = document.createElement('li');
-            li.textContent = item;
-            listElement.appendChild(li);
-        });
-        return;
-    }
-
-    const li = document.createElement('li');
-    li.className = 'text-muted';
-    li.textContent = emptyText;
-    listElement.appendChild(li);
-}
-
-// 切换预测类型
-document.querySelectorAll('input[name="predType"]').forEach(function(radio) {
-    radio.addEventListener('change', function() {
-        if (this.value === 'individual') {
-            document.getElementById('individualParams').style.display = 'block';
-            document.getElementById('communityParams').style.display = 'none';
-        } else {
-            document.getElementById('individualParams').style.display = 'none';
-            document.getElementById('communityParams').style.display = 'block';
-        }
-    });
-});
-
-// 加载模型状态
-fetch('/api/ml/status')
-    .then(response => response.json())
-    .then(data => {
-        const modelStatus = document.getElementById('modelStatus');
-        if (data.success && data.status.loaded) {
-            const modelType = data.status.model_type || 'binary';
-            const typeText = modelType === 'multiclass' ? '多分类' : '二分类';
-            const classCount = data.status.classes ? data.status.classes.length : 2;
-            
-            modelStatus.className = 'badge bg-success';
-            const accuracy = data.status.accuracy ? (data.status.accuracy * 100).toFixed(1) : '--';
-            clearElement(modelStatus);
-            appendIconText(
-                modelStatus,
-                'fas fa-check-circle me-1',
-                '模型已加载 (' + typeText + ', ' + classCount + '类, 准确率:' + accuracy + '%)'
-            );
-        } else {
-            modelStatus.className = 'badge bg-danger';
-            clearElement(modelStatus);
-            appendIconText(modelStatus, 'fas fa-times-circle me-1', '模型加载失败');
-        }
-    });
-
-// 执行预测
-function runPrediction() {
-    const predType = document.querySelector('input[name="predType"]:checked').value;
-    
-    document.getElementById('initialPrompt').style.display = 'none';
-    document.getElementById('predictionResult').style.display = 'none';
-    document.getElementById('loadingResult').style.display = 'block';
-    
-    // 收集所有天气数据
-    const weatherData = {
-        temperature: parseInt(document.getElementById('inputTemp').value),
-        tmean: parseInt(document.getElementById('inputTemp').value),
-        tmin: parseInt(document.getElementById('inputTmin').value),
-        tmax: parseInt(document.getElementById('inputTmax').value),
-        humidity: parseInt(document.getElementById('inputHumidity').value),
-        aqi: parseInt(document.getElementById('inputAQI').value),
-        wind_speed: parseFloat(document.getElementById('inputWindSpeed').value),
-        precipitation: parseFloat(document.getElementById('inputPrecipitation').value),
-        month: parseInt(document.getElementById('inputMonth').value)
-    };
-    
-    let url, requestData;
-    
-    if (predType === 'individual') {
-        url = '/api/ml/predict';
-        requestData = {
-            age: parseInt(document.getElementById('inputAge').value),
-            gender: document.getElementById('inputGender').value,
-            ...weatherData
-        };
-    } else {
-        url = '/api/ml/predict-community';
-        requestData = {
-            community_id: parseInt(document.getElementById('inputCommunity').value),
-            ...weatherData
-        };
-    }
-    
-    fetch(url, {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(requestData)
-    })
-    .then(response => response.json())
-    .then(data => {
-        document.getElementById('loadingResult').style.display = 'none';
-        document.getElementById('predictionResult').style.display = 'block';
-        
-        if (data.success) {
-            displayResults(data, predType);
-        } else {
-            alert('预测失败: ' + (data.error || '未知错误'));
-        }
-    })
-    .catch(error => {
-        document.getElementById('loadingResult').style.display = 'none';
-        alert('请求失败: ' + error);
-    });
-}
-
-function displayResults(data, predType) {
-    // 风险分数 - 安全处理
-    const riskScore = data.risk_score !== undefined ? Math.round(data.risk_score) : 0;
-    const riskColor = data.risk_color || 'secondary';
-    const riskLevel = data.risk_level || '未知';
-    
-    document.getElementById('riskScoreDisplay').textContent = riskScore;
-    document.getElementById('riskScoreDisplay').className = 'display-1 fw-bold text-' + riskColor;
-    document.getElementById('riskLevelDisplay').textContent = riskLevel;
-    document.getElementById('riskLevelDisplay').className = 'h5 text-' + riskColor;
-    
-    // 风险因素
-    const factorsList = document.getElementById('riskFactorsList');
-    clearElement(factorsList);
-    (data.risk_factors || []).forEach(factor => {
-        const li = document.createElement('li');
-        li.className = 'mb-2';
-        const icon = document.createElement('i');
-        icon.className = 'fas fa-exclamation-triangle text-warning me-2';
-        li.appendChild(icon);
-        li.appendChild(document.createTextNode(factor));
-        factorsList.appendChild(li);
-    });
-    
-    // 天气影响分析
-    if (data.weather_impact) {
-        const impact = data.weather_impact;
-        const impactLevel = document.getElementById('weatherImpactLevel');
-        clearElement(impactLevel);
-        const impactBadge = document.createElement('span');
-        impactBadge.className = 'badge bg-' + (impact.color || 'secondary');
-        impactBadge.textContent = impact.level || '--';
-        impactLevel.appendChild(impactBadge);
-        
-        // 天气条件
-        const conditionsList = document.getElementById('weatherConditionsList');
-        clearElement(conditionsList);
-        if (data.weather_conditions) {
-            const wc = data.weather_conditions;
-            const formatNum = (val, decimals = 1) => {
-                if (val === null || val === undefined) return '--';
-                return typeof val === 'number' ? val.toFixed(decimals) : val;
-            };
-            const conditions = [
-                {
-                    icon: 'fas fa-thermometer-half text-danger me-1',
-                    label: '温度',
-                    value: formatNum(wc.temperature, 1) + '°C'
-                },
-                {
-                    icon: 'fas fa-temperature-low text-info me-1',
-                    label: '体感温度',
-                    value: formatNum(wc.feels_like, 1) + '°C'
-                },
-                {
-                    icon: 'fas fa-tint text-primary me-1',
-                    label: '湿度',
-                    value: formatNum(wc.humidity, 0) + '%'
-                },
-                {
-                    icon: 'fas fa-wind text-secondary me-1',
-                    label: '风速',
-                    value: formatNum(wc.wind_speed, 1) + 'm/s'
-                },
-                {
-                    icon: 'fas fa-cloud-rain text-info me-1',
-                    label: '降水',
-                    value: formatNum(wc.precipitation, 1) + 'mm'
-                },
-                {
-                    icon: 'fas fa-calendar me-1',
-                    label: '季节',
-                    value: wc.season || '--'
-                }
-            ];
-
-            conditions.forEach(item => {
-                const li = document.createElement('li');
-                const icon = document.createElement('i');
-                icon.className = item.icon;
-                li.appendChild(icon);
-                li.appendChild(document.createTextNode(item.label + ': ' + item.value));
-                conditionsList.appendChild(li);
-            });
-        }
-        
-        // 天气因素
-        const factorsList2 = document.getElementById('weatherFactorsList');
-        clearElement(factorsList2);
-        (impact.factors || []).forEach(f => {
-            const li = document.createElement('li');
-            const icon = document.createElement('i');
-            icon.className = 'fas fa-check-circle text-' + (impact.color || 'info') + ' me-1';
-            li.appendChild(icon);
-            li.appendChild(document.createTextNode(f));
-            factorsList2.appendChild(li);
-        });
-    }
-    
-    // 疾病预测
-    const diseaseDiv = document.getElementById('diseasePredictions');
-    clearElement(diseaseDiv);
-    
-    const predictions = data.predictions || data.disease_risks || [];
-    predictions.forEach((pred, index) => {
-        // 安全获取概率值，处理 undefined/null 情况
-        let prob = 0;
-        if (pred.probability !== undefined && pred.probability !== null) {
-            prob = pred.probability * 100;
-        } else if (pred.risk !== undefined && pred.risk !== null) {
-            prob = pred.risk;
-        } else if (pred.percentage) {
-            prob = parseFloat(pred.percentage) || 0;
-        }
-        
-        let colorClass;
-        if (prob > 40) {
-            colorClass = 'danger';
-        } else if (prob > 25) {
-            colorClass = 'warning';
-        } else if (prob > 15) {
-            colorClass = 'info';
-        } else {
-            colorClass = 'success';
-        }
-        
-        const row = document.createElement('div');
-        row.className = 'mb-3';
-        const header = document.createElement('div');
-        header.className = 'd-flex justify-content-between mb-1';
-        const nameSpan = document.createElement('span');
-        nameSpan.textContent = pred.disease || '未知疾病';
-        const valueSpan = document.createElement('span');
-        valueSpan.className = 'text-' + colorClass;
-        valueSpan.textContent = prob.toFixed(1) + '%';
-        header.appendChild(nameSpan);
-        header.appendChild(valueSpan);
-
-        const progress = document.createElement('div');
-        progress.className = 'progress';
-        const bar = document.createElement('div');
-        bar.className = 'progress-bar bg-' + colorClass;
-        bar.style.width = Math.min(prob, 100) + '%';
-        progress.appendChild(bar);
-
-        row.appendChild(header);
-        row.appendChild(progress);
-        diseaseDiv.appendChild(row);
-    });
-    
-    // 健康建议
-    const recList = document.getElementById('recommendationsList');
-    clearElement(recList);
-    (data.recommendations || []).forEach(rec => {
-        const card = document.createElement('div');
-        const priority = rec.priority || 'low';
-        card.className = 'alert alert-light mb-2 priority-' + priority;
-        if (typeof rec === 'object' && rec !== null) {
-            if (priority === 'high' || priority === 'medium') {
-                const badge = document.createElement('span');
-                badge.className = 'badge ' + (priority === 'high' ? 'bg-danger' : 'bg-warning') + ' me-2';
-                badge.textContent = priority === 'high' ? '重要' : '注意';
-                card.appendChild(badge);
-            }
-
-            const strong = document.createElement('strong');
-            strong.textContent = (rec.category || '') + ':';
-            card.appendChild(strong);
-            card.appendChild(document.createTextNode(' ' + (rec.advice || '')));
-        } else {
-            const icon = document.createElement('i');
-            icon.className = 'fas fa-check-circle text-success me-2';
-            card.appendChild(icon);
-            card.appendChild(document.createTextNode(rec));
-        }
-        recList.appendChild(card);
-    });
-
-    // 可解释输出
-    const explainCard = document.getElementById('explainCard');
-    if (data.explain) {
-        const reasons = data.explain.reasons || [];
-        const actions = data.explain.actions || [];
-        const escalation = data.explain.escalation || [];
-        populateList(document.getElementById('explainReasons'), reasons, '暂无明显触发原因');
-        populateList(document.getElementById('explainActions'), actions, '保持规律作息');
-        populateList(document.getElementById('explainEscalation'), escalation, '出现严重不适请及时就医');
-        document.getElementById('explainDisclaimer').textContent =
-            data.explain.disclaimer || '风险提示不是诊断，紧急情况优先就医。';
-        explainCard.style.display = 'block';
-    } else {
-        explainCard.style.display = 'none';
-    }
-    
-    // 模型信息
-    if (data.model_info) {
-        document.getElementById('modelType').textContent = data.model_info.model_type;
-        document.getElementById('classType').textContent = 
-            data.model_info.classification_type === 'multiclass' ? 
-            `多分类(${data.model_info.total_classes}类)` : '二分类';
-        document.getElementById('modelAccuracy').textContent = data.model_info.accuracy;
-    } else if (data.model_accuracy) {
-        document.getElementById('modelAccuracy').textContent = data.model_accuracy;
-    }
-    document.getElementById('predictionTime').textContent = new Date().toLocaleTimeString();
-}
-</script>
 {% endblock %}

--- a/templates/ml_prediction.html
+++ b/templates/ml_prediction.html
@@ -20,24 +20,24 @@
                     <select name="member_id" class="form-select">
                         <option value="">我本人</option>
                         {% for m in (family_members or []) %}
-                        <option value="{{ m.id }}" {% if request.args.get('member_id')|int == m.id %}selected{% endif %}>{{ m.name }}</option>
+                        <option value="{{ m.id }}" {% if form_state and form_state.member_id|string == m.id|string %}selected{% endif %}>{{ m.name }}</option>
                         {% endfor %}
                     </select>
                 </div>
                 <div class="mb-3">
                     <label class="form-label">所在地</label>
-                    <input type="text" class="form-control" name="location" value="{{ current_location or '' }}" list="locOpts">
+                    <input type="text" class="form-control" name="location" value="{{ form_state.location if form_state else (current_location or '') }}" list="locOpts">
                     <datalist id="locOpts">{% for loc in (location_options or []) %}<option value="{{ loc }}"></option>{% endfor %}</datalist>
                 </div>
                 <div class="mb-3">
                     <label class="form-label">年龄</label>
-                    <input type="number" class="form-control" name="age" value="{{ age or 65 }}" min="1" max="120">
+                    <input type="number" class="form-control" name="age" value="{{ form_state.age if form_state else (age or 65) }}" min="1" max="120">
                 </div>
                 <div class="mb-3">
                     <label class="form-label">已有慢病(可多选)</label>
                     <select name="chronic" class="form-select" multiple size="6">
-                        {% for c in ['高血压','糖尿病','冠心病','慢阻肺','脑卒中史','慢性肾病','骨关节病'] %}
-                        <option value="{{ c }}">{{ c }}</option>
+                        {% for c in ['高血压','糖尿病','冠心病','慢阻肺','哮喘','脑卒中','慢性肾病','关节炎'] %}
+                        <option value="{{ c }}" {% if form_state and c in (form_state.chronic or []) %}selected{% endif %}>{{ c }}</option>
                         {% endfor %}
                     </select>
                     <div class="form-text">按住 Ctrl/⌘ 多选</div>
@@ -47,6 +47,11 @@
         </div>
 
         <div class="col-lg-8">
+            {% if prediction_error %}
+            <section class="yl-section yl-fade-up yl-fade-up-d2 mb-3">
+                <div class="alert alert-danger mb-0">{{ prediction_error }}</div>
+            </section>
+            {% endif %}
             {% if prediction %}
             <section class="yl-section yl-fade-up yl-fade-up-d2 mb-3">
                 <h4 style="font-size:1.1rem;">未来 3 天风险预测</h4>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,99 +1,104 @@
 {% extends "base.html" %}
 
-{% block title %}注册 - 天气健康风险预测系统{% endblock %}
+{% block title %}注册 · 宜老天气通{% endblock %}
+{% block body_class %}register-page{% endblock %}
 
 {% block content %}
-<div class="container">
-    <div class="row justify-content-center align-items-center" style="min-height: 80vh;">
-        <div class="col-md-7 col-lg-6">
-            <div class="text-center mb-4">
-                <div class="d-inline-flex align-items-center justify-content-center bg-success bg-opacity-10 rounded-circle mb-3" style="width: 64px; height: 64px;">
-                    <i class="bi bi-person-plus-fill text-success" style="font-size: 2rem;"></i>
+<div class="container auth-shell">
+    <div class="row justify-content-center">
+        <div class="col-md-10 col-lg-8 col-xl-7">
+
+            <section class="auth-panel yl-fade-up">
+                <div class="auth-panel-head text-center">
+                    <div class="auth-icon-wrap" style="background: linear-gradient(135deg, #4E8B49, #6aaa5f); box-shadow: 0 8px 20px rgba(78,139,73,.25);">
+                        <i class="bi bi-person-plus-fill"></i>
+                    </div>
+                    <h2>注册账号</h2>
+                    <p>几步就好——大多数字段都可选</p>
                 </div>
-                <h2 class="fw-bold mb-2">注册账户</h2>
-                <p class="text-secondary mb-0">创建您的健康风险预测账户</p>
-            </div>
-            
-            <div class="card shadow-sm">
-                <div class="card-body p-4">
-                    <form method="POST" action="{{ url_for('public.register') }}">
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <div class="row">
-                            <div class="col-md-6 mb-3">
-                                <label for="username" class="form-label">
-                                    <i class="bi bi-person"></i> 用户名 *
-                                </label>
-                                <input type="text" class="form-control" id="username" name="username" required>
-                            </div>
-                            <div class="col-md-6 mb-3">
-                                <label for="email" class="form-label">
-                                    <i class="bi bi-envelope"></i> 邮箱
-                                </label>
-                                <input type="email" class="form-control" id="email" name="email">
-                            </div>
-                        </div>
 
-                        <div class="row">
-                            <div class="col-md-6 mb-3">
-                                <label for="password" class="form-label">
-                                    <i class="bi bi-lock"></i> 密码 *
-                                </label>
-                                <input type="password" class="form-control" id="password" name="password" required>
-                            </div>
-                            <div class="col-md-6 mb-3">
-                                <label for="confirm_password" class="form-label">
-                                    <i class="bi bi-lock-fill"></i> 确认密码 *
-                                </label>
-                                <input type="password" class="form-control" id="confirm_password" name="confirm_password" required>
-                            </div>
-                        </div>
+                <div class="card auth-form-card">
+                    <div class="card-body p-4 p-md-5">
+                        <form method="POST" action="{{ url_for('public.register') }}">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
-                        <div class="row">
-                            <div class="col-md-4 mb-3">
-                                <label for="age" class="form-label">
-                                    <i class="bi bi-calendar"></i> 年龄
-                                </label>
-                                <input type="number" class="form-control" id="age" name="age" min="1" max="120">
+                            {# 基础 #}
+                            <div class="mb-3" style="font-size:.8rem; color:var(--yl-muted); text-transform:uppercase; letter-spacing:.05em; font-weight:600;">
+                                账号信息
                             </div>
-                            <div class="col-md-4 mb-3">
-                                <label for="gender" class="form-label">
-                                    <i class="bi bi-gender-ambiguous"></i> 性别
-                                </label>
-                                <select class="form-select" id="gender" name="gender">
-                                    <option value="">请选择</option>
-                                    <option value="男性">男性</option>
-                                    <option value="女性">女性</option>
-                                </select>
-                            </div>
-                            <div class="col-md-4 mb-3">
-                                <label for="community" class="form-label">
-                                    <i class="bi bi-geo-alt"></i> 所属社区
-                                </label>
-                                <select class="form-select" id="community" name="community">
-                                    <option value="">请选择</option>
-                                    {% for comm in communities %}
-                                        <option value="{{ comm.name }}">{{ comm.name }}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                        </div>
 
-                        <div class="alert alert-info">
-                            <i class="bi bi-info-circle"></i> 提示：完善个人信息有助于系统提供更精准的健康风险评估
-                        </div>
+                            <div class="row g-3 mb-4">
+                                <div class="col-md-6">
+                                    <label for="username" class="form-label">
+                                        <i class="bi bi-person me-1"></i>用户名 <span style="color:var(--yl-danger);">*</span>
+                                    </label>
+                                    <input type="text" class="form-control" id="username" name="username" required>
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="email" class="form-label">
+                                        <i class="bi bi-envelope me-1"></i>邮箱
+                                    </label>
+                                    <input type="email" class="form-control" id="email" name="email" placeholder="可选">
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="password" class="form-label">
+                                        <i class="bi bi-lock me-1"></i>密码 <span style="color:var(--yl-danger);">*</span>
+                                    </label>
+                                    <input type="password" class="form-control" id="password" name="password" required>
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="confirm_password" class="form-label">
+                                        <i class="bi bi-lock-fill me-1"></i>确认密码 <span style="color:var(--yl-danger);">*</span>
+                                    </label>
+                                    <input type="password" class="form-control" id="confirm_password" name="confirm_password" required>
+                                </div>
+                            </div>
 
-                        <div class="d-grid mb-3">
-                            <button type="submit" class="btn btn-success btn-lg">
-                                注册
-                            </button>
-                        </div>
-                        <div class="text-center">
-                            <span class="text-secondary small">已有账号？</span>
-                            <a href="{{ url_for('public.login') }}" class="text-decoration-none small fw-semibold">立即登录</a>
-                        </div>
-                    </form>
+                            {# 画像 #}
+                            <div class="mb-3" style="font-size:.8rem; color:var(--yl-muted); text-transform:uppercase; letter-spacing:.05em; font-weight:600;">
+                                基础画像 <span style="text-transform:none; letter-spacing:0; color:var(--yl-muted); font-weight:400;">· 选填,用于更贴合的风险评估</span>
+                            </div>
+
+                            <div class="row g-3">
+                                <div class="col-md-4">
+                                    <label for="age" class="form-label"><i class="bi bi-calendar me-1"></i>年龄</label>
+                                    <input type="number" class="form-control" id="age" name="age" min="1" max="120" placeholder="可选">
+                                </div>
+                                <div class="col-md-4">
+                                    <label for="gender" class="form-label"><i class="bi bi-gender-ambiguous me-1"></i>性别</label>
+                                    <select class="form-select" id="gender" name="gender">
+                                        <option value="">请选择</option>
+                                        <option value="男性">男性</option>
+                                        <option value="女性">女性</option>
+                                    </select>
+                                </div>
+                                <div class="col-md-4">
+                                    <label for="community" class="form-label"><i class="bi bi-geo-alt me-1"></i>所属社区</label>
+                                    <select class="form-select" id="community" name="community">
+                                        <option value="">请选择</option>
+                                        {% for comm in communities %}
+                                            <option value="{{ comm.name }}">{{ comm.name }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div class="alert alert-info mt-4 mb-4">
+                                <i class="bi bi-info-circle me-1"></i>填写年龄和慢病信息不是必需的,但能让风险评估更贴近你的情况。
+                            </div>
+
+                            <div class="d-grid">
+                                <button type="submit" class="btn btn-primary btn-lg">创建账号</button>
+                            </div>
+
+                            <div class="text-center mt-3">
+                                <span class="text-muted" style="font-size:.88rem;">已有账号?</span>
+                                <a href="{{ url_for('public.login') }}" class="text-decoration-none fw-semibold" style="font-size:.88rem;">立即登录</a>
+                            </div>
+                        </form>
+                    </div>
                 </div>
-            </div>
+            </section>
         </div>
     </div>
 </div>

--- a/templates/user_dashboard.html
+++ b/templates/user_dashboard.html
@@ -1,631 +1,206 @@
 {% extends "base.html" %}
 
-{% block title %}我的主页 - 天气健康风险预测系统{% endblock %}
+{% block title %}我的主页 · 宜老天气通{% endblock %}
+{% block body_class %}dashboard-page{% endblock %}
 
 {% block content %}
-<div class="container-fluid">
-    <div class="row">
-        <div class="col-12 mb-4">
-            <h2>
-                <i class="bi bi-house-door"></i> 我的健康仪表板
-                {% if demo_mode %}
-                    <span class="badge bg-warning-subtle text-warning border ms-2">演示模式</span>
+{% set risk_score = heat_result.risk_score if heat_result else none %}
+{% set risk_level = heat_result.risk_level if heat_result else none %}
+<div class="yl-dashboard-shell">
+
+    {# ============== 今日一屏 ============== #}
+    <section class="yl-hero-today yl-fade-up">
+        <div class="yl-hero-today-grid">
+            <div class="yl-hero-copy">
+                <div class="today-label"><i class="bi bi-sun"></i> 今日 · {{ today_date or '今天' }}</div>
+                <div class="today-location"><i class="bi bi-geo-alt"></i> {{ current_location or '未设置' }}</div>
+                <div class="today-temp">
+                    {{ weather.temperature if weather and weather.temperature is not none else '--' }}<span class="unit">°C</span>
+                </div>
+                <div class="today-condition">
+                    {{ weather.weather_condition if weather and weather.weather_condition else '--' }}
+                    {% if weather and weather.temperature_max is not none %}
+                        · 最高 {{ weather.temperature_max }}° / 最低 {{ weather.temperature_min if weather.temperature_min is not none else '--' }}°
+                    {% endif %}
+                </div>
+
+                <div class="today-meta">
+                    <div class="today-meta-item">
+                        <div class="k">湿度</div>
+                        <div class="v">{{ weather.humidity if weather and weather.humidity is not none else '--' }}%</div>
+                    </div>
+                    <div class="today-meta-item">
+                        <div class="k">气压</div>
+                        <div class="v">{{ weather.pressure if weather and weather.pressure is not none else '--' }} hPa</div>
+                    </div>
+                    <div class="today-meta-item">
+                        <div class="k">风速</div>
+                        <div class="v">{{ weather.wind_speed if weather and weather.wind_speed is not none else '--' }} m/s</div>
+                    </div>
+                    <div class="today-meta-item">
+                        <div class="k">AQI</div>
+                        <div class="v">{{ weather.aqi if weather and weather.aqi is not none else '--' }}</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="yl-hero-side">
+                <div class="risk-dial">
+                    <div class="score" {% if risk_score and risk_score >= 70 %}style="color:var(--yl-risk-high);"{% elif risk_score and risk_score >= 40 %}style="color:var(--yl-risk-mid);"{% else %}style="color:var(--yl-success);"{% endif %}>
+                        {{ risk_score if risk_score is not none else '--' }}
+                    </div>
+                    <div class="label">今日健康风险</div>
+                    <div class="mt-2">
+                        {% if risk_level in ['high', 'extreme'] %}
+                            <span class="badge bg-danger-subtle">高风险</span>
+                        {% elif risk_level == 'medium' %}
+                            <span class="badge bg-warning-subtle">中等风险</span>
+                        {% else %}
+                            <span class="badge bg-success-subtle">低风险</span>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <div class="yl-dash-grid">
+        {# 预警 #}
+        {% if alerts %}
+        <section class="yl-section yl-fade-up yl-fade-up-d1 mb-3 yl-panel yl-panel-wide yl-panel-alerts">
+            <div class="section-heading compact">
+                <span class="section-kicker"><i class="bi bi-exclamation-triangle"></i> 进行中的预警</span>
+                <h3 style="font-size:1.2rem; margin:4px 0 0;">共 {{ alerts|length }} 条需要关注</h3>
+            </div>
+            <div class="yl-alert-list mt-3">
+                {% for a in alerts %}
+                <div class="yl-alert-item {% if a.level == 'high' %}level-high{% endif %}">
+                    <span class="dot"></span>
+                    <div class="body">
+                        <strong>{{ a.title or a.event }}</strong>
+                        <div class="meta">{{ a.start_time or '' }} · {{ a.region or current_location }}</div>
+                        {% if a.description %}<div class="mt-1" style="font-size:.88rem; color:var(--yl-ink-soft);">{{ a.description }}</div>{% endif %}
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </section>
+        {% endif %}
+
+        {# 今日行动清单 #}
+        <section class="yl-section yl-fade-up yl-fade-up-d2 mb-3 yl-panel yl-panel-actions">
+            <div class="section-heading compact d-flex justify-content-between align-items-center flex-wrap gap-3 yl-section-head">
+                <div>
+                    <span class="section-kicker">给你的一些建议</span>
+                    <h3 style="font-size:1.2rem; margin:4px 0 0;">今天可以做的 4 件小事</h3>
+                </div>
+                <a class="btn btn-sm btn-outline-primary" href="{{ url_for('public.action_check') }}">打卡 <i class="bi bi-arrow-right"></i></a>
+            </div>
+            <div class="yl-action-list mt-3">
+                {% if heat_actions %}
+                    {% for act in heat_actions %}
+                    <div class="yl-action">
+                        <i class="bi bi-{{ act.icon or 'check-circle' }}"></i>
+                        <div>
+                            <strong>{{ act.title }}</strong>
+                            <div class="detail">{{ act.detail }}</div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                {% else %}
+                    {# 兜底,保证页面始终有内容可看 #}
+                    <div class="yl-action"><i class="bi bi-cup-hot"></i><div><strong>多喝温水</strong><div class="detail">建议 1.5L,少量多次</div></div></div>
+                    <div class="yl-action"><i class="bi bi-sun"></i><div><strong>避开午后外出</strong><div class="detail">11:00–15:00 紫外线强</div></div></div>
+                    <div class="yl-action"><i class="bi bi-heart-pulse"></i><div><strong>关注血压</strong><div class="detail">早晚各测一次</div></div></div>
+                    <div class="yl-action"><i class="bi bi-capsule"></i><div><strong>按时服药</strong><div class="detail">别漏降压药</div></div></div>
                 {% endif %}
-            </h2>
-            <p class="text-muted">欢迎回来，{{ current_user.username }}！</p>
-            {% if is_guest %}
-                <div class="alert alert-warning mb-0">
-                    <i class="bi bi-info-circle me-2"></i>
-                    当前为游客模式，评估记录不会保存，建议注册/登录获得完整功能。
-                </div>
-            {% endif %}
-        </div>
-    </div>
-
-    <div class="row">
-        <!-- 当前天气卡片 -->
-        <div class="col-md-4 mb-4">
-            <div class="card shadow-sm h-100">
-                <div class="card-header bg-primary text-white">
-                    <h5 class="mb-0"><i class="bi bi-cloud-sun"></i> 当前天气</h5>
-                </div>
-                <div class="card-body">
-                    {% if weather %}
-                        <div class="text-center mb-2">
-                            <span class="badge bg-info-subtle text-info border">来源：{{ weather_source_city }}</span>
-                            {% if weather_is_mock %}
-                                <span class="badge bg-warning-subtle text-warning border">模拟数据</span>
-                            {% endif %}
-                        </div>
-                        <div class="text-center mb-3">
-                            <h2 class="display-3">{{ weather.temperature|round(1) }}°C</h2>
-                            <p class="fs-5 text-muted">{{ weather.weather_condition }}</p>
-                        </div>
-                        <hr>
-                        <div class="row text-center">
-                            <div class="col-6 mb-2">
-                                <i class="bi bi-thermometer-high text-danger"></i>
-                                <p class="mb-0 small">最高温度</p>
-                                <p class="fw-bold">{{ weather.temperature_max|round(1) }}°C</p>
-                            </div>
-                            <div class="col-6 mb-2">
-                                <i class="bi bi-thermometer-low text-info"></i>
-                                <p class="mb-0 small">最低温度</p>
-                                <p class="fw-bold">{{ weather.temperature_min|round(1) }}°C</p>
-                            </div>
-                            <div class="col-6 mb-2">
-                                <i class="bi bi-droplet text-primary"></i>
-                                <p class="mb-0 small">湿度</p>
-                                <p class="fw-bold">{{ weather.humidity|round(1) }}%</p>
-                            </div>
-                            <div class="col-6 mb-2">
-                                <i class="bi bi-wind text-success"></i>
-                                <p class="mb-0 small">风速</p>
-                                <p class="fw-bold">{{ weather.wind_speed|round(1) }} m/s</p>
-                            </div>
-                        </div>
-                        {% if weather.is_extreme %}
-                            <div class="alert alert-danger mt-3">
-                                <i class="bi bi-exclamation-triangle-fill"></i> 
-                                <strong>极端天气预警</strong><br>
-                                {{ weather.extreme_type }}
-                            </div>
-                        {% endif %}
-                    {% else %}
-                        <p class="text-muted">暂无天气数据</p>
-                    {% endif %}
-                </div>
             </div>
-        </div>
+        </section>
 
-        <!-- 健康风险评估卡片 -->
-        <div class="col-md-4 mb-4">
-            <div class="card shadow-sm h-100">
-                <div class="card-header bg-success text-white">
-                    <h5 class="mb-0"><i class="bi bi-heart-pulse"></i> 健康风险评估</h5>
-                </div>
-                <div class="card-body">
-                    {% if assessment %}
-                        <div class="text-center mb-3">
-                            {% if assessment.risk_level == '高风险' %}
-                                <div class="badge bg-danger fs-3 p-3">{{ assessment.risk_level }}</div>
-                            {% elif assessment.risk_level == '中风险' %}
-                                <div class="badge bg-warning fs-3 p-3">{{ assessment.risk_level }}</div>
-                            {% else %}
-                                <div class="badge bg-success fs-3 p-3">{{ assessment.risk_level }}</div>
-                            {% endif %}
-                        </div>
-                        <div class="progress mb-3" style="height: 25px;">
-                            {% if assessment.risk_score < 30 %}
-                                <div class="progress-bar bg-success" style="width: {{ assessment.risk_score }}%">
-                            {% elif assessment.risk_score < 60 %}
-                                <div class="progress-bar bg-warning" style="width: {{ assessment.risk_score }}%">
-                            {% else %}
-                                <div class="progress-bar bg-danger" style="width: {{ assessment.risk_score }}%">
-                            {% endif %}
-                                    {{ assessment.risk_score|round(1) }}
-                                </div>
-                        </div>
-                        <p class="text-muted small">评估时间：{{ assessment.assessment_date.strftime('%Y-%m-%d %H:%M') }}</p>
-                        <a href="{{ url_for('user.health_assessment') }}" class="btn btn-outline-success w-100">
-                            <i class="bi bi-arrow-repeat"></i> 重新评估
-                        </a>
-                    {% else %}
-                        <p class="text-center text-muted my-5">尚未进行健康风险评估</p>
-                        <a href="{{ url_for('user.health_assessment') }}" class="btn btn-success w-100">
-                            <i class="bi bi-clipboard-pulse"></i> 开始评估
-                        </a>
-                    {% endif %}
-                </div>
+        {# 快捷入口 #}
+        <section class="yl-section yl-fade-up yl-fade-up-d1 mb-3 yl-panel yl-panel-shortcuts">
+            <div class="section-heading compact">
+                <span class="section-kicker">常用入口</span>
+                <h4 style="font-size:1.05rem; margin:4px 0 0;">快捷入口</h4>
             </div>
-        </div>
-
-        <!-- 天气预警卡片 -->
-        <div class="col-md-4 mb-4">
-            <div class="card shadow-sm h-100">
-                <div class="card-header bg-warning text-dark">
-                    <h5 class="mb-0"><i class="bi bi-exclamation-triangle"></i> 天气预警</h5>
-                </div>
-                <div class="card-body" style="max-height: 400px; overflow-y: auto;">
-                    {% if alerts %}
-                        {% for alert in alerts %}
-                            <div class="alert alert-warning mb-2">
-                                <h6 class="alert-heading">
-                                    <i class="bi bi-geo-alt"></i> {{ alert.location }}
-                                </h6>
-                                <p class="mb-1"><strong>{{ alert.alert_type }}</strong></p>
-                                <p class="mb-0 small text-muted">{{ alert.alert_date.strftime('%m-%d %H:%M') }}</p>
-                            </div>
-                        {% endfor %}
-                    {% else %}
-                        <p class="text-center text-muted my-5">暂无预警信息</p>
-                    {% endif %}
-                </div>
+            <div class="yl-feature-grid mt-3">
+                <a href="{{ url_for('health.family_members') }}" class="yl-feature">
+                    <div class="yl-feature-icon"><i class="bi bi-people"></i></div>
+                    <div><h5>照护工作台</h5><p>管理家人</p></div>
+                </a>
+                <a href="{{ url_for('tools.ml_prediction') }}" class="yl-feature">
+                    <div class="yl-feature-icon"><i class="bi bi-cpu"></i></div>
+                    <div><h5>AI 疾病预测</h5><p>基于天气的个性化预测</p></div>
+                </a>
+                <a href="{{ url_for('tools.chronic_risk') }}" class="yl-feature">
+                    <div class="yl-feature-icon"><i class="bi bi-heart-pulse"></i></div>
+                    <div><h5>慢病风险评估</h5><p>评估当前慢病状态</p></div>
+                </a>
+                <a href="{{ url_for('user.health_assessment') }}" class="yl-feature">
+                    <div class="yl-feature-icon"><i class="bi bi-clipboard-pulse"></i></div>
+                    <div><h5>健康评估</h5><p>完成自评问卷</p></div>
+                </a>
+                <a href="{{ url_for('public.cooling_resources') }}" class="yl-feature">
+                    <div class="yl-feature-icon"><i class="bi bi-snow2"></i></div>
+                    <div><h5>避暑资源</h5><p>周边纳凉点</p></div>
+                </a>
             </div>
-        </div>
-    </div>
+        </section>
 
-    <!-- 行动型热健康预警 -->
-    <div class="row">
-        <div class="col-12 mb-4">
-            {% set heat_color = 'dark' if heat_risk_label == '极高' else 'danger' if heat_risk_label == '高风险' else 'warning' if heat_risk_label == '中风险' else 'success' %}
-            <div class="card shadow-sm">
-                <div class="card-header bg-{{ heat_color }} text-white">
-                    <h5 class="mb-0"><i class="bi bi-thermometer-sun"></i> 行动型热健康预警</h5>
+        {# 7 日预测 #}
+        <section class="yl-section yl-fade-up yl-fade-up-d3 yl-panel yl-panel-forecast">
+            <div class="section-heading compact d-flex justify-content-between align-items-center flex-wrap gap-3 yl-section-head">
+                <div>
+                    <span class="section-kicker">7 日健康预测</span>
+                    <h3 style="font-size:1.2rem; margin:4px 0 0;">接下来一周的风险趋势</h3>
                 </div>
-                <div class="card-body">
-                    <div class="d-flex flex-wrap align-items-center gap-3 mb-3">
-                        <span class="badge bg-{{ heat_color }} fs-6">{{ heat_risk_label }}</span>
-                        {% if heat_result %}
-                            <span class="text-muted small">综合评分：{{ heat_result.risk_score if heat_result.risk_score is not none else '--' }}</span>
-                            <span class="text-muted small">体感热：{{ heat_result.heat_index if heat_result.heat_index is not none else '--' }}</span>
-                            <span class="text-muted small">夜间最低：{{ heat_result.night_min if heat_result.night_min is not none else '--' }}°C</span>
-                            <span class="text-muted small">连续高温：{{ heat_result.consecutive_hot_days if heat_result.consecutive_hot_days is not none else 0 }}天</span>
-                        {% endif %}
-                        <span class="text-muted small">提示：仅提供通用热健康行动建议</span>
+                <a class="btn btn-sm btn-outline-primary" href="{{ url_for('tools.forecast_7day') }}">查看详情 <i class="bi bi-arrow-right"></i></a>
+            </div>
+
+            <div class="yl-forecast-row mt-3">
+                {% if forecast_days %}
+                    {% for d in forecast_days %}
+                    <div class="day">
+                        <div class="dow">{{ d.dow }}</div>
+                        <div class="t">{{ d.temp_high }}° / {{ d.temp_low }}°</div>
+                        <div class="mt-1" style="font-size:.78rem; color:var(--yl-muted);">{{ d.condition }}</div>
+                        <span class="rk {{ d.risk_level or 'low' }}">{{ d.risk_label or '低' }}</span>
                     </div>
-                    <div class="d-flex flex-wrap align-items-center gap-2 mb-3" id="heatRiskAdjustDashboard" data-heat-risk-score="{{ heat_result.risk_score if heat_result and heat_result.risk_score is not none else 0 }}">
-                        <span class="text-muted small">个人阈值</span>
-                        <div class="btn-group btn-group-sm" role="group" aria-label="Heat threshold adjust">
-                            <input type="radio" class="btn-check" name="heatAdjustDashboard" id="heatAdjustDashLow" value="-0.1" data-heat-adjust>
-                            <label class="btn btn-outline-secondary" for="heatAdjustDashLow">-0.1</label>
-                            <input type="radio" class="btn-check" name="heatAdjustDashboard" id="heatAdjustDashMid" value="0" data-heat-adjust>
-                            <label class="btn btn-outline-secondary" for="heatAdjustDashMid">0</label>
-                            <input type="radio" class="btn-check" name="heatAdjustDashboard" id="heatAdjustDashHigh" value="0.1" data-heat-adjust>
-                            <label class="btn btn-outline-secondary" for="heatAdjustDashHigh">+0.1</label>
-                        </div>
-                        <span class="badge bg-secondary" id="heatAdjustedBadgeDashboard">--</span>
-                        <span class="text-muted small">仅保存在本机</span>
+                    {% endfor %}
+                {% else %}
+                    {% for d in [('今','32°/25°','多云','mid','中'),('明','34°/26°','晴','high','高'),('三','30°/24°','雷阵雨','mid','中'),('四','29°/23°','小雨','low','低'),('五','31°/24°','多云','low','低'),('六','33°/25°','晴','mid','中'),('日','34°/26°','晴','high','高')] %}
+                    <div class="day">
+                        <div class="dow">{{ d[0] }}</div>
+                        <div class="t">{{ d[1] }}</div>
+                        <div class="mt-1" style="font-size:.78rem; color:var(--yl-muted);">{{ d[2] }}</div>
+                        <span class="rk {{ d[3] }}">{{ d[4] }}</span>
                     </div>
-                    <div class="row">
-                        {% for item in heat_actions %}
-                            <div class="col-md-4 mb-2">
-                                <div class="d-flex align-items-start">
-                                    <i class="bi bi-check-circle-fill text-success me-2 mt-1"></i>
-                                    <div>
-                                        <strong>{{ item.title }}</strong>
-                                        <div class="text-muted small">{{ item.detail }}</div>
-                                    </div>
-                                </div>
-                            </div>
-                        {% endfor %}
+                    {% endfor %}
+                {% endif %}
+            </div>
+        </section>
+
+        {# 家人概览 #}
+        {% if family_members %}
+        <section class="yl-section yl-fade-up yl-fade-up-d2 yl-panel yl-panel-family">
+            <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+                <h4 style="font-size:1.05rem; margin:0;">关注的家人</h4>
+                <a class="btn btn-sm btn-link p-0" href="{{ url_for('health.family_members') }}">全部 →</a>
+            </div>
+            <div class="list-group">
+                {% for m in family_members[:4] %}
+                <a href="{{ url_for('health.family_member_detail', member_id=m.id) }}" class="list-group-item d-flex align-items-center gap-3 border-0 rounded mb-2" style="background:var(--yl-orange-50);">
+                    <div class="member-avatar" style="width:40px; height:40px; font-size:1rem;">{{ m.name[:1] }}</div>
+                    <div class="flex-grow-1 min-w-0">
+                        <div class="fw-semibold text-truncate">{{ m.name }}</div>
+                        <div class="text-muted" style="font-size:.8rem;">{{ m.age }}岁 · {{ m.location or '未设定所在地' }}</div>
                     </div>
-                    <div class="d-flex flex-wrap gap-2 mt-3">
-                        <a class="btn btn-outline-primary" href="{{ url_for('user.pair_management') }}">
-                            <i class="bi bi-people"></i> 管理照护绑定
-                        </a>
-                        <a class="btn btn-outline-secondary" href="{{ url_for('public.action_check') }}">
-                            <i class="bi bi-clipboard-check"></i> 短码行动打卡
-                        </a>
-                    </div>
-                </div>
+                    <span class="risk-badge risk-{{ m.risk_level or 'low' }} badge">{{ m.risk_label or '低' }}</span>
+                </a>
+                {% endfor %}
             </div>
-        </div>
-    </div>
-
-    <!-- 健康建议 -->
-    <div class="row">
-        <div class="col-12">
-            <div class="card shadow-sm">
-                <div class="card-header bg-info text-white">
-                    <h5 class="mb-0"><i class="bi bi-lightbulb"></i> 个性化健康建议</h5>
-                </div>
-                <div class="card-body">
-                    {% if assessment and assessment.recommendations %}
-                        <div class="row">
-                            {% set recommendations = assessment.recommendations|from_json %}
-                            {% for rec in recommendations %}
-                                <div class="col-md-6 mb-3">
-                                    <div class="d-flex align-items-start">
-                                        <i class="bi bi-check-circle-fill text-success me-2 mt-1"></i>
-                                        <div>
-                                            <strong>{{ rec.category }}</strong>
-                                            <p class="mb-0 text-muted">{{ rec.advice }}</p>
-                                        </div>
-                                    </div>
-                                </div>
-                            {% endfor %}
-                        </div>
-                    {% else %}
-                        <p class="text-muted mb-0">完成健康评估后，系统将为您生成个性化健康建议</p>
-                    {% endif %}
-                </div>
-            </div>
-        </div>
-    </div>
-
-    {% if assessment_explain and assessment_explain.get('explain') %}
-    <div class="row mt-4">
-        <div class="col-12">
-            <div class="card shadow-sm">
-                <div class="card-header bg-light">
-                    <h5 class="mb-0"><i class="bi bi-card-checklist"></i> 原因与提醒</h5>
-                </div>
-                <div class="card-body">
-                    <div class="row g-3">
-                        <div class="col-md-4">
-                            <h6>原因</h6>
-                            <ul class="mb-0">
-                                {% for item in assessment_explain.explain.reasons %}
-                                    <li class="mb-1">{{ item }}</li>
-                                {% endfor %}
-                                {% if not assessment_explain.explain.reasons %}
-                                    <li class="text-muted">暂无明显触发原因</li>
-                                {% endif %}
-                            </ul>
-                        </div>
-                        <div class="col-md-4">
-                            <h6>今天怎么做</h6>
-                            <ul class="mb-0">
-                                {% for item in assessment_explain.explain.actions %}
-                                    <li class="mb-1">{{ item }}</li>
-                                {% endfor %}
-                                {% if not assessment_explain.explain.actions %}
-                                    <li class="text-muted">保持规律作息</li>
-                                {% endif %}
-                            </ul>
-                        </div>
-                        <div class="col-md-4">
-                            <h6>什么时候要找人</h6>
-                            <ul class="mb-0">
-                                {% for item in assessment_explain.explain.escalation %}
-                                    <li class="mb-1">{{ item }}</li>
-                                {% endfor %}
-                                {% if not assessment_explain.explain.escalation %}
-                                    <li class="text-muted">出现严重不适请及时就医</li>
-                                {% endif %}
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="small text-muted mt-3">风险提示不是诊断，紧急情况优先就医。</div>
-                </div>
-            </div>
-        </div>
-    </div>
-    {% endif %}
-
-    {% if notifications %}
-    <div class="row mt-4">
-        <div class="col-12">
-            <div class="card shadow-sm">
-                <div class="card-header bg-warning text-dark">
-                    <h5 class="mb-0"><i class="bi bi-bell"></i> 站内提醒</h5>
-                </div>
-                <div class="card-body">
-                    <ul class="list-group">
-                        {% for note in notifications %}
-                            <li class="list-group-item d-flex justify-content-between align-items-start">
-                                <div>
-                                    <div class="fw-bold">{{ note.title }}</div>
-                                    <div class="text-muted small">{{ note.message }}</div>
-                                </div>
-                                <span class="badge bg-{{ 'danger' if note.level == 'danger' else 'warning' if note.level == 'warning' else 'info' }}">
-                                    {{ note.created_at.strftime('%m-%d %H:%M') }}
-                                </span>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </div>
-            </div>
-        </div>
-    </div>
-    {% endif %}
-
-    <!-- 用药提醒 -->
-    <div class="row mt-4">
-        <div class="col-12">
-            <div class="card shadow-sm">
-                <div class="card-header bg-warning text-dark">
-                    <h5 class="mb-0"><i class="bi bi-capsule"></i> 用药提醒</h5>
-                </div>
-                <div class="card-body">
-                    {% if reminders and reminders|length > 0 %}
-                        <ul class="list-group">
-                            {% for reminder in reminders %}
-                                <li class="list-group-item d-flex justify-content-between align-items-center">
-                                    <div>
-                                        <strong>{{ reminder.medicine_name }}</strong>
-                                        {% if reminder.dosage %}<span class="text-muted">（{{ reminder.dosage }}）</span>{% endif %}
-                                        <div class="small text-muted">触发原因：{{ reminder.reason }}</div>
-                                    </div>
-                                    <span class="badge bg-danger">
-                                        {% if reminder.time_of_day %}{{ reminder.time_of_day }}{% else %}今日{% endif %}
-                                    </span>
-                                </li>
-                            {% endfor %}
-                        </ul>
-                    {% else %}
-                        <p class="text-muted mb-0">暂无触发的用药提醒</p>
-                    {% endif %}
-                    <div class="mt-3">
-                        <a href="{{ url_for('health.medication_reminders') }}" class="btn btn-outline-warning btn-sm">
-                            管理用药提醒
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    {% if current_user.role == 'admin' %}
-    <!-- 7天健康预测快速入口（管理员/研究功能） -->
-    <div class="row mt-4">
-        <div class="col-md-6 mb-4">
-            <div class="card shadow-sm h-100 border-primary">
-                <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
-                    <h5 class="mb-0"><i class="bi bi-calendar-week"></i> 未来7天健康预测</h5>
-                    <a href="{{ url_for('tools.forecast_7day') }}" class="btn btn-light btn-sm">
-                        查看详情 <i class="bi bi-arrow-right"></i>
-                    </a>
-                </div>
-                <div class="card-body" id="forecast7dayPreview">
-                    <div class="text-center py-3">
-                        <div class="spinner-border spinner-border-sm text-primary me-2"></div>
-                        加载预测数据...
-                    </div>
-                </div>
-            </div>
-        </div>
-        
-        <div class="col-md-6 mb-4">
-            <div class="card shadow-sm h-100 border-success">
-                <div class="card-header bg-success text-white d-flex justify-content-between align-items-center">
-                    <h5 class="mb-0"><i class="bi bi-heart-pulse"></i> 慢病风险评估</h5>
-                    <a href="{{ url_for('tools.chronic_risk') }}" class="btn btn-light btn-sm">
-                        开始评估 <i class="bi bi-arrow-right"></i>
-                    </a>
-                </div>
-                <div class="card-body">
-                    <p class="text-muted">基于您的年龄、慢性病史和当前天气条件，进行个性化健康风险评估。</p>
-                    {% if is_guest %}
-                        <div class="alert alert-info mb-0 py-2">
-                            <i class="bi bi-info-circle me-1"></i>
-                            游客模式无法保存健康档案，注册后可获得更精准的评估结果。
-                        </div>
-                    {% elif current_user.has_chronic_disease %}
-                        <div class="alert alert-info mb-0 py-2">
-                            <i class="bi bi-info-circle me-1"></i>
-                            您已登记慢性病信息，可获得更精准的风险评估
-                        </div>
-                    {% else %}
-                        <div class="alert alert-warning mb-0 py-2">
-                            <i class="bi bi-exclamation-triangle me-1"></i>
-                            建议在<a href="{{ url_for('user.profile') }}">个人设置</a>中完善健康信息
-                        </div>
-                    {% endif %}
-                </div>
-            </div>
-        </div>
-    </div>
-    {% endif %}
-
-    <!-- 社区风险概览 -->
-    <div class="row">
-        <div class="col-12">
-            <div class="card shadow-sm">
-                <div class="card-header bg-secondary text-white d-flex justify-content-between align-items-center">
-                    <h5 class="mb-0"><i class="bi bi-map"></i> 社区风险概览</h5>
-                    <a href="{{ url_for('user.community_risk') }}" class="btn btn-light btn-sm">
-                        查看详细地图 <i class="bi bi-arrow-right"></i>
-                    </a>
-                </div>
-                <div class="card-body">
-                    <p class="text-muted">您的社区：<strong>{{ current_user.community or '未设置' }}</strong></p>
-                    <p class="mb-0">点击上方按钮查看所有社区的风险分布地图</p>
-                </div>
-            </div>
-        </div>
+        </section>
+        {% endif %}
     </div>
 </div>
-
-{% block extra_js %}
-<script>
-function clearElement(element) {
-    while (element && element.firstChild) {
-        element.removeChild(element.firstChild);
-    }
-}
-
-function safeText(value, fallback) {
-    if (value === undefined || value === null) {
-        return fallback || '';
-    }
-    return String(value);
-}
-
-function toNumber(value, fallback) {
-    if (value === undefined || value === null || value === '') {
-        return fallback;
-    }
-    const num = Number(value);
-    if (!Number.isFinite(num)) {
-        return fallback;
-    }
-    return num;
-}
-
-function formatNumber(value, digits, fallbackText) {
-    const num = toNumber(value, null);
-    if (num === null) {
-        return fallbackText;
-    }
-    return num.toFixed(digits);
-}
-
-// 添加from_json过滤器的支持
-{% if assessment and assessment.recommendations %}
-try {
-    const recommendationsPayload = {{ assessment.recommendations|tojson }};
-    let recommendations = [];
-    if (typeof recommendationsPayload === 'string' && recommendationsPayload.trim()) {
-        const parsed = JSON.parse(recommendationsPayload);
-        if (Array.isArray(parsed)) {
-            recommendations = parsed;
-        }
-    } else if (Array.isArray(recommendationsPayload)) {
-        recommendations = recommendationsPayload;
-    }
-    console.log('推荐建议:', recommendations);
-} catch(e) {
-    console.error('解析推荐建议失败:', e);
-}
-{% endif %}
-
-// 加载7天预测预览（管理员/研究功能）
-document.addEventListener('DOMContentLoaded', function() {
-    const previewDiv = document.getElementById('forecast7dayPreview');
-    if (previewDiv) {
-        fetch('/api/forecast/7day', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({})
-        })
-        .then(response => response.json())
-        .then(data => {
-            clearElement(previewDiv);
-            if (data.success) {
-                const summary = data.summary || {};
-                const forecasts = Array.isArray(data.forecasts) ? data.forecasts.slice(0, 3) : [];
-                const totalVisitsText = formatNumber(summary.total_expected_visits, 0, '--');
-                const totalVisitsValue = toNumber(summary.total_expected_visits, null);
-                const highRiskDaysValue = toNumber(summary.high_risk_days, 0);
-                const highRiskDaysText = formatNumber(summary.high_risk_days, 0, '--');
-                const avgVisitsText = totalVisitsValue === null ? '--' : String(Math.round(totalVisitsValue / 7));
-
-                const row = document.createElement('div');
-                row.className = 'row text-center mb-3';
-
-                const totalCol = document.createElement('div');
-                totalCol.className = 'col-4';
-                const totalValue = document.createElement('div');
-                totalValue.className = 'h4 text-primary mb-0';
-                totalValue.textContent = totalVisitsText;
-                const totalLabel = document.createElement('small');
-                totalLabel.className = 'text-muted';
-                totalLabel.textContent = '预计总门诊';
-                totalCol.appendChild(totalValue);
-                totalCol.appendChild(totalLabel);
-
-                const riskCol = document.createElement('div');
-                riskCol.className = 'col-4';
-                const riskValue = document.createElement('div');
-                const riskClass = highRiskDaysValue >= 2 ? 'text-danger' :
-                    highRiskDaysValue >= 1 ? 'text-warning' : 'text-success';
-                riskValue.className = 'h4 ' + riskClass + ' mb-0';
-                riskValue.textContent = highRiskDaysText;
-                const riskLabel = document.createElement('small');
-                riskLabel.className = 'text-muted';
-                riskLabel.textContent = '高风险天数';
-                riskCol.appendChild(riskValue);
-                riskCol.appendChild(riskLabel);
-
-                const avgCol = document.createElement('div');
-                avgCol.className = 'col-4';
-                const avgValue = document.createElement('div');
-                avgValue.className = 'h4 mb-0';
-                avgValue.textContent = avgVisitsText;
-                const avgLabel = document.createElement('small');
-                avgLabel.className = 'text-muted';
-                avgLabel.textContent = '日均门诊';
-                avgCol.appendChild(avgValue);
-                avgCol.appendChild(avgLabel);
-
-                row.appendChild(totalCol);
-                row.appendChild(riskCol);
-                row.appendChild(avgCol);
-                previewDiv.appendChild(row);
-
-                const cardsRow = document.createElement('div');
-                cardsRow.className = 'd-flex justify-content-between';
-                forecasts.forEach(f => {
-                    const riskLevel = safeText(f.risk_level, '--');
-                    const badgeClass = riskLevel.includes('红') ? 'danger' :
-                        riskLevel.includes('橙') ? 'warning' :
-                        riskLevel.includes('黄') ? 'info' : 'success';
-                    const card = document.createElement('div');
-                    card.className = 'text-center p-2 border rounded';
-                    card.style.minWidth = '80px';
-
-                    const dayText = document.createElement('div');
-                    dayText.className = 'small text-muted';
-                    dayText.textContent = safeText(f.day_of_week, '--');
-                    const tempText = document.createElement('div');
-                    tempText.className = 'fw-bold';
-                    tempText.textContent = formatNumber(f.temperature && f.temperature.corrected, 0, '--') + '°C';
-                    const badge = document.createElement('span');
-                    badge.className = 'badge bg-' + badgeClass;
-                    badge.style.fontSize = '0.7rem';
-                    badge.textContent = riskLevel;
-
-                    card.appendChild(dayText);
-                    card.appendChild(tempText);
-                    card.appendChild(badge);
-                    cardsRow.appendChild(card);
-                });
-                previewDiv.appendChild(cardsRow);
-            } else {
-                const empty = document.createElement('p');
-                empty.className = 'text-muted text-center mb-0';
-                empty.textContent = '预测数据加载失败';
-                previewDiv.appendChild(empty);
-            }
-        })
-        .catch(error => {
-            clearElement(previewDiv);
-            const empty = document.createElement('p');
-            empty.className = 'text-muted text-center mb-0';
-            empty.textContent = '预测服务暂不可用';
-            previewDiv.appendChild(empty);
-        });
-    }
-
-    const adjustContainer = document.getElementById('heatRiskAdjustDashboard');
-    if (adjustContainer) {
-        const storageKey = 'heat_threshold_adjust';
-        const score = parseFloat(adjustContainer.dataset.heatRiskScore || '0');
-        const badge = document.getElementById('heatAdjustedBadgeDashboard');
-        const inputs = adjustContainer.querySelectorAll('[data-heat-adjust]');
-        const badgeClass = {
-            '低风险': 'bg-success',
-            '中风险': 'bg-warning text-dark',
-            '高风险': 'bg-danger',
-            '极高': 'bg-dark'
-        };
-        const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
-        const computeLevel = (scoreValue, adjust) => {
-            const norm = scoreValue / 100;
-            const t1 = clamp(0.35 + adjust, 0.05, 0.9);
-            const t2 = clamp(0.55 + adjust, t1 + 0.05, 0.95);
-            const t3 = clamp(0.75 + adjust, t2 + 0.05, 0.98);
-            if (norm >= t3) return '极高';
-            if (norm >= t2) return '高风险';
-            if (norm >= t1) return '中风险';
-            return '低风险';
-        };
-        const applyAdjust = (adjust) => {
-            const level = computeLevel(score, adjust);
-            if (badge) {
-                badge.textContent = level;
-                badge.className = `badge ${badgeClass[level] || 'bg-secondary'}`;
-            }
-        };
-        let storedAdjust = parseFloat(localStorage.getItem(storageKey) || '0');
-        if (![-0.1, 0, 0.1].includes(storedAdjust)) {
-            storedAdjust = 0;
-        }
-        inputs.forEach(input => {
-            if (parseFloat(input.value) === storedAdjust) {
-                input.checked = true;
-            }
-            input.addEventListener('change', () => {
-                const value = parseFloat(input.value);
-                localStorage.setItem(storageKey, value);
-                applyAdjust(value);
-            });
-        });
-        applyAdjust(storedAdjust);
-    }
-});
-</script>
-{% endblock %}
 {% endblock %}

--- a/tests/test_tools_page_regressions.py
+++ b/tests/test_tools_page_regressions.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+"""工具页与用户端导航回归测试。"""
+
+
+def _login_as(client, user_id: int, csrf_token='test-csrf-token'):
+    with client.session_transaction() as session:
+        session['_user_id'] = str(user_id)
+        session['_fresh'] = True
+        session['_csrf_token'] = csrf_token
+
+
+def _create_user(db_session, username='tooluser', role='user'):
+    from core.db_models import User
+
+    user = User(username=username, role=role)
+    user.set_password('testpass')
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+def test_forecast_page_loads_chartjs(client, db_session):
+    user = _create_user(db_session, username='forecast_user')
+    _login_as(client, user.id)
+
+    response = client.get('/forecast-7day')
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert 'id="forecastChart"' in body
+    assert '/static/vendor/chartjs/chart.umd.min.js' in body
+
+
+def test_authenticated_nav_uses_desktop_mega_menu(client, db_session):
+    user = _create_user(db_session, username='nav_user')
+    _login_as(client, user.id)
+
+    response = client.get('/dashboard')
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert 'id="appMegaMenu"' in body
+    assert 'data-nav-more-trigger="desktop"' in body
+    assert 'AI 疾病预测' in body
+    assert 'AI 提问' in body
+    assert '健康评估' in body
+    assert '家庭成员' in body
+
+
+def test_ml_prediction_post_renders_result_and_preserves_form(client, db_session, monkeypatch):
+    user = _create_user(db_session, username='ml_user')
+    _login_as(client, user.id)
+
+    class FakeMLService:
+        def predict_disease_risk(self, user_info, weather_info=None):
+            return {
+                'success': True,
+                'predictions': [
+                    {'disease': '高血压', 'probability': 0.812, 'percentage': '81.2%'},
+                    {'disease': '支气管炎', 'probability': 0.421, 'percentage': '42.1%'},
+                ],
+                'risk_factors': [
+                    '高温天气增加心血管负担',
+                    '湿度偏高可能放大呼吸系统不适',
+                ],
+            }
+
+    monkeypatch.setattr('blueprints.tools.get_ml_service', lambda: FakeMLService())
+
+    response = client.post(
+        '/ml-prediction',
+        data={
+            'location': '都昌',
+            'age': '72',
+            'chronic': ['高血压', '糖尿病'],
+            'csrf_token': 'test-csrf-token',
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert '未来 3 天风险预测' in body
+    assert '高血压' in body
+    assert 'Method Not Allowed' not in body
+    assert 'value="72"' in body
+    assert 'value="都昌"' in body
+    assert '<option value="高血压" selected>' in body
+    assert '<option value="糖尿病" selected>' in body
+
+
+def test_ml_prediction_selected_member_chronic_aliases_refill_selected(client, db_session, monkeypatch):
+    import json
+    from core.db_models import FamilyMember
+
+    user = _create_user(db_session, username='ml_member_user')
+    member = FamilyMember(
+        user_id=user.id,
+        name='母亲',
+        relation='母亲',
+        age=74,
+        gender='女',
+        chronic_diseases=json.dumps(['慢性阻塞性肺病', '脑卒中史', '关节炎'], ensure_ascii=False),
+    )
+    db_session.add(member)
+    db_session.commit()
+    _login_as(client, user.id)
+
+    class FakeMLService:
+        def predict_disease_risk(self, user_info, weather_info=None):
+            return {
+                'success': True,
+                'predictions': [{'disease': '支气管炎', 'probability': 0.52}],
+                'risk_factors': ['高温天气增加呼吸负担'],
+            }
+
+    monkeypatch.setattr('blueprints.tools.get_ml_service', lambda: FakeMLService())
+
+    response = client.post(
+        '/ml-prediction',
+        data={
+            'member_id': str(member.id),
+            'location': '都昌',
+            'age': '',
+            'csrf_token': 'test-csrf-token',
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert 'value="74"' in body
+    assert '<option value="慢阻肺" selected>' in body
+    assert '<option value="脑卒中" selected>' in body
+    assert '<option value="关节炎" selected>' in body
+
+
+def test_chronic_risk_post_no_longer_returns_405(client, db_session, monkeypatch):
+    user = _create_user(db_session, username='chronic_user')
+    _login_as(client, user.id)
+
+    class FakeChronicService:
+        def predict_individual_risk(self, user_info, weather_data, target_diseases=None):
+            return {
+                'overall_risk': {'score': 66, 'level': '中风险'},
+                'disease_risks': {
+                    'cardiovascular': {'risk_score': 66, 'risk_level': '中风险'},
+                    'respiratory': {'risk_score': 34, 'risk_level': '低风险'},
+                },
+                'recommendations': ['按时服药', '本周内复诊'],
+            }
+
+    monkeypatch.setattr('blueprints.tools.get_chronic_service', lambda: FakeChronicService())
+
+    response = client.post(
+        '/chronic-risk',
+        data={
+            'disease': 'hypertension',
+            'sbp': '142',
+            'fbg': '7.8',
+            'adherence': 'loose',
+            'symptoms': '头晕',
+            'csrf_token': 'test-csrf-token',
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert 'Method Not Allowed' not in body
+    assert '综合风险评分' in body
+    assert '按时服药' in body


### PR DESCRIPTION
## 这次改了什么
同步本地 preview 已确认的新版 UI 到正式仓库，并补齐响应式布局与健康评估页的字段对齐。

## 为什么要改
Claude Code 的设计稿只完成了部分页面，且在 dashboard / health assessment 等关键页留下了两类问题：
1. 窄窗口和 IAB 场景下布局会横向挤压或只偏左显示
2. `health_assessment` 新模板把表单字段改成了后端不识别的名字，导致页面能提交但评估输入没有真正参与计算

## 怎么测试
- 本地干净 clone 执行：`python3 -m pytest -q`
- 结果：`113 passed, 11 deselected, 1 warning`
- 额外核对：已将 PR 分支重写为基于 `main` 的单提交，保留现有 PR #7

## 文件去向
全部为主仓库文件，无额外迁移。

## 其他说明
- 本次没有修改 `.sh` 或 `.githooks` 的逻辑
- 新增样式文件：`static/css/yilao.css`
- `health_assessment` 已恢复使用现有后端字段：`outdoor_exposure`、`symptom_level`、`hydration`、`medication_adherence`、`sleep_quality`