### PR TITLE
fix: 完成三轮缺陷修复与回归加固

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 配置 Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: 安装依赖
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip check
+
+      - name: 检查 Python 与 Shell 语法
+        run: |
+          python -m compileall -q app.py blueprints core services utils
+          for file in scripts/*.sh .githooks/*; do
+            bash -n "$file"
+          done
+
+      - name: 检查变更与仓库边界
+        shell: bash
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            git diff --check "origin/${GITHUB_BASE_REF}...HEAD"
+          else
+            git show --check --oneline --no-renames HEAD
+          fi
+
+          forbidden=$(
+            git ls-files \
+              | grep -E '(^\.env($|\.)|^\.claude/|^\.superpowers/|^\.playwright-cli/|^output/|^backups/| 2\.|\.DS_Store$)' \
+              | grep -v '^\.env\.example$' \
+              || true
+          )
+          if [ -n "$forbidden" ]; then
+            printf '发现禁止提交的文件：\n%s\n' "$forbidden" >&2
+            exit 1
+          fi
+
+          if git grep -nE \
+            '(AKIA[0-9A-Z]{16}|gh[pousr]_[A-Za-z0-9]{20,}|sk-[A-Za-z0-9_-]{20,}|BEGIN (RSA|OPENSSH|EC) PRIVATE KEY)' \
+            -- . ':(exclude)tests/**' ':(exclude).github/workflows/ci.yml'; then
+            echo '发现疑似真实密钥或私钥。' >&2
+            exit 1
+          fi
+
+          oversized=0
+          while IFS= read -r -d '' file; do
+            bytes=$(wc -c < "$file")
+            if [ "$bytes" -gt 10485760 ]; then
+              echo "文件超过 10 MB: $file ($bytes bytes)" >&2
+              oversized=1
+            fi
+          done < <(git ls-files -z)
+          test "$oversized" -eq 0
+
+      - name: 运行默认测试
+        run: python -m pytest -q
+
+      - name: 检查弃用警告
+        run: >-
+          python -m pytest -q
+          -W error::DeprecationWarning
+          -W ignore::DeprecationWarning:flask_login.login_manager
+
+      - name: 运行手工契约测试
+        run: python -m pytest -q -m manual

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -24,13 +24,13 @@
 | 用户认证 | Flask-Login | 0.6.3 |
 | 速率限制 | Flask-Limiter | 3.7.0 |
 | XSS 防护 | bleach | 6.2.0 |
-| 机器学习 | scikit-learn | ≥1.3.0 |
+| 机器学习 | scikit-learn | 1.7.2 |
 | 科学计算 | scipy | ≥1.11.0 |
 | 数据处理 | pandas | 2.1.3 |
 | 数值计算 | numpy | 1.26.4 |
 | PDF 导出 | reportlab | 4.2.2 |
-| Excel 导出 | openpyxl | 3.1.2 |
-| HTTP 请求 | requests | 2.31.0 |
+| Excel 导出 | openpyxl | 3.1.5 |
+| HTTP 请求 | requests | 2.32.4 |
 | 数据库迁移 | alembic | 1.13.1 |
 | 测试框架 | pytest | 8.2.2 |
 | 生产部署 | gunicorn + nginx + systemd | - |
@@ -609,7 +609,7 @@ python app.py
 
 ```bash
 # 运行部署脚本
-./deploy.sh
+./scripts/deploy.sh
 ```
 
 ---

--- a/blueprints/analysis.py
+++ b/blueprints/analysis.py
@@ -27,7 +27,7 @@ from core.db_models import (
     WeatherAlert,
     WeatherData
 )
-from core.time_utils import today_local, date_to_utc_start, date_to_utc_end, utc_to_local_date
+from core.time_utils import today_local, date_to_utc_start, date_to_utc_end, utc_to_local_date, utcnow
 from utils.parsers import parse_date
 from utils.validators import sanitize_input
 

--- a/blueprints/mp_api.py
+++ b/blueprints/mp_api.py
@@ -17,6 +17,7 @@ from functools import wraps
 
 from flask import Blueprint, current_app, g, jsonify, request
 
+from core.audit import _get_client_ip
 from core.db_models import FamilyMember, FamilyMemberProfile, Pair, User
 from core.extensions import db, limiter
 from core.security import hash_identifier
@@ -45,10 +46,9 @@ def _bearer_token() -> str:
 
 
 def _mp_rate_limit_key() -> str:
-    token = _bearer_token()
-    if token:
-        return f"mp-token:{hash_identifier(token)}"
-    return request.remote_addr or "mp-anonymous"
+    """外层限流使用稳定客户端 IP，避免轮换无效 Bearer 换桶。"""
+    client_ip = _get_client_ip() or request.remote_addr or "unknown"
+    return f"mp-ip:{hash_identifier(client_ip)}"
 
 
 def require_api_token(fn):

--- a/blueprints/public.py
+++ b/blueprints/public.py
@@ -195,7 +195,11 @@ def transparency():
 @bp.route('/cooling', endpoint='cooling_resources')
 def cooling_resources():
     """避暑资源公开页"""
-    community = sanitize_input(request.args.get('community'), max_length=100)
+    # 兼容旧版 location 参数，同时统一交给后端查询，避免地图数据仍混入其他社区。
+    community = sanitize_input(
+        request.args.get('community') or request.args.get('location'),
+        max_length=100,
+    )
     resource_type = sanitize_input(
         request.args.get('resource_type') or request.args.get('type'),
         max_length=50
@@ -230,11 +234,16 @@ def amap_proxy(proxy_path):
     if security_code:
         params.append(('jscode', security_code))
 
-    upstream = requests.get(
-        f'https://restapi.amap.com/{safe_path}',
-        params=params,
-        timeout=10
-    )
+    try:
+        upstream = requests.get(
+            f'https://restapi.amap.com/{safe_path}',
+            params=params,
+            timeout=10
+        )
+    except requests.RequestException:
+        # 上游网络异常统一收口，避免错误细节泄露给前端。
+        logger.warning("高德地图上游请求失败")
+        abort(502)
     content_type = upstream.headers.get('Content-Type', 'application/json; charset=utf-8')
     if len(upstream.content or b'') > AMAP_PROXY_MAX_BYTES:
         abort(502)

--- a/core/hooks.py
+++ b/core/hooks.py
@@ -27,6 +27,21 @@ MAX_JSON_BYTES = 10 * 1024
 MAX_JSON_DEPTH = 5
 
 
+def _redact_sensitive_path(path):
+    """结构化日志不得记录行动链接或点击追踪 token。"""
+    path = str(path or '')
+    for prefix in ('/e/', '/t/'):
+        if not path.startswith(prefix):
+            continue
+        remainder = path[len(prefix):]
+        suffix = ''
+        if '/' in remainder:
+            _, tail = remainder.split('/', 1)
+            suffix = f'/{tail}'
+        return f'{prefix}<token>{suffix}'
+    return path
+
+
 def _exceeds_json_depth(value, max_depth, current_depth=1):
     if current_depth > max_depth:
         return True
@@ -83,7 +98,7 @@ def register_hooks(app):
                 'user_id': user_id,
                 'user_role': user_role,
                 'method': request.method,
-                'path': request.path,
+                'path': _redact_sensitive_path(request.path),
                 'endpoint': request.endpoint,
                 'status': response.status_code,
                 'duration_ms': duration_ms,

--- a/core/weather.py
+++ b/core/weather.py
@@ -167,7 +167,7 @@ def get_demo_weather_data():
 
 
 def weather_source_label(weather_data):
-    """返回天气来源标签，避免 mock 数据被误标成和风。"""
+    """返回显式天气来源标签，缺少 provenance 时保持未知。"""
     if not isinstance(weather_data, dict):
         return ''
     source = str(weather_data.get('data_source') or weather_data.get('source') or '').strip()
@@ -177,7 +177,7 @@ def weather_source_label(weather_data):
         return 'Demo'
     if weather_data.get('is_mock'):
         return 'Mock'
-    return 'QWeather'
+    return ''
 
 
 def is_qweather_online_weather(weather_data):

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,50 +1,110 @@
 #!/bin/bash
 # 数据库自动备份脚本
 # 每天保留30天的备份
+set -euo pipefail
 
-ENV_FILE="${ENV_FILE:-/opt/your-app/.env}"
-PROJECT_DIR="${PROJECT_DIR:-$(dirname "$ENV_FILE")}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# 项目目录只由脚本位置或显式变量决定，外置 ENV_FILE 不应改变数据库根目录。
+PROJECT_DIR="${PROJECT_DIR:-$ROOT_DIR}"
+ENV_FILE="${ENV_FILE:-$PROJECT_DIR/.env}"
 BACKUP_DIR="${BACKUP_DIR:-$PROJECT_DIR/backups}"
 DEFAULT_DB_FILE="${DEFAULT_DB_FILE:-$PROJECT_DIR/instance/health_weather.db}"
-DB_FILE=$DEFAULT_DB_FILE
-DATE=$(date +%Y%m%d_%H%M%S)
-BACKUP_FILE=$BACKUP_DIR/health_weather_$DATE.db
+DB_FILE="$DEFAULT_DB_FILE"
+DATE="$(date +%Y%m%d_%H%M%S)"
+BACKUP_FILE="$BACKUP_DIR/health_weather_$DATE.db"
+
+trim_whitespace() {
+    local value="${1:-}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    printf '%s' "$value"
+}
+
+normalize_env_value() {
+    local value
+    local remainder
+    value="$(trim_whitespace "${1:-}")"
+
+    case "$value" in
+        \"*)
+            value="${value#\"}"
+            [[ "$value" == *\"* ]] || return 1
+            remainder="${value#*\"}"
+            value="${value%%\"*}"
+            ;;
+        \'*)
+            value="${value#\'}"
+            [[ "$value" == *\'* ]] || return 1
+            remainder="${value#*\'}"
+            value="${value%%\'*}"
+            ;;
+        *)
+            value="${value%%#*}"
+            remainder=""
+            ;;
+    esac
+
+    remainder="$(trim_whitespace "$remainder")"
+    if [ -n "$remainder" ] && [[ "$remainder" != \#* ]]; then
+        return 1
+    fi
+    trim_whitespace "$value"
+}
 
 load_database_uri() {
+    local line
+    local key
+    local value
+
+    # 显式环境变量优先于配置文件。
+    if [ -n "${DATABASE_URI:-}" ]; then
+        return 0
+    fi
     [ -f "$ENV_FILE" ] || return 1
-    while IFS='=' read -r key value; do
-        case "$key" in
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="$(trim_whitespace "$line")"
+        case "$line" in
             ''|\#*) continue ;;
-            DATABASE_URI)
-                value="${value%%#*}"
-                value="${value%"${value##*[![:space:]]}"}"
-                value="${value#"${value%%[![:space:]]*}"}"
-                if [[ "$value" == \"*\" && "$value" == *\" ]]; then
-                    value="${value:1:${#value}-2}"
-                fi
-                if [ -n "$value" ]; then
-                    DATABASE_URI="$value"
-                    return 0
-                fi
-                return 1
-                ;;
         esac
+        [[ "$line" == *=* ]] || continue
+        key="$(trim_whitespace "${line%%=*}")"
+        [ "$key" = "DATABASE_URI" ] || continue
+        if ! value="$(normalize_env_value "${line#*=}")"; then
+            echo "DATABASE_URI 格式无效: 引号或行尾内容不完整" >&2
+            return 2
+        fi
+        if [ -z "$value" ]; then
+            echo "DATABASE_URI 已配置但值为空" >&2
+            return 2
+        fi
+        DATABASE_URI="$value"
+        return 0
     done < "$ENV_FILE"
     return 1
 }
 
 parse_sqlite_path() {
-    local uri="$1"
+    local uri
     local path=""
-    if [[ "$uri" == sqlite:////* ]]; then
-        path="/${uri#sqlite:////}"
-    elif [[ "$uri" == sqlite:///* ]]; then
-        path="${uri#sqlite:///}"
-    else
-        return 1
-    fi
+    uri="$(trim_whitespace "${1:-}")"
+
+    case "$uri" in
+        sqlite+pysqlite:///*) path="${uri#sqlite+pysqlite:///}" ;;
+        sqlite:///*) path="${uri#sqlite:///}" ;;
+        *)
+            echo "仅支持 sqlite 或 sqlite+pysqlite DATABASE_URI: $uri" >&2
+            return 2
+            ;;
+    esac
+
     path="${path%%\?*}"
-    [ -n "$path" ] || return 1
+    if [ -z "$path" ] || [ "$path" = ":memory:" ]; then
+        echo "DATABASE_URI 未指向可备份的 SQLite 文件" >&2
+        return 2
+    fi
     if [[ "$path" != /* ]]; then
         if [[ "$path" == */* || "$path" == *\\* ]]; then
             path="$PROJECT_DIR/$path"
@@ -52,22 +112,72 @@ parse_sqlite_path() {
             path="$PROJECT_DIR/instance/$path"
         fi
     fi
-    echo "$path"
+    printf '%s\n' "$path"
+}
+
+usage() {
+    echo "用法: $0 [--if-present]" >&2
 }
 
 main() {
+    local if_present=0
+    local load_status=0
+    local parse_status=0
+    local parsed_path=""
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --if-present) if_present=1 ;;
+            -h|--help)
+                usage
+                return 0
+                ;;
+            *)
+                echo "未知参数: $1" >&2
+                usage
+                return 2
+                ;;
+        esac
+        shift
+    done
+
     if load_database_uri; then
-        parsed_path="$(parse_sqlite_path "$DATABASE_URI")"
-        if [ -n "$parsed_path" ]; then
+        if parsed_path="$(parse_sqlite_path "$DATABASE_URI")"; then
             DB_FILE="$parsed_path"
+        else
+            parse_status=$?
+            return "$parse_status"
+        fi
+    else
+        load_status=$?
+        if [ "$load_status" -ne 1 ]; then
+            return "$load_status"
         fi
     fi
+
+    if [ ! -f "$DB_FILE" ]; then
+        if [ "$if_present" -eq 1 ]; then
+            echo "未发现源数据库，按 --if-present 跳过备份: $DB_FILE"
+            return 0
+        fi
+        echo "源数据库不存在，拒绝创建空备份: $DB_FILE" >&2
+        return 3
+    fi
+
+    command -v sqlite3 >/dev/null 2>&1 || {
+        echo "缺少 sqlite3 命令，无法执行备份" >&2
+        return 127
+    }
+    command -v gzip >/dev/null 2>&1 || {
+        echo "缺少 gzip 命令，无法压缩备份" >&2
+        return 127
+    }
 
     # 创建备份目录
     mkdir -p "$BACKUP_DIR"
 
     # 创建备份（使用SQLite的.backup命令保证一致性）
-    sqlite3 "$DB_FILE" ".backup $BACKUP_FILE"
+    sqlite3 "$DB_FILE" ".backup '$BACKUP_FILE'"
 
     # 压缩备份
     gzip "$BACKUP_FILE"

--- a/scripts/complete_manual_fixes.sh
+++ b/scripts/complete_manual_fixes.sh
@@ -5,17 +5,150 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-cd "$ROOT_DIR"
-
-echo "============================================================"
-echo "安全修复 - 手动步骤辅助脚本"
-echo "============================================================"
 
 # 颜色定义
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
+
+trim_whitespace() {
+    local value="${1:-}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    printf '%s' "$value"
+}
+
+normalize_env_value() {
+    local value
+    local remainder
+    value="$(trim_whitespace "${1:-}")"
+    case "$value" in
+        \"*)
+            value="${value#\"}"
+            [[ "$value" == *\"* ]] || return 1
+            remainder="${value#*\"}"
+            value="${value%%\"*}"
+            ;;
+        \'*)
+            value="${value#\'}"
+            [[ "$value" == *\'* ]] || return 1
+            remainder="${value#*\'}"
+            value="${value%%\'*}"
+            ;;
+        *)
+            value="${value%%#*}"
+            remainder=""
+            ;;
+    esac
+    remainder="$(trim_whitespace "$remainder")"
+    if [ -n "$remainder" ] && [[ "$remainder" != \#* ]]; then
+        return 1
+    fi
+    trim_whitespace "$value"
+}
+
+read_env_value() {
+    local target="$1"
+    local env_file="$2"
+    local line key value found=1
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="$(trim_whitespace "$line")"
+        case "$line" in ''|\#*) continue ;; esac
+        [[ "$line" == *=* ]] || continue
+        key="$(trim_whitespace "${line%%=*}")"
+        [ "$key" = "$target" ] || continue
+        if ! value="$(normalize_env_value "${line#*=}")"; then
+            value=""
+        fi
+        found=0
+    done < "$env_file"
+    [ "$found" -eq 0 ] || return 1
+    printf '%s' "$value"
+}
+
+is_placeholder_secret() {
+    local value lowered
+    if ! value="$(normalize_env_value "${1:-}")"; then
+        return 0
+    fi
+    lowered="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+    case "$lowered" in
+        ''|your-*|your_*|change-me*|change_me*|changeme*|example*|placeholder*|replace-me*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+write_env_value() {
+    local key="$1"
+    local value="$2"
+    local env_file="$3"
+    local tmp_file="${env_file}.tmp"
+    awk -v wanted="$key" -v replacement="$key=$value" '
+        BEGIN { updated = 0 }
+        {
+            line = $0
+            trimmed = line
+            sub(/^[[:space:]]*/, "", trimmed)
+            if (trimmed !~ /^#/ && index(trimmed, "=") > 0) {
+                candidate = substr(trimmed, 1, index(trimmed, "=") - 1)
+                gsub(/[[:space:]]/, "", candidate)
+                if (candidate == wanted) {
+                    if (!updated) {
+                        print replacement
+                        updated = 1
+                    }
+                    # 后续重复键直接丢弃，确保最终配置只有一个有效值。
+                    next
+                }
+            }
+            print line
+        }
+        END { if (!updated) print replacement }
+    ' "$env_file" > "$tmp_file"
+    # 新文件固定为仅当前用户可读写，避免密钥轮换时放宽原有权限。
+    chmod 600 "$tmp_file"
+    mv "$tmp_file" "$env_file"
+}
+
+check_or_generate_secret() {
+    local key="$1"
+    local value=""
+    local prompt_text=""
+    local generated=""
+    local reply=""
+
+    if value="$(read_env_value "$key" .env)"; then
+        if ! is_placeholder_secret "$value"; then
+            echo -e "${GREEN}✅ $key 已配置${NC}"
+            return 0
+        fi
+        echo -e "${RED}❌ $key 为空或使用示例值${NC}"
+        prompt_text="是否生成新的 $key? (y/n) "
+    else
+        echo -e "${YELLOW}⚠️  $key 未找到${NC}"
+        prompt_text="是否生成 $key? (y/n) "
+    fi
+
+    read -p "$prompt_text" -n 1 -r reply
+    echo
+    if [[ "$reply" =~ ^[Yy]$ ]]; then
+        generated="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+        write_env_value "$key" "$generated" .env
+        echo -e "${GREEN}✅ $key 已生成${NC}"
+    fi
+}
+
+# 被测试脚本 source 时只暴露辅助函数，不进入交互流程。
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+fi
+
+cd "$ROOT_DIR"
+
+echo "============================================================"
+echo "安全修复 - 手动步骤辅助脚本"
+echo "============================================================"
 
 # 1. 检查 .env 文件
 echo -e "\n${YELLOW}[1/5] 检查 .env 文件...${NC}"
@@ -43,29 +176,7 @@ fi
 # 2. 检查 SECRET_KEY
 echo -e "\n${YELLOW}[2/5] 检查 SECRET_KEY...${NC}"
 if [ -f .env ]; then
-    if grep -q "^SECRET_KEY=change-me-min-32-chars" .env; then
-        echo -e "${RED}❌ SECRET_KEY 使用示例值${NC}"
-        read -p "是否生成新的 SECRET_KEY? (y/n) " -n 1 -r
-        echo
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
-            NEW_KEY=$(python3 -c 'import secrets; print(secrets.token_hex(32))')
-            # 使用临时文件替换
-            sed "s/^SECRET_KEY=.*/SECRET_KEY=$NEW_KEY/" .env > .env.tmp
-            mv .env.tmp .env
-            echo -e "${GREEN}✅ SECRET_KEY 已生成${NC}"
-        fi
-    elif grep -q "^SECRET_KEY=" .env; then
-        echo -e "${GREEN}✅ SECRET_KEY 已配置${NC}"
-    else
-        echo -e "${YELLOW}⚠️  SECRET_KEY 未找到${NC}"
-        read -p "是否生成 SECRET_KEY? (y/n) " -n 1 -r
-        echo
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
-            NEW_KEY=$(python3 -c 'import secrets; print(secrets.token_hex(32))')
-            echo "SECRET_KEY=$NEW_KEY" >> .env
-            echo -e "${GREEN}✅ SECRET_KEY 已添加${NC}"
-        fi
-    fi
+    check_or_generate_secret "SECRET_KEY"
 else
     echo -e "${RED}❌ .env 文件不存在，跳过检查${NC}"
 fi
@@ -73,28 +184,7 @@ fi
 # 3. 检查 PAIR_TOKEN_PEPPER
 echo -e "\n${YELLOW}[3/5] 检查 PAIR_TOKEN_PEPPER...${NC}"
 if [ -f .env ]; then
-    if grep -q "^PAIR_TOKEN_PEPPER=change-me-min-32-chars" .env; then
-        echo -e "${RED}❌ PAIR_TOKEN_PEPPER 使用示例值${NC}"
-        read -p "是否生成新的 PAIR_TOKEN_PEPPER? (y/n) " -n 1 -r
-        echo
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
-            NEW_PEPPER=$(python3 -c 'import secrets; print(secrets.token_hex(32))')
-            sed "s/^PAIR_TOKEN_PEPPER=.*/PAIR_TOKEN_PEPPER=$NEW_PEPPER/" .env > .env.tmp
-            mv .env.tmp .env
-            echo -e "${GREEN}✅ PAIR_TOKEN_PEPPER 已生成${NC}"
-        fi
-    elif grep -q "^PAIR_TOKEN_PEPPER=" .env; then
-        echo -e "${GREEN}✅ PAIR_TOKEN_PEPPER 已配置${NC}"
-    else
-        echo -e "${YELLOW}⚠️  PAIR_TOKEN_PEPPER 未找到${NC}"
-        read -p "是否生成 PAIR_TOKEN_PEPPER? (y/n) " -n 1 -r
-        echo
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
-            NEW_PEPPER=$(python3 -c 'import secrets; print(secrets.token_hex(32))')
-            echo "PAIR_TOKEN_PEPPER=$NEW_PEPPER" >> .env
-            echo -e "${GREEN}✅ PAIR_TOKEN_PEPPER 已添加${NC}"
-        fi
-    fi
+    check_or_generate_secret "PAIR_TOKEN_PEPPER"
 else
     echo -e "${RED}❌ .env 文件不存在，跳过检查${NC}"
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -196,7 +196,7 @@ remote_exec "echo '连接成功'"
 
 echo ""
 echo "步骤2: 安装系统依赖..."
-remote_exec "apt-get update && apt-get install -y python3 python3-pip python3-venv rsync redis-server"
+remote_exec "apt-get update && apt-get install -y python3 python3-pip python3-venv rsync redis-server sqlite3"
 
 echo ""
 echo "步骤2.1: 启动 Redis（用于生产环境限流存储）..."
@@ -274,7 +274,7 @@ fi
 
 echo ""
 echo "步骤6.2: 初始化/迁移数据库（安全 stamp + upgrade）..."
-remote_exec "cd $PROJECT_DIR && mkdir -p backups && if [ -f instance/health_weather.db ]; then cp -a instance/health_weather.db backups/health_weather.db.$(date +%Y%m%d_%H%M%S); echo '已备份 instance/health_weather.db'; else echo '未发现 instance/health_weather.db，跳过备份'; fi"
+remote_exec "cd '$PROJECT_DIR' && PROJECT_DIR='$PROJECT_DIR' ENV_FILE='$PROJECT_DIR/.env' bash scripts/backup.sh --if-present"
 remote_exec "systemctl stop case-weather || true; systemctl stop case-weather-dispatch.timer || true; systemctl stop case-weather-risk-precompute.timer || true"
 remote_exec "cd $PROJECT_DIR && VENV_PY=$VENV_DIR/bin/python bash scripts/server_migrate.sh"
 

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # 快速同步脚本 - 仅上传代码并重启服务（不修改配置）
 
+set -euo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -31,6 +33,7 @@ USER="${DEPLOY_USER:-}"
 PROJECT_DIR="${DEPLOY_PROJECT_DIR:-/opt/your-app}"
 LOCAL_DIR="${DEPLOY_LOCAL_DIR:-$ROOT_DIR}"
 PASSWORD="${DEPLOY_PASSWORD:-${SSHPASS:-}}"
+SSHPASS="${SSHPASS:-}"
 
 require_env_value() {
     local name="$1"
@@ -90,6 +93,8 @@ elif use_expect && [ -n "$SSHPASS" ]; then
             }
             eof
         }
+        set wait_result [wait]
+        exit [lindex \$wait_result 3]
     "
 else
     rsync -avz --exclude __pycache__ --exclude *.pyc --exclude instance --exclude storage --exclude health_weather.db --exclude .git --exclude venv --exclude .venv --exclude .venv2 --exclude .env --exclude .env.local -e ssh "$LOCAL_DIR/" "$USER@$SERVER:$PROJECT_DIR/"
@@ -116,6 +121,8 @@ elif use_expect && [ -n "$SSHPASS" ]; then
             }
             eof
         }
+        set wait_result [wait]
+        exit [lindex \$wait_result 3]
     "
 else
     ssh -o StrictHostKeyChecking=no "$USER@$SERVER" "systemctl restart case-weather && systemctl status case-weather --no-pager"

--- a/services/pipelines/sync_weather_data.py
+++ b/services/pipelines/sync_weather_data.py
@@ -2,6 +2,7 @@
 """Weather data sync pipeline (CSV backfill + daily API update)."""
 import argparse
 import json
+import math
 from datetime import date, datetime
 from pathlib import Path
 
@@ -13,7 +14,7 @@ from core.app import create_app
 from core.constants import DEFAULT_CITY_LABEL  # noqa: E402
 from core.db_models import CommunityDaily, DailyStatus, Pair, WeatherData  # noqa: E402
 from core.extensions import db  # noqa: E402
-from core.weather import get_consecutive_hot_days  # noqa: E402
+from core.weather import get_consecutive_hot_days, is_qweather_online_weather  # noqa: E402
 from core.time_utils import today_local  # noqa: E402
 from services.heat_action_service import HeatActionService  # noqa: E402
 from services.weather_service import WeatherService  # noqa: E402
@@ -30,6 +31,73 @@ CSV_RENAME_MAP = {
 }
 
 DEFAULT_CSV_PATH = ROOT_DIR / 'data' / 'raw' / '逐日数据.csv'
+REQUIRED_ACTION_WEATHER_FIELDS = (
+    'temperature',
+    'temperature_max',
+    'temperature_min',
+    'humidity',
+)
+ESCALATED_RELAY_STAGES = {'backup', 'community', 'emergency'}
+
+
+def _validate_action_weather(weather_data):
+    """仅允许字段完整的真实和风天气写入风险与行动状态。"""
+    if not isinstance(weather_data, dict) or not weather_data:
+        return {
+            'valid': False,
+            'reason': 'weather_unavailable',
+            'weather_source': 'unknown',
+            'missing_fields': list(REQUIRED_ACTION_WEATHER_FIELDS),
+        }
+
+    source = str(
+        weather_data.get('data_source') or weather_data.get('source') or 'unknown'
+    ).strip()
+    if weather_data.get('is_mock') or weather_data.get('is_demo'):
+        return {
+            'valid': False,
+            'reason': 'mock_weather',
+            'weather_source': source,
+            'missing_fields': [],
+        }
+    if source != 'QWeather':
+        return {
+            'valid': False,
+            'reason': 'untrusted_weather_source',
+            'weather_source': source,
+            'missing_fields': [],
+        }
+
+    missing_fields = []
+    for field in REQUIRED_ACTION_WEATHER_FIELDS:
+        try:
+            value = float(weather_data.get(field))
+        except (TypeError, ValueError):
+            missing_fields.append(field)
+            continue
+        if not math.isfinite(value):
+            missing_fields.append(field)
+
+    if missing_fields:
+        return {
+            'valid': False,
+            'reason': 'incomplete_weather',
+            'weather_source': source,
+            'missing_fields': missing_fields,
+        }
+    if not is_qweather_online_weather(weather_data):
+        return {
+            'valid': False,
+            'reason': 'untrusted_weather_source',
+            'weather_source': source,
+            'missing_fields': [],
+        }
+    return {
+        'valid': True,
+        'reason': None,
+        'weather_source': source,
+        'missing_fields': [],
+    }
 
 
 def _normalize_location(location):
@@ -124,13 +192,30 @@ def sync_daily_weather(target_date=None, location=None, overwrite=True):
         location = _normalize_location(location)
         weather_service = WeatherService()
         weather_data = weather_service.get_current_weather(location)
-        if not weather_data:
-            return {'location': location, 'date': target_date, 'updated': False}
+        validation = _validate_action_weather(weather_data)
+        if not validation['valid']:
+            return {
+                'location': location,
+                'date': target_date,
+                'updated': False,
+                'skipped': True,
+                'reason': validation['reason'],
+                'weather_source': validation['weather_source'],
+                'missing_fields': validation['missing_fields'],
+            }
 
         extreme = weather_service.identify_extreme_weather(weather_data)
         record = WeatherData.query.filter_by(date=target_date, location=location).first()
         if record and not overwrite:
-            return {'location': location, 'date': target_date, 'updated': False}
+            return {
+                'location': location,
+                'date': target_date,
+                'updated': False,
+                'skipped': True,
+                'reason': 'existing_record',
+                'weather_source': validation['weather_source'],
+                'missing_fields': [],
+            }
         if record is None:
             record = WeatherData(date=target_date, location=location)
             db.session.add(record)
@@ -148,7 +233,15 @@ def sync_daily_weather(target_date=None, location=None, overwrite=True):
         record.extreme_type = '、'.join([c['type'] for c in extreme.get('conditions', [])]) if extreme.get('is_extreme') else None
 
         db.session.commit()
-        return {'location': location, 'date': target_date, 'updated': True}
+        return {
+            'location': location,
+            'date': target_date,
+            'updated': True,
+            'skipped': False,
+            'reason': None,
+            'weather_source': validation['weather_source'],
+            'missing_fields': [],
+        }
 
 
 def _map_heat_level(level):
@@ -182,7 +275,15 @@ def sync_action_daily(target_date=None, community_code=None, overwrite=False):
             query = query.filter_by(community_code=community_code)
         pairs = query.all()
         if not pairs:
-            return {'date': target_date, 'updated': 0, 'communities': 0}
+            return {
+                'date': target_date,
+                'updated': 0,
+                'communities': 0,
+                'processed_communities': 0,
+                'skipped': True,
+                'reason': 'no_active_pairs',
+                'skipped_communities': {},
+            }
 
         heat_service = HeatActionService()
         weather_service = WeatherService()
@@ -192,8 +293,19 @@ def sync_action_daily(target_date=None, community_code=None, overwrite=False):
             communities.setdefault(pair.community_code, []).append(pair)
 
         updated = 0
+        processed_communities = []
+        skipped_communities = {}
         for code, members in communities.items():
             weather_data = weather_service.get_current_weather(code)
+            validation = _validate_action_weather(weather_data)
+            if not validation['valid']:
+                skipped_communities[code] = {
+                    'reason': validation['reason'],
+                    'weather_source': validation['weather_source'],
+                    'missing_fields': validation['missing_fields'],
+                }
+                continue
+
             consecutive_hot_days = get_consecutive_hot_days(
                 code,
                 target_date=target_date,
@@ -238,18 +350,25 @@ def sync_action_daily(target_date=None, community_code=None, overwrite=False):
                     db.session.add(status)
                 status.risk_level = risk_level
                 updated += 1
+            processed_communities.append(code)
 
         db.session.commit()
 
-        for code in communities.keys():
-            total_people = Pair.query.filter_by(status='active', community_code=code).count()
-            statuses = DailyStatus.query.filter_by(
-                community_code=code,
-                status_date=target_date
-            ).all()
+        for code in processed_communities:
+            active_pair_ids = {pair.id for pair in communities[code]}
+            total_people = len(active_pair_ids)
+            statuses = []
+            if active_pair_ids:
+                statuses = DailyStatus.query.filter(
+                    DailyStatus.community_code == code,
+                    DailyStatus.status_date == target_date,
+                    DailyStatus.pair_id.in_(active_pair_ids),
+                ).all()
             confirmed_count = sum(1 for s in statuses if s.confirmed_at)
             help_count = sum(1 for s in statuses if s.help_flag)
-            escalation_count = sum(1 for s in statuses if s.relay_stage in ('community', 'emergency'))
+            escalation_count = sum(
+                1 for s in statuses if s.relay_stage in ESCALATED_RELAY_STAGES
+            )
             risk_dist = {'低风险': 0, '中风险': 0, '高风险': 0, '极高': 0}
             for status in statuses:
                 if status.risk_level in risk_dist:
@@ -276,7 +395,22 @@ def sync_action_daily(target_date=None, community_code=None, overwrite=False):
             record.outreach_summary = summary
 
         db.session.commit()
-        return {'date': target_date, 'updated': updated, 'communities': len(communities)}
+        skipped = bool(skipped_communities)
+        if skipped and not processed_communities:
+            reason = 'weather_unavailable_for_all_communities'
+        elif skipped:
+            reason = 'some_communities_skipped'
+        else:
+            reason = None
+        return {
+            'date': target_date,
+            'updated': updated,
+            'communities': len(communities),
+            'processed_communities': len(processed_communities),
+            'skipped': skipped,
+            'reason': reason,
+            'skipped_communities': skipped_communities,
+        }
 
 
 def main():

--- a/services/public_service.py
+++ b/services/public_service.py
@@ -316,9 +316,10 @@ def _resolve_pair(short_code, token):
     short_code_hash = hash_short_code(short_code)
     pair = Pair.query.filter_by(short_code_hash=short_code_hash, status='active').first()
     if pair:
-        if not _pair_short_code_is_valid(pair):
+        action_token_valid = bool(token) and _validate_pair_action_token(pair, short_code, token)
+        if not _pair_short_code_is_valid(pair) and not action_token_valid:
             return None, '短码已过期，请联系照护人重新生成'
-        if token and not _validate_pair_token_binding(pair, short_code, token):
+        if token and not action_token_valid and not _validate_pair_token_binding(pair, short_code, token):
             return None, '绑定令牌不匹配'
         return pair, None
 
@@ -462,13 +463,21 @@ def _refresh_community_daily(community_code, status_date):
     from core.db_models import CommunityDaily
 
     total_people = Pair.query.filter_by(status='active', community_code=community_code).count()
-    statuses = DailyStatus.query.filter_by(
-        community_code=community_code,
-        status_date=status_date
+    statuses = DailyStatus.query.join(
+        Pair,
+        Pair.id == DailyStatus.pair_id,
+    ).filter(
+        DailyStatus.community_code == community_code,
+        DailyStatus.status_date == status_date,
+        Pair.community_code == community_code,
+        Pair.status == 'active',
     ).all()
-    confirmed_count = sum(1 for s in statuses if s.confirmed_at)
+    confirmed_count = min(sum(1 for s in statuses if s.confirmed_at), total_people)
     help_count = sum(1 for s in statuses if s.help_flag)
-    escalation_count = sum(1 for s in statuses if s.relay_stage in ('backup', 'community', 'emergency'))
+    escalation_count = min(
+        sum(1 for s in statuses if s.relay_stage in ('backup', 'community', 'emergency')),
+        total_people,
+    )
     risk_dist = {'低风险': 0, '中风险': 0, '高风险': 0, '极高': 0}
     for status in statuses:
         if status.risk_level in risk_dist:
@@ -476,7 +485,7 @@ def _refresh_community_daily(community_code, status_date):
     if total_people <= 0:
         summary = '暂无可用行动数据。'
     else:
-        pending = total_people - confirmed_count
+        pending = max(total_people - confirmed_count, 0)
         if escalation_count > 0:
             summary = f'已有{escalation_count}个家庭进入升级链，优先安排社区跟进。'
         elif help_count > 0:
@@ -666,9 +675,12 @@ def _handle_action_lookup(token=None, entry_action=None, confirm_action=None, he
     )
 
 
-def _resolve_pair_from_session_or_code(short_code):
+def _resolve_pair_from_session_or_code(short_code, token=None):
     pair = None
     short_code = (short_code or '').replace(' ', '').strip()
+    if token is None:
+        route_token = (request.view_args or {}).get('token')
+        token = route_token or _get_pair_token()
     session_pair_id = session.get('pair_session_id')
     session_pair_code = session.get('pair_session_code')
     if session_pair_id:
@@ -677,12 +689,20 @@ def _resolve_pair_from_session_or_code(short_code):
         if session_pair_code and session_pair_code != short_code:
             return None
         pair = Pair.query.filter_by(id=session_pair_id, status='active').first()
-        if pair and not _pair_short_code_is_valid(pair):
+        if (
+            pair
+            and not _pair_short_code_is_valid(pair)
+            and not _validate_pair_action_token(pair, short_code, token)
+        ):
             return None
     if not pair and short_code:
         short_code_hash = hash_short_code(short_code)
         pair = Pair.query.filter_by(short_code_hash=short_code_hash, status='active').first()
-        if pair and not _pair_short_code_is_valid(pair):
+        if (
+            pair
+            and not _pair_short_code_is_valid(pair)
+            and not _validate_pair_action_token(pair, short_code, token)
+        ):
             return None
     return pair
 
@@ -711,12 +731,12 @@ def _validate_pair_token_binding(pair, short_code, token):
 def _handle_action_confirm(token=None, confirm_action=None, debrief_action=None):
     short_code = sanitize_input(request.form.get('short_code'), max_length=12) or ''
     short_code = short_code.replace(' ', '').strip()
-    pair = _resolve_pair_from_session_or_code(short_code)
+    token = sanitize_input(request.form.get('token') or token, max_length=200)
+    pair = _resolve_pair_from_session_or_code(short_code, token=token)
     if not pair:
         flash('短码无效或已失效', 'error')
         return redirect(url_for('public.action_check'))
 
-    token = sanitize_input(request.form.get('token') or token, max_length=200)
     if (token or request.path.startswith('/e/')) and not _validate_pair_token_binding(pair, short_code, token):
         flash('短码或令牌无效，请联系照护人确认。', 'error')
         return redirect(url_for('public.action_check'))
@@ -756,12 +776,12 @@ def _handle_action_confirm(token=None, confirm_action=None, debrief_action=None)
 def _handle_action_help(token=None, confirm_action=None, debrief_action=None):
     short_code = sanitize_input(request.form.get('short_code'), max_length=12) or ''
     short_code = short_code.replace(' ', '').strip()
-    pair = _resolve_pair_from_session_or_code(short_code)
+    token = sanitize_input(request.form.get('token') or token, max_length=200)
+    pair = _resolve_pair_from_session_or_code(short_code, token=token)
     if not pair:
         flash('短码无效或已失效', 'error')
         return redirect(url_for('public.action_check'))
 
-    token = sanitize_input(request.form.get('token') or token, max_length=200)
     if (token or request.path.startswith('/e/')) and not _validate_pair_token_binding(pair, short_code, token):
         flash('短码或令牌无效，请联系照护人确认。', 'error')
         return redirect(url_for('public.action_check'))
@@ -769,7 +789,6 @@ def _handle_action_help(token=None, confirm_action=None, debrief_action=None):
     status, actions, resources, weather_data, heat_result, risk_label, risk_reasons = _build_action_context(
         pair, status_date
     )
-    status.confirmed_at = utcnow()
     status.help_flag = True
     if not status.relay_stage or status.relay_stage == 'none':
         status.relay_stage = 'caregiver'
@@ -802,12 +821,12 @@ def _handle_action_help(token=None, confirm_action=None, debrief_action=None):
 def _handle_action_debrief(token=None, confirm_action=None, debrief_action=None, focus_debrief=False):
     short_code = sanitize_input(request.form.get('short_code'), max_length=12) or ''
     short_code = short_code.replace(' ', '').strip()
-    pair = _resolve_pair_from_session_or_code(short_code)
+    token = sanitize_input(request.form.get('token') or token, max_length=200)
+    pair = _resolve_pair_from_session_or_code(short_code, token=token)
     if not pair:
         flash('短码无效或已失效', 'error')
         return redirect(url_for('public.action_check'))
 
-    token = sanitize_input(request.form.get('token') or token, max_length=200)
     if (token or request.path.startswith('/e/')) and not _validate_pair_token_binding(pair, short_code, token):
         flash('短码或令牌无效，请联系照护人确认。', 'error')
         return redirect(url_for('public.action_check'))

--- a/services/push/dispatch.py
+++ b/services/push/dispatch.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from flask import current_app, has_app_context
 
-from core.db_models import AlertDelivery, FamilyMember, Pair, User, WeatherAlert
+from core.db_models import AlertDelivery, FamilyMemberProfile, Pair, User, WeatherAlert
 from core.extensions import db
 from core.time_utils import utcnow
 from core.usage import log_usage_event
@@ -137,12 +137,38 @@ def _get_or_create_weather_alert(
     return record
 
 
-def _load_family_member_map(pairs: List[Pair]) -> Dict[int, FamilyMember]:
+def _load_family_member_profile_map(pairs: List[Pair]) -> Dict[int, FamilyMemberProfile]:
+    """只加载推送授权所需画像，避免读取不必要的成员身份信息。"""
     member_ids = sorted({p.member_id for p in pairs if getattr(p, "member_id", None)})
     if not member_ids:
         return {}
-    rows = FamilyMember.query.filter(FamilyMember.id.in_(member_ids)).all()
-    return {m.id: m for m in rows}
+    rows = FamilyMemberProfile.query.filter(
+        FamilyMemberProfile.member_id.in_(member_ids)
+    ).all()
+    return {profile.member_id: profile for profile in rows}
+
+
+def _pair_allows_family_push(pair: Pair, profile_map: Dict[int, FamilyMemberProfile]) -> bool:
+    """成员级开关和隐私级别必须先于第三方推送生效。"""
+    member_id = getattr(pair, "member_id", None)
+    if not member_id:
+        return True
+    profile = profile_map.get(member_id)
+    if profile is None:
+        return True
+    if getattr(profile, "alert_enabled", True) is False:
+        return False
+    privacy_level = str(getattr(profile, "privacy_level", None) or "family").strip().lower()
+    return privacy_level == "family"
+
+
+def _push_location_label(resolved: Dict[str, Any]) -> str:
+    """第三方推送只使用静态公开地点标签，地址解析结果统一降为泛称。"""
+    provider = str((resolved or {}).get("provider") or "").strip().lower()
+    display_name = str((resolved or {}).get("display_name") or "").strip()
+    if provider in {"map", "default"} and display_name:
+        return display_name
+    return "所在地区"
 
 
 def _render_push_content(
@@ -198,15 +224,16 @@ def dispatch_alerts(now=None, dedupe_hours: int = 6) -> Dict[str, Any]:
     if not pairs:
         return {"pairs": 0, "locations": 0, "alerts": 0, "deliveries": 0, "sent": 0, "failed": 0}
 
-    caregiver_ids = sorted({p.caregiver_id for p in pairs if getattr(p, "caregiver_id", None)})
+    profile_map = _load_family_member_profile_map(pairs)
+    eligible_pairs = [pair for pair in pairs if _pair_allows_family_push(pair, profile_map)]
+
+    caregiver_ids = sorted({p.caregiver_id for p in eligible_pairs if getattr(p, "caregiver_id", None)})
     users = User.query.filter(User.id.in_(caregiver_ids)).all() if caregiver_ids else []
     user_map = {u.id: u for u in users}
 
-    member_map = _load_family_member_map(pairs)
-
     # Resolve and group by location_code (QWeather compatible)
     groups: Dict[str, Dict[str, Any]] = {}
-    for pair in pairs:
+    for pair in eligible_pairs:
         query = (pair.location_query or pair.community_code or "").strip()
         resolved = resolve_location(query)
         if query and resolved.get("provider") == "fallback":
@@ -222,7 +249,7 @@ def dispatch_alerts(now=None, dedupe_hours: int = 6) -> Dict[str, Any]:
 
     for location_code, group in groups.items():
         resolved = group.get("resolved") or {}
-        display_name = resolved.get("display_name") or location_code
+        display_name = _push_location_label(resolved)
 
         # Prefer official warnings.
         warnings = get_qweather_warnings(location_code)
@@ -276,23 +303,14 @@ def dispatch_alerts(now=None, dedupe_hours: int = 6) -> Dict[str, Any]:
                 continue
 
             # Build content
-            elder_names = []
-            location_query = ""
-            for p in user_pairs:
-                if not location_query:
-                    location_query = (p.location_query or p.community_code or "").strip()
-                mid = getattr(p, "member_id", None)
-                member = member_map.get(mid) if mid else None
-                if member and member.name:
-                    elder_names.append(member.name)
-
             threshold_desc = threshold[2] if (not primary_warning and threshold) else None
             title, content = _render_push_content(
                 display_name=display_name,
-                elder_names=elder_names,
+                # WxPusher 是第三方渠道，不外发老人姓名或细粒度地址。
+                elder_names=[],
                 warning=primary_warning,
                 threshold_desc=threshold_desc,
-                location_query=location_query,
+                location_query=display_name,
             )
 
             delivery_token = _generate_delivery_token()

--- a/services/user/_common.py
+++ b/services/user/_common.py
@@ -8,7 +8,7 @@ from flask_login import current_user
 
 from core.extensions import db
 from core.db_models import Pair, PairActionToken, PairLink
-from core.security import hash_pair_token, hash_short_code
+from core.security import hash_identifier, hash_pair_token, hash_short_code
 from core.time_utils import utcnow
 from utils.validators import sanitize_input
 
@@ -160,18 +160,53 @@ def _create_pair_record(caregiver_id, location_query, member_id=None, flush=Fals
     return pair
 
 
+def _derive_pair_action_token(record):
+    """从令牌记录与服务端 pepper 派生可重复生成的明文 token。"""
+    if not record or not getattr(record, 'id', None) or not getattr(record, 'pair_id', None):
+        return None
+    return hash_identifier(f'pair-action-record:{record.pair_id}:{record.id}')
+
+
 def _create_pair_action_token(pair, flush=False):
-    """创建行动链接 token，只把哈希写入数据库。"""
+    """创建或复用行动链接 token，数据库始终只保存哈希。"""
     if not pair or not getattr(pair, 'id', None):
         raise ValueError('pair id is required')
-    token = secrets.token_urlsafe(24)
+
+    now = utcnow()
+    reusable = PairActionToken.query.filter(
+        PairActionToken.pair_id == pair.id,
+        PairActionToken.revoked_at.is_(None),
+        PairActionToken.expires_at >= now,
+    ).order_by(PairActionToken.id.desc()).first()
+    if reusable:
+        token = _derive_pair_action_token(reusable)
+        expected_hash = hash_pair_token(token)
+        if (
+            token
+            and expected_hash
+            and reusable.token_hash
+            and secrets.compare_digest(expected_hash, reusable.token_hash)
+        ):
+            return reusable, token
+
+    # 清理已经失效的历史记录，避免长期运行后表持续增长。
+    PairActionToken.query.filter(
+        PairActionToken.pair_id == pair.id,
+        PairActionToken.expires_at < now,
+    ).delete(synchronize_session=False)
+
+    # 先写入一次性占位哈希取得记录 ID，再用 ID 派生可重建 token。
+    placeholder = secrets.token_urlsafe(32)
     record = PairActionToken(
         pair_id=pair.id,
-        token_hash=hash_pair_token(token),
+        token_hash=hash_pair_token(f'pending:{placeholder}'),
         expires_at=_action_token_expires_at(),
-        created_at=utcnow(),
+        created_at=now,
     )
     db.session.add(record)
+    db.session.flush()
+    token = _derive_pair_action_token(record)
+    record.token_hash = hash_pair_token(token)
     if flush:
         db.session.flush()
     return record, token

--- a/services/user/dashboard_service.py
+++ b/services/user/dashboard_service.py
@@ -12,7 +12,7 @@ from flask_login import current_user
 from core.extensions import db
 from core.guest import get_guest_assessment, is_guest_user
 from core.health_profiles import reminder_triggered
-from core.time_utils import today_local, utcnow
+from core.time_utils import today_local, utc_to_local_date, utcnow
 from core.weather import (
     ensure_user_location_valid,
     get_consecutive_hot_days,
@@ -105,6 +105,24 @@ def _dashboard_hero_theme(temperature):
         'effective_temperature': effective_temp,
         'intensity': round(intensity, 3),
         'style': style,
+    }
+
+
+def _dashboard_alert_card(alert):
+    """将 WeatherAlert 真字段转换成首页展示字段。"""
+    local_date = utc_to_local_date(alert.alert_date)
+    level_text = (alert.alert_level or '未分级').strip()
+    normalized_level = level_text.lower()
+    is_high = normalized_level in {'high', 'severe', 'red'} or any(
+        marker in level_text for marker in ('高', '严重', '红', '橙')
+    )
+    return {
+        'alert_type': alert.alert_type or '天气预警',
+        'alert_level': level_text,
+        'alert_date_local': local_date.strftime('%Y-%m-%d') if local_date else '日期未标注',
+        'location': alert.location or '地点未标注',
+        'description': alert.description,
+        'is_high': is_high,
     }
 
 
@@ -463,6 +481,8 @@ def user_dashboard(force_elder=False):
             is_guest=is_guest
         )
 
+    alert_cards = [_dashboard_alert_card(alert) for alert in alerts]
+
     return render_template('user_dashboard.html',
                          weather=weather if weather_available else None,
                          weather_source_city=weather_source_city,
@@ -477,7 +497,7 @@ def user_dashboard(force_elder=False):
                          dashboard_hero_theme=dashboard_hero_theme,
                          dashboard_metric_cards=dashboard_metric_cards,
                          forecast_days=forecast_days,
-                         alerts=alerts,
+                         alerts=alert_cards,
                          reminders=reminders,
                          notifications=notifications,
                          is_guest=is_guest)

--- a/services/weather_service.py
+++ b/services/weather_service.py
@@ -86,11 +86,22 @@ class WeatherService:
         if not (-180 <= lon <= 180 and -90 <= lat <= 90):
             return None
         return lon, lat
+
+    def _get_fallback_weather(self, city, logger=None):
+        """按 Open-Meteo、Mock 的顺序返回兜底天气。"""
+        logger = logger or logging.getLogger(__name__)
+        if self.use_openmeteo_fallback:
+            logger.info("尝试使用Open-Meteo备用API...")
+            openmeteo_result = self._get_openmeteo_weather(city)
+            if openmeteo_result:
+                return openmeteo_result
+
+        logger.error("所有天气API均失败，使用模拟数据")
+        return self._get_mock_weather()
     
     def get_current_weather(self, city="都昌"):
         """
-        获取当前天气数据 - 使用和风天气API
-        如果API调用失败，返回模拟数据
+        获取当前天气数据，依次尝试和风天气、Open-Meteo 与模拟数据。
         """
         logger = logging.getLogger(__name__)
         # 尝试调用和风天气API
@@ -112,30 +123,42 @@ class WeatherService:
                 
                 # 检查HTTP状态码
                 if weather_response.status_code != 200:
-                    logger.warning("API HTTP状态码: %s，使用模拟数据", weather_response.status_code)
-                    return self._get_mock_weather()
+                    logger.warning("API HTTP状态码: %s，尝试备用API", weather_response.status_code)
+                    return self._get_fallback_weather(city, logger)
                 
                 try:
                     weather_data = weather_response.json()
                 except Exception as json_error:
-                    logger.warning("JSON解析失败: %s，使用模拟数据", json_error)
+                    logger.warning("JSON解析失败: %s，尝试备用API", json_error)
                     logger.debug("响应内容: %s", weather_response.text[:200])
-                    return self._get_mock_weather()
+                    return self._get_fallback_weather(city, logger)
                 
                 # 检查返回状态
                 code = weather_data.get('code')
                 if code != '200':
                     if code is None:
-                        logger.warning("和风天气API响应格式异常，使用模拟数据")
+                        logger.warning("和风天气API响应格式异常，尝试备用API")
                         logger.debug("响应内容: %s", str(weather_data)[:200])
                     else:
                         error_msg = self._get_error_message(code)
-                        logger.warning("和风天气API返回错误[%s]: %s，使用模拟数据", code, error_msg)
-                    return self._get_mock_weather()
+                        logger.warning("和风天气API返回错误[%s]: %s，尝试备用API", code, error_msg)
+                    return self._get_fallback_weather(city, logger)
                 
                 # 解析天气数据
-                now = weather_data.get('now', {})
-                temp_val = float(now.get('temp', 20))
+                now = weather_data.get('now')
+                if not isinstance(now, dict):
+                    logger.warning("和风天气API缺少实况字段，尝试备用API")
+                    return self._get_fallback_weather(city, logger)
+                temp_val = self._safe_float(now.get('temp'))
+                humidity_val = self._safe_float(now.get('humidity'))
+                if (
+                    temp_val is None
+                    or humidity_val is None
+                    or not math.isfinite(temp_val)
+                    or not math.isfinite(humidity_val)
+                ):
+                    logger.warning("和风天气API关键实况字段不完整，尝试备用API")
+                    return self._get_fallback_weather(city, logger)
                 result = {
                     'temperature': temp_val,
                     # 优先使用真实日极值，必要时回退到小时序列推导
@@ -144,12 +167,12 @@ class WeatherService:
                     'temperature_estimated': True,
                     'temperature_range_source': 'unavailable',
                     'temperature_range_confidence': 'none',
-                    'humidity': float(now.get('humidity', 60)),
-                    'pressure': float(now.get('pressure', 1013)),
+                    'humidity': humidity_val,
+                    'pressure': self._safe_float(now.get('pressure')),
                     'weather_condition': now.get('text', '晴'),
-                    'wind_speed': float(now.get('windSpeed', 3)),
+                    'wind_speed': self._safe_float(now.get('windSpeed')),
                     'wind_dir': now.get('windDir', ''),
-                    'feels_like': float(now.get('feelsLike', now.get('temp', 20))),
+                    'feels_like': self._safe_float(now.get('feelsLike'), temp_val),
                     'pm25': None,
                     'aqi': None,
                     'location': city,
@@ -211,16 +234,7 @@ class WeatherService:
         else:
             logger.warning("未配置和风天气API，尝试备用API")
         
-        # 和风天气API失败，尝试Open-Meteo备用API
-        if self.use_openmeteo_fallback:
-            logger.info("尝试使用Open-Meteo备用API...")
-            openmeteo_result = self._get_openmeteo_weather(city)
-            if openmeteo_result:
-                return openmeteo_result
-        
-        # 所有API都失败，返回模拟数据
-        logger.error("所有天气API均失败，使用模拟数据")
-        return self._get_mock_weather()
+        return self._get_fallback_weather(city, logger)
     
     def _get_error_message(self, code):
         """获取错误码对应的说明"""

--- a/templates/cooling.html
+++ b/templates/cooling.html
@@ -48,8 +48,8 @@
         <div class="row g-3 align-items-end">
             <div class="col-md-5">
                 <label class="form-label">所在地</label>
-                <input type="text" class="form-control" name="location" value="{{ request.args.get('location', current_location) }}" list="locOpts">
-                <datalist id="locOpts">{% for loc in (location_options or []) %}<option value="{{ loc }}"></option>{% endfor %}</datalist>
+                <input type="text" class="form-control" name="community" value="{{ selected_community or current_location or '' }}" list="locOpts">
+                <datalist id="locOpts">{% for loc in (communities or location_options or []) %}<option value="{{ loc }}"></option>{% endfor %}</datalist>
             </div>
             <div class="col-md-4">
                 <label class="form-label">类型</label>

--- a/templates/user_dashboard.html
+++ b/templates/user_dashboard.html
@@ -166,11 +166,11 @@
             </div>
             <div class="yl-alert-list mt-3">
                 {% for a in alerts %}
-                <div class="yl-alert-item {% if a.level == 'high' %}level-high{% endif %}">
+                <div class="yl-alert-item {% if a.is_high %}level-high{% endif %}">
                     <span class="dot"></span>
                     <div class="body">
-                        <strong>{{ a.title or a.event }}</strong>
-                        <div class="meta">{{ a.start_time or '' }} · {{ a.region or current_location }}</div>
+                        <strong>{{ a.alert_type }} · {{ a.alert_level }}</strong>
+                        <div class="meta">{{ a.alert_date_local }} · {{ a.location }}</div>
                         {% if a.description %}<div class="mt-1" style="font-size:.88rem; color:var(--yl-ink-soft);">{{ a.description }}</div>{% endif %}
                     </div>
                 </div>

--- a/tests/manual/test_weather_api.py
+++ b/tests/manual/test_weather_api.py
@@ -21,16 +21,13 @@ def test_qweather_api():
     location = "116.20,29.27"  # 都昌县
 
     if not key:
-        print("❌ 未设置环境变量 QWEATHER_KEY，无法测试。")
-        return
+        pytest.skip("未设置 QWEATHER_KEY")
     if not base_url:
-        print("❌ 未设置环境变量 QWEATHER_API_BASE，无法测试。")
-        return
+        pytest.skip("未设置 QWEATHER_API_BASE")
     if "your-qweather-host.example.com" in base_url:
-        print("❌ QWEATHER_API_BASE 仍是占位值，请先改成真实 Host。")
-        return
+        pytest.skip("QWEATHER_API_BASE 仍是占位值")
     
-    print(f"\nAPI Key: {key[:6]}...{key[-4:]}")
+    print("\nAPI Key: 已配置")
     print(f"Base URL: {base_url}")
     print(f"Location: {location}")
     
@@ -48,31 +45,16 @@ def test_qweather_api():
         
         print(f"HTTP状态码: {response.status_code}")
         
-        if response.status_code == 200:
-            data = response.json()
-            code = data.get('code')
-            print(f"API返回码: {code}")
+        assert response.status_code == 200, f"实况天气 HTTP {response.status_code}"
+        data = response.json()
+        code = data.get('code')
+        assert code == '200', f"实况天气业务码 {code}"
+        now = data.get('now') or {}
+        assert now.get('temp') is not None
+        assert now.get('humidity') is not None
             
-            if code == '200':
-                now = data.get('now', {})
-                print(f"✅ 成功！")
-                print(f"   温度: {now.get('temp')}°C")
-                print(f"   天气: {now.get('text')}")
-                print(f"   湿度: {now.get('humidity')}%")
-                print(f"   风速: {now.get('windSpeed')} km/h")
-            else:
-                print(f"❌ API返回错误码: {code}")
-                print(f"   完整响应: {data}")
-        else:
-            print(f"❌ HTTP错误: {response.status_code}")
-            print(f"   响应内容: {response.text[:500]}")
-            
-    except requests.exceptions.Timeout:
-        print("❌ 请求超时")
-    except requests.exceptions.ConnectionError as e:
-        print(f"❌ 连接错误: {e}")
-    except Exception as e:
-        print(f"❌ 未知错误: {e}")
+    except requests.RequestException as exc:
+        pytest.fail(f"实况天气请求失败: {type(exc).__name__}")
     
     # 测试2: 7天预报
     print("\n" + "-" * 40)
@@ -86,23 +68,15 @@ def test_qweather_api():
         response = requests.get(url, params=params, timeout=10)
         print(f"HTTP状态码: {response.status_code}")
         
-        if response.status_code == 200:
-            data = response.json()
-            code = data.get('code')
-            print(f"API返回码: {code}")
+        assert response.status_code == 200, f"7天预报 HTTP {response.status_code}"
+        data = response.json()
+        code = data.get('code')
+        assert code == '200', f"7天预报业务码 {code}"
+        daily = data.get('daily') or []
+        assert len(daily) >= 7
             
-            if code == '200':
-                daily = data.get('daily', [])
-                print(f"✅ 成功！获取到 {len(daily)} 天预报")
-                for day in daily[:3]:
-                    print(f"   {day.get('fxDate')}: {day.get('tempMin')}~{day.get('tempMax')}°C, {day.get('textDay')}")
-            else:
-                print(f"❌ API返回错误码: {code}")
-        else:
-            print(f"❌ HTTP错误")
-            
-    except Exception as e:
-        print(f"❌ 错误: {e}")
+    except requests.RequestException as exc:
+        pytest.fail(f"7天预报请求失败: {type(exc).__name__}")
     
     # 测试3: 空气质量
     print("\n" + "-" * 40)
@@ -116,24 +90,17 @@ def test_qweather_api():
         response = requests.get(url, params=params, timeout=10)
         print(f"HTTP状态码: {response.status_code}")
         
-        if response.status_code == 200:
-            data = response.json()
-            code = data.get('code')
-            print(f"API返回码: {code}")
+        assert response.status_code == 200, f"空气质量 HTTP {response.status_code}"
+        data = response.json()
+        code = data.get('code')
+        assert code in {'200', '204'}, f"空气质量业务码 {code}"
+        if code == '200':
+            now = data.get('now') or {}
+            assert now.get('aqi') is not None
+            assert now.get('pm2p5') is not None
             
-            if code == '200':
-                now = data.get('now', {})
-                print(f"✅ 成功！")
-                print(f"   AQI: {now.get('aqi')}")
-                print(f"   PM2.5: {now.get('pm2p5')}")
-                print(f"   空气质量: {now.get('category')}")
-            else:
-                print(f"⚠️ API返回码: {code} (空气质量数据可能不可用)")
-        else:
-            print(f"❌ HTTP错误")
-            
-    except Exception as e:
-        print(f"❌ 错误: {e}")
+    except requests.RequestException as exc:
+        pytest.fail(f"空气质量请求失败: {type(exc).__name__}")
     
     print("\n" + "=" * 50)
     print("测试完成")

--- a/tests/test_action_rate_active_pairs.py
+++ b/tests/test_action_rate_active_pairs.py
@@ -98,3 +98,36 @@ def test_refresh_persists_active_pair_denominator_and_numerators(db_session):
     assert record.escalation_rate == 0
     risk_distribution = json.loads(record.risk_distribution)
     assert risk_distribution == {'低风险': 1, '中风险': 0, '高风险': 0, '极高': 0}
+
+
+def test_public_refresh_uses_the_same_active_pair_population(db_session):
+    from services.public_service import _refresh_community_daily
+
+    status_date = _seed_active_and_inactive_statuses(db_session)
+
+    _refresh_community_daily('行动率测试社区', status_date)
+    record = CommunityDaily.query.filter_by(
+        community_code='行动率测试社区',
+        date=status_date,
+    ).one()
+
+    assert record.total_people == 1
+    assert record.confirm_rate == 0
+    assert record.escalation_rate == 0
+    assert record.confirm_rate <= 1
+    assert json.loads(record.risk_distribution) == {
+        '低风险': 1,
+        '中风险': 0,
+        '高风险': 0,
+        '极高': 0,
+    }
+
+    active_status = DailyStatus.query.join(Pair).filter(
+        Pair.status == 'active',
+        DailyStatus.status_date == status_date,
+    ).one()
+    active_status.relay_stage = 'backup'
+    db_session.commit()
+
+    _refresh_community_daily('行动率测试社区', status_date)
+    assert record.escalation_rate == 1

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -62,3 +62,37 @@ def test_admin_statistics_renders(client, db_session):
     assert '相关系数分析（基于历史数据）' not in body
     assert 'data: [35, 75, 65, 85, 70]' not in body
     assert 'min="2023-12-01"' not in body
+
+
+def test_pilot_dashboard_renders_for_admin(client, db_session):
+    from core.db_models import User
+
+    admin = User(username='admin_pilot', role='admin')
+    admin.set_password('testpass')
+    db_session.add(admin)
+    db_session.commit()
+
+    _login_as(client, admin.id)
+    response = client.get('/analysis/pilot?days=30')
+
+    assert response.status_code == 200
+    assert '试点数据看板' in response.get_data(as_text=True)
+
+
+def test_pilot_export_csv_returns_empty_export_for_admin(client, db_session):
+    from core.db_models import User
+
+    admin = User(username='admin_pilot_export', role='admin')
+    admin.set_password('testpass')
+    db_session.add(admin)
+    db_session.commit()
+
+    _login_as(client, admin.id)
+    response = client.get('/analysis/pilot/export.csv?days=30')
+
+    assert response.status_code == 200
+    assert response.mimetype == 'text/csv'
+    assert 'pilot_events_last_30d.csv' in response.headers['Content-Disposition']
+    assert response.get_data(as_text=True).startswith(
+        '\ufeffcreated_at,event_type,user_id,pair_id,member_id,source,meta_json'
+    )

--- a/tests/test_amap_proxy.py
+++ b/tests/test_amap_proxy.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import json
 
+import pytest
+import requests
+
 
 def test_amap_proxy_appends_server_side_jscode(client, app, monkeypatch):
     class FakeResp:
@@ -60,3 +63,27 @@ def test_amap_proxy_rejects_oversized_response(client, app, monkeypatch):
 
     response = client.get('/_AMapService/v3/place/text?key=frontend-visible-key&keywords=test')
     assert response.status_code == 502
+
+
+@pytest.mark.parametrize(
+    'error_type',
+    [requests.Timeout, requests.ConnectionError, requests.RequestException],
+)
+def test_amap_proxy_returns_safe_502_for_upstream_request_errors(
+    client,
+    app,
+    monkeypatch,
+    error_type,
+):
+    def fake_get(*args, **kwargs):
+        raise error_type('upstream-sensitive-detail')
+
+    monkeypatch.setattr('blueprints.public.requests.get', fake_get)
+
+    with app.app_context():
+        app.config['AMAP_SECURITY_JS_CODE'] = 'server-side-security-code-123456'
+
+    response = client.get('/_AMapService/v3/place/text?key=frontend-visible-key&keywords=test')
+
+    assert response.status_code == 502
+    assert 'upstream-sensitive-detail' not in response.get_data(as_text=True)

--- a/tests/test_dashboard_temperature_theme.py
+++ b/tests/test_dashboard_temperature_theme.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
+from datetime import datetime, timezone
 
 from services.user.dashboard_service import _dashboard_hero_theme
 
@@ -43,3 +44,43 @@ def test_dashboard_renders_temperature_theme(authenticated_client):
     assert 'data-temp-intensity="' in html
     assert "--yl-hero-primary:" in html
     assert "家庭照护今日页" in html
+
+
+def test_dashboard_renders_weather_alert_real_fields_with_local_date(
+    authenticated_client,
+    db_session,
+    monkeypatch,
+):
+    from core.db_models import User, WeatherAlert
+
+    fixed_now = datetime(2026, 1, 1, 20, 0, tzinfo=timezone.utc)
+    user = User.query.filter_by(username='testuser').one()
+    user.community = '都昌'
+    db_session.add(WeatherAlert(
+        alert_date=datetime(2026, 1, 1, 18, 0, tzinfo=timezone.utc),
+        location='都昌',
+        alert_type='高温预警',
+        alert_level='红色',
+        description='测试预警详情',
+    ))
+    db_session.commit()
+
+    monkeypatch.setattr('services.user.dashboard_service.utcnow', lambda: fixed_now)
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_weather_with_cache',
+        lambda _location: ({'data_source': 'Demo', 'is_mock': True}, False),
+    )
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_qweather_forecast_with_cache',
+        lambda _location, days=7: ([], False, {'error': 'qweather_unavailable'}),
+    )
+
+    response = authenticated_client.get('/dashboard')
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert '高温预警 · 红色' in html
+    assert '2026-01-02 · 都昌' in html
+    assert '测试预警详情' in html
+    assert 'yl-alert-item level-high' in html
+    assert '<strong></strong>' not in html

--- a/tests/test_deploy_script.py
+++ b/tests/test_deploy_script.py
@@ -37,6 +37,16 @@ def test_deploy_script_sets_precompute_python_path():
     assert 'Environment=VENV_PY=$VENV_DIR/bin/python' in content
 
 
+def test_deploy_script_uses_shared_database_backup_resolver():
+    content = _load_deploy_script()
+
+    assert "bash scripts/backup.sh --if-present" in content
+    assert "PROJECT_DIR='$PROJECT_DIR'" in content
+    assert "ENV_FILE='$PROJECT_DIR/.env'" in content
+    assert "cp -a instance/health_weather.db" not in content
+    assert "redis-server sqlite3" in content
+
+
 def test_deploy_script_excludes_local_design_drafts():
     content = _load_deploy_script()
 

--- a/tests/test_manual_fix_script.py
+++ b/tests/test_manual_fix_script.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""手动安全修复脚本回归测试。"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT_DIR / "scripts" / "complete_manual_fixes.sh"
+
+
+def _classify_value(env_file, key):
+    command = (
+        f"source '{SCRIPT_PATH}'; "
+        f"value=$(read_env_value '{key}' '{env_file}'); "
+        "if is_placeholder_secret \"$value\"; then printf placeholder; else printf configured; fi"
+    )
+    return subprocess.run(
+        ["bash", "-c", command], check=True, capture_output=True, text=True
+    ).stdout
+
+
+@pytest.mark.parametrize("key", ["SECRET_KEY", "PAIR_TOKEN_PEPPER"])
+@pytest.mark.parametrize(
+    "raw_value",
+    [
+        "",
+        "your-secret-key-here",
+        "'change-me-min-32-chars' # 旧示例",
+        '\"example-secret\" # 旧示例',
+        "YOUR_PLACEHOLDER_VALUE",
+    ],
+)
+def test_manual_fix_script_detects_legacy_placeholders(tmp_path, key, raw_value):
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"{key} = {raw_value}\n", encoding="utf-8")
+    assert _classify_value(env_file, key) == "placeholder"
+
+
+def test_manual_fix_script_accepts_quoted_real_value_with_comment(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        'SECRET_KEY="9f50c89b76e94f739918a54e7c47a6218ca55bc7" # production\n',
+        encoding="utf-8",
+    )
+    assert _classify_value(env_file, "SECRET_KEY") == "configured"
+
+
+def test_manual_fix_script_keeps_generated_env_private():
+    content = SCRIPT_PATH.read_text(encoding="utf-8")
+    assert 'chmod 600 "$tmp_file"' in content
+
+
+def test_manual_fix_script_replaces_and_deduplicates_secret_keys(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "SECRET_KEY=first-real-value\n"
+        "OTHER_SETTING=kept\n"
+        "SECRET_KEY=change-me-min-32-chars\n",
+        encoding="utf-8",
+    )
+    command = (
+        f"source '{SCRIPT_PATH}'; "
+        f"write_env_value SECRET_KEY generated-value '{env_file}'"
+    )
+
+    subprocess.run(["bash", "-c", command], check=True)
+
+    lines = env_file.read_text(encoding="utf-8").splitlines()
+    assert lines.count("SECRET_KEY=generated-value") == 1
+    assert sum(line.startswith("SECRET_KEY=") for line in lines) == 1
+    assert "OTHER_SETTING=kept" in lines
+    assert env_file.stat().st_mode & 0o777 == 0o600

--- a/tests/test_mp_api_auth.py
+++ b/tests/test_mp_api_auth.py
@@ -48,18 +48,72 @@ def test_mp_api_me_and_patch(app, client, db_session):
     assert resp3.status_code == 401
 
 
-def test_mp_api_rate_limit_key_uses_bearer_token(app):
+def test_mp_api_rate_limit_key_uses_stable_client_ip(app):
     from blueprints.mp_api import _mp_rate_limit_key
 
-    with app.test_request_context("/mp/api/v1/me", headers={"Authorization": "Bearer token-a"}):
+    same_ip = {"REMOTE_ADDR": "203.0.113.10"}
+    other_ip = {"REMOTE_ADDR": "203.0.113.11"}
+    with app.test_request_context(
+        "/mp/api/v1/me",
+        headers={"Authorization": "Bearer token-a"},
+        environ_base=same_ip,
+    ):
         key_a = _mp_rate_limit_key()
 
-    with app.test_request_context("/mp/api/v1/me", headers={"Authorization": "Bearer token-b"}):
+    with app.test_request_context(
+        "/mp/api/v1/me",
+        headers={"Authorization": "Bearer token-b"},
+        environ_base=same_ip,
+    ):
         key_b = _mp_rate_limit_key()
 
-    assert key_a.startswith("mp-token:")
-    assert key_b.startswith("mp-token:")
-    assert key_a != key_b
+    with app.test_request_context(
+        "/mp/api/v1/me",
+        headers={"Authorization": "Bearer token-a"},
+        environ_base=other_ip,
+    ):
+        key_other_ip = _mp_rate_limit_key()
+
+    assert key_a.startswith("mp-ip:")
+    assert key_a == key_b
+    assert key_other_ip != key_a
+
+
+def test_mp_api_invalid_bearer_rotation_cannot_bypass_ip_limit(
+    app,
+    client,
+    db_session,
+):
+    """同一 IP 轮换无效 Bearer 仍应命中同一个外层限流桶。"""
+    from core.extensions import limiter
+
+    app.config['RATE_LIMIT_MP_READ'] = '1 per minute'
+    limiter.reset()
+    same_ip = {'REMOTE_ADDR': '203.0.113.20'}
+    other_ip = {'REMOTE_ADDR': '203.0.113.21'}
+
+    try:
+        first = client.get(
+            '/mp/api/v1/me',
+            headers={'Authorization': 'Bearer invalid-a'},
+            environ_overrides=same_ip,
+        )
+        rotated = client.get(
+            '/mp/api/v1/me',
+            headers={'Authorization': 'Bearer invalid-b'},
+            environ_overrides=same_ip,
+        )
+        separate_ip = client.get(
+            '/mp/api/v1/me',
+            headers={'Authorization': 'Bearer invalid-c'},
+            environ_overrides=other_ip,
+        )
+
+        assert first.status_code == 401
+        assert rotated.status_code == 429
+        assert separate_ip.status_code == 401
+    finally:
+        limiter.reset()
 
 
 def test_mp_api_events_rejects_invalid_event_type(app, client, db_session):

--- a/tests/test_open_source_contracts.py
+++ b/tests/test_open_source_contracts.py
@@ -120,7 +120,7 @@ def test_multimodel_forecast_contract_preserves_provider_names(app):
 
 
 def test_qweather_production_guard_rejects_non_finite_temperature():
-    from core.weather import is_qweather_online_weather
+    from core.weather import is_qweather_online_weather, weather_source_label
 
     assert is_qweather_online_weather({
         'temperature': 31,
@@ -137,10 +137,12 @@ def test_qweather_production_guard_rejects_non_finite_temperature():
         'data_source': 'QWeather',
         'is_mock': False,
     }) is False
-    assert is_qweather_online_weather({
+    missing_provenance = {
         'temperature': 31,
         'is_mock': False,
-    }) is False
+    }
+    assert weather_source_label(missing_provenance) == ''
+    assert is_qweather_online_weather(missing_provenance) is False
 
 
 def test_dlnm_profile_contract_is_frozen_json_artifact():

--- a/tests/test_public_token_flow.py
+++ b/tests/test_public_token_flow.py
@@ -3,7 +3,7 @@
 
 from datetime import timedelta
 
-from core.db_models import DailyStatus, Pair, PairActionToken, PairLink, User
+from core.db_models import CommunityDaily, DailyStatus, Pair, PairActionToken, PairLink, User
 from core.security import hash_pair_token, hash_short_code
 from core.time_utils import today_local, utcnow
 from core.extensions import db
@@ -300,6 +300,100 @@ def test_pair_action_token_route_rejects_expired_token(app, client):
     with app.app_context():
         status = DailyStatus.query.filter_by(pair_id=pair_id, status_date=today_local()).first()
         assert status is None or status.confirmed_at is None
+
+
+def test_generated_action_token_survives_short_code_expiry_and_is_reused(app, client):
+    """新行动 token 使用自己的有效期，重复渲染链接不应持续新增记录。"""
+    from services.user._common import _build_pair_action_link
+
+    with app.app_context():
+        db.create_all()
+        user = _create_user("generated_token_user", "generated_token_pass")
+        pair = Pair(
+            caregiver_id=user.id,
+            community_code="都昌",
+            location_query="都昌",
+            elder_code="elder-generated-token",
+            short_code="55667788",
+            short_code_hash=hash_short_code("55667788"),
+            short_code_expires_at=utcnow() - timedelta(seconds=1),
+            status="active",
+            created_at=utcnow() - timedelta(days=91),
+            last_active_at=utcnow(),
+        )
+        db.session.add(pair)
+        db.session.flush()
+        pair_id = pair.id
+
+        with app.test_request_context("/pairs"):
+            first_link = _build_pair_action_link(pair, external=False)
+        db.session.commit()
+        db.session.expire_all()
+
+        pair = db.session.get(Pair, pair_id)
+        with app.test_request_context("/pairs"):
+            second_link = _build_pair_action_link(pair, external=False)
+        db.session.commit()
+
+        assert first_link == second_link
+        assert PairActionToken.query.filter_by(pair_id=pair_id).count() == 1
+        token = first_link.rsplit("/e/", 1)[-1].split("?", 1)[0]
+
+    with client.session_transaction() as sess:
+        sess["_csrf_token"] = "generated-token-csrf"
+
+    response = client.post(
+        f"/e/{token}/checkin",
+        data={"short_code": "55667788", "csrf_token": "generated-token-csrf"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 200
+    with app.app_context():
+        status = DailyStatus.query.filter_by(pair_id=pair_id, status_date=today_local()).one()
+        assert status.confirmed_at is not None
+        assert PairActionToken.query.filter_by(pair_id=pair_id).count() == 1
+
+
+def test_help_does_not_count_as_confirmation(app, client):
+    """求助只写 help_flag，不能抬高行动确认率。"""
+    with app.app_context():
+        db.create_all()
+        user = _create_user("help_only_user", "help_only_pass")
+        pair = Pair(
+            caregiver_id=user.id,
+            community_code="求助口径社区",
+            location_query="都昌",
+            elder_code="elder-help-only",
+            short_code="44332211",
+            short_code_hash=hash_short_code("44332211"),
+            status="active",
+            created_at=utcnow(),
+            last_active_at=utcnow(),
+        )
+        db.session.add(pair)
+        db.session.commit()
+        pair_id = pair.id
+
+    with client.session_transaction() as sess:
+        sess["_csrf_token"] = "help-only-csrf"
+
+    response = client.post(
+        "/action/help",
+        data={"short_code": "44332211", "csrf_token": "help-only-csrf"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 200
+    with app.app_context():
+        status = DailyStatus.query.filter_by(pair_id=pair_id, status_date=today_local()).one()
+        aggregate = CommunityDaily.query.filter_by(
+            community_code="求助口径社区",
+            date=today_local(),
+        ).one()
+        assert status.help_flag is True
+        assert status.confirmed_at is None
+        assert aggregate.confirm_rate == 0
 
 
 def test_token_debrief_get_rejects_mismatched_token(app, client):

--- a/tests/test_push_dispatch.py
+++ b/tests/test_push_dispatch.py
@@ -128,3 +128,134 @@ def test_tracking_route_marks_clicked(client, app, db_session):
         assert refreshed is not None
         assert refreshed.clicked_at is not None
         assert UsageEvent.query.filter_by(event_type="push_click").count() == 1
+
+
+def _stub_dispatch_weather(monkeypatch, dispatch_mod):
+    monkeypatch.setattr(dispatch_mod, "get_qweather_warnings", lambda _location: [])
+    monkeypatch.setattr(
+        dispatch_mod,
+        "get_weather_with_cache",
+        lambda _location: ({
+            "temperature": 36,
+            "temperature_max": 38,
+            "temperature_min": 27,
+            "data_source": "QWeather",
+            "is_mock": False,
+        }, False),
+    )
+
+
+def test_dispatch_respects_member_alert_and_privacy_settings(app, db_session, monkeypatch):
+    from core.db_models import FamilyMember, FamilyMemberProfile, Pair, User
+    from core.security import hash_short_code
+    from core.time_utils import utcnow
+    from services.push import dispatch as dispatch_mod
+
+    with app.app_context():
+        user = User(username="push_privacy", role="user", wxpusher_uid="UID_PRIVATE", push_enabled=True)
+        user.set_password("pw123456")
+        db_session.add(user)
+        db_session.flush()
+
+        disabled_member = FamilyMember(user_id=user.id, name="关闭预警成员")
+        private_member = FamilyMember(user_id=user.id, name="私密成员")
+        db_session.add_all([disabled_member, private_member])
+        db_session.flush()
+        db_session.add_all([
+            FamilyMemberProfile(
+                member_id=disabled_member.id,
+                alert_enabled=False,
+                privacy_level="family",
+            ),
+            FamilyMemberProfile(
+                member_id=private_member.id,
+                alert_enabled=True,
+                privacy_level="private",
+            ),
+        ])
+        for index, member in enumerate((disabled_member, private_member), start=1):
+            code = f"9900000{index}"
+            db_session.add(Pair(
+                caregiver_id=user.id,
+                member_id=member.id,
+                community_code="都昌",
+                location_query="都昌",
+                elder_code=f"privacy-{index}",
+                short_code=code,
+                short_code_hash=hash_short_code(code),
+                status="active",
+                last_active_at=utcnow(),
+            ))
+        db_session.commit()
+
+        sent = []
+        monkeypatch.setattr(
+            dispatch_mod,
+            "wxpusher_send",
+            lambda *args, **kwargs: sent.append((args, kwargs)) or {"ok": True},
+        )
+        _stub_dispatch_weather(monkeypatch, dispatch_mod)
+
+        result = dispatch_mod.dispatch_alerts()
+
+        assert result["deliveries"] == 0
+        assert sent == []
+
+
+def test_dispatch_minimizes_identity_data_sent_to_third_party(app, db_session, monkeypatch):
+    from core.db_models import FamilyMember, FamilyMemberProfile, Pair, User
+    from core.security import hash_short_code
+    from core.time_utils import utcnow
+    from services.push import dispatch as dispatch_mod
+
+    with app.app_context():
+        user = User(username="push_minimized", role="user", wxpusher_uid="UID_MIN", push_enabled=True)
+        user.set_password("pw123456")
+        db_session.add(user)
+        db_session.flush()
+        member = FamilyMember(user_id=user.id, name="不应外发的姓名")
+        db_session.add(member)
+        db_session.flush()
+        db_session.add(FamilyMemberProfile(
+            member_id=member.id,
+            alert_enabled=True,
+            privacy_level="family",
+        ))
+        code = "99112233"
+        db_session.add(Pair(
+            caregiver_id=user.id,
+            member_id=member.id,
+            community_code="都昌",
+            location_query="都昌某路123号",
+            elder_code="minimized-elder",
+            short_code=code,
+            short_code_hash=hash_short_code(code),
+            status="active",
+            last_active_at=utcnow(),
+        ))
+        db_session.commit()
+
+        captured = {}
+
+        def fake_send(_uid, title, content, url=None):
+            captured.update({"title": title, "content": content, "url": url})
+            return {"ok": True}
+
+        monkeypatch.setattr(dispatch_mod, "wxpusher_send", fake_send)
+        monkeypatch.setattr(
+            dispatch_mod,
+            "resolve_location",
+            lambda _query: {
+                "location_code": "101240201",
+                "provider": "amap",
+                "display_name": "都昌某路123号",
+            },
+        )
+        _stub_dispatch_weather(monkeypatch, dispatch_mod)
+
+        result = dispatch_mod.dispatch_alerts()
+
+        assert result["deliveries"] == 1
+        assert "不应外发的姓名" not in captured["content"]
+        assert "都昌某路123号" not in captured["content"]
+        assert "地点：所在地区" in captured["content"]

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -333,5 +333,22 @@ def test_create_notification_fails_closed_on_quota_error(app, monkeypatch):
     assert result is None
 
 
+def test_structured_logs_redact_action_and_tracking_tokens(app, client, monkeypatch):
+    """高熵链接凭据不能进入结构化请求日志。"""
+    from core.hooks import _redact_sensitive_path
+
+    assert _redact_sensitive_path('/e/action-secret/checkin') == '/e/<token>/checkin'
+    assert _redact_sensitive_path('/t/tracking-secret') == '/t/<token>'
+    assert _redact_sensitive_path('/dashboard') == '/dashboard'
+
+    app.config['FEATURE_STRUCTURED_LOGS'] = True
+    messages = []
+    monkeypatch.setattr('core.hooks.logger.info', lambda message, *args: messages.append(message))
+    client.get('/e/action-secret')
+
+    assert any('"path": "/e/<token>"' in message for message in messages)
+    assert all('action-secret' not in message for message in messages)
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -5,7 +5,8 @@ import tempfile
 import pytest
 
 
-TEST_DB_PATH = os.path.join(tempfile.gettempdir(), "case_weather_test.db")
+# 每个 pytest 进程使用独立数据库，避免未来并行 CI 互相删表。
+TEST_DB_PATH = os.path.join(tempfile.gettempdir(), f"case_weather_test_{os.getpid()}.db")
 os.environ["DATABASE_URI"] = f"sqlite:///{TEST_DB_PATH}"
 os.environ["QWEATHER_KEY"] = ""
 os.environ["AMAP_KEY"] = ""

--- a/tests/test_sqlite_path_resolution.py
+++ b/tests/test_sqlite_path_resolution.py
@@ -1,7 +1,10 @@
 import importlib.util
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
@@ -56,3 +59,72 @@ def test_backup_script_parses_relative_sqlite_uri_to_instance_path():
     )
     expected = str((ROOT_DIR / "instance" / "health_weather.db").resolve())
     assert result.stdout.strip() == expected
+
+
+def _backup_env(**overrides):
+    env = os.environ.copy()
+    env.pop("DATABASE_URI", None)
+    env.update({key: str(value) for key, value in overrides.items()})
+    return env
+
+
+def test_backup_project_dir_does_not_follow_external_env_file(tmp_path):
+    script_path = ROOT_DIR / "scripts" / "backup.sh"
+    env_file = tmp_path / "external" / ".env"
+    result = subprocess.run(
+        ["bash", "-c", f"source '{script_path}'; printf '%s' \"$PROJECT_DIR\""],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_backup_env(ENV_FILE=env_file),
+    )
+    assert result.stdout == str(ROOT_DIR)
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected"),
+    [
+        ("sqlite:///health_weather.db", "/srv/case/instance/health_weather.db"),
+        ("sqlite:///storage/live.db?mode=ro", "/srv/case/storage/live.db"),
+        ("sqlite:////var/lib/case/live.db", "/var/lib/case/live.db"),
+        ("sqlite+pysqlite:///health_weather.db", "/srv/case/instance/health_weather.db"),
+        ("sqlite+pysqlite:////var/lib/case/live.db?timeout=10", "/var/lib/case/live.db"),
+    ],
+)
+def test_backup_script_sqlite_uri_matrix(uri, expected):
+    script_path = ROOT_DIR / "scripts" / "backup.sh"
+    command = f"source '{script_path}'; PROJECT_DIR=/srv/case; parse_sqlite_path '{uri}'"
+    result = subprocess.run(["bash", "-c", command], check=True, capture_output=True, text=True)
+    assert result.stdout.strip() == expected
+
+
+def test_backup_script_rejects_non_sqlite_uri(tmp_path):
+    script_path = ROOT_DIR / "scripts" / "backup.sh"
+    env_file = tmp_path / ".env"
+    env_file.write_text("DATABASE_URI=postgresql://db.example/live\n", encoding="utf-8")
+    result = subprocess.run(
+        ["bash", str(script_path), "--if-present"],
+        capture_output=True,
+        text=True,
+        env=_backup_env(PROJECT_DIR=tmp_path, ENV_FILE=env_file),
+    )
+    assert result.returncode == 2
+    assert "仅支持 sqlite" in result.stderr
+
+
+def test_backup_script_missing_source_fails_unless_if_present(tmp_path):
+    script_path = ROOT_DIR / "scripts" / "backup.sh"
+    env_file = tmp_path / ".env"
+    env_file.write_text("DATABASE_URI='sqlite:///missing.db' # 首次部署\n", encoding="utf-8")
+    env = _backup_env(PROJECT_DIR=tmp_path, ENV_FILE=env_file)
+
+    required = subprocess.run(["bash", str(script_path)], capture_output=True, text=True, env=env)
+    optional = subprocess.run(
+        ["bash", str(script_path), "--if-present"], capture_output=True, text=True, env=env
+    )
+
+    assert required.returncode == 3
+    assert "拒绝创建空备份" in required.stderr
+    assert optional.returncode == 0
+    assert "按 --if-present 跳过备份" in optional.stdout
+    assert not (tmp_path / "backups").exists()

--- a/tests/test_sync_script.py
+++ b/tests/test_sync_script.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""快速同步脚本的失败传播回归测试。"""
+
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SYNC_SCRIPT = ROOT_DIR / "scripts" / "sync.sh"
+
+
+def test_sync_script_stops_when_upload_fails(tmp_path):
+    """上传失败后必须返回失败，不能继续重启或打印完成。"""
+    fake_rsync = tmp_path / "rsync"
+    fake_rsync.write_text("#!/bin/sh\nexit 23\n", encoding="utf-8")
+    fake_rsync.chmod(0o755)
+
+    ssh_marker = tmp_path / "ssh-called"
+    fake_ssh = tmp_path / "ssh"
+    fake_ssh.write_text(
+        f"#!/bin/sh\ntouch '{ssh_marker}'\nexit 0\n",
+        encoding="utf-8",
+    )
+    fake_ssh.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update({
+        "DEPLOY_SERVER": "example.invalid",
+        "DEPLOY_USER": "test-user",
+        "DEPLOY_LOCAL_DIR": str(ROOT_DIR),
+        "ENV_FILE": str(tmp_path / "missing.env"),
+        "PATH": f"{tmp_path}{os.pathsep}{env['PATH']}",
+    })
+    for key in ("DEPLOY_PASSWORD", "SSHPASS"):
+        env.pop(key, None)
+
+    result = subprocess.run(
+        ["bash", str(SYNC_SCRIPT)],
+        cwd=ROOT_DIR,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 23
+    assert "同步完成" not in result.stdout
+    assert not ssh_marker.exists()
+
+
+def test_sync_script_expect_branch_propagates_child_status():
+    """密码交互分支也必须返回 rsync/ssh 的真实退出码。"""
+    content = SYNC_SCRIPT.read_text(encoding="utf-8")
+
+    assert "set -euo pipefail" in content
+    assert content.count("set wait_result [wait]") == 2
+    assert content.count("exit [lindex \\$wait_result 3]") == 2

--- a/tests/test_tools_page_regressions.py
+++ b/tests/test_tools_page_regressions.py
@@ -726,3 +726,43 @@ def test_cooling_resource_type_takes_precedence_over_legacy_type(client, db_sess
     assert '真实商场' in body
     assert '真实图书馆' not in body
     assert '<option value="商场" selected>' in body
+
+
+def test_cooling_community_filter_supports_new_and_legacy_query_names(client, db_session, monkeypatch):
+    from core.db_models import CoolingResource
+
+    monkeypatch.setattr(
+        'services.public_service.get_weather_with_cache',
+        lambda location: ({'temperature': 27.5, 'is_mock': False, 'data_source': 'QWeather'}, False),
+    )
+    db_session.add_all([
+        CoolingResource(
+            community_code='甲村',
+            name='甲村纳凉点',
+            resource_type='活动中心',
+            is_active=True,
+        ),
+        CoolingResource(
+            community_code='乙村',
+            name='乙村纳凉点',
+            resource_type='活动中心',
+            is_active=True,
+        ),
+    ])
+    db_session.commit()
+
+    response = client.get('/cooling?community=甲村')
+    body = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert '甲村纳凉点' in body
+    assert '乙村纳凉点' not in body
+    assert 'name="community"' in body
+    assert 'value="甲村"' in body
+
+    legacy_response = client.get('/cooling?location=乙村')
+    legacy_body = legacy_response.get_data(as_text=True)
+    assert legacy_response.status_code == 200
+    assert '乙村纳凉点' in legacy_body
+    assert '甲村纳凉点' not in legacy_body
+    assert 'name="community"' in legacy_body
+    assert 'value="乙村"' in legacy_body

--- a/tests/test_weather_sync_pipeline.py
+++ b/tests/test_weather_sync_pipeline.py
@@ -1,0 +1,322 @@
+# -*- coding: utf-8 -*-
+"""天气兜底与行动同步 fail-closed 回归测试。"""
+
+import json
+from datetime import date
+
+import pytest
+
+from core.db_models import CommunityDaily, DailyStatus, Pair, User, WeatherData
+from core.security import hash_short_code
+from core.time_utils import utcnow
+
+
+VALID_QWEATHER = {
+    'temperature': 38.0,
+    'temperature_max': 40.0,
+    'temperature_min': 29.0,
+    'humidity': 70.0,
+    'pressure': 1002.0,
+    'weather_condition': '晴',
+    'wind_speed': 2.0,
+    'pm25': 20,
+    'aqi': 45,
+    'is_mock': False,
+    'data_source': 'QWeather',
+}
+
+
+class _Response:
+    def __init__(self, status_code, payload=None, json_error=None):
+        self.status_code = status_code
+        self._payload = payload
+        self._json_error = json_error
+        self.text = 'upstream response'
+
+    def json(self):
+        if self._json_error:
+            raise self._json_error
+        return self._payload
+
+
+class _PipelineWeatherService:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def get_current_weather(self, _location):
+        return dict(self.payload) if isinstance(self.payload, dict) else self.payload
+
+    def identify_extreme_weather(self, _weather_data):
+        return {'is_extreme': False, 'conditions': []}
+
+
+def _load_pipeline(app, monkeypatch):
+    from services.pipelines import sync_weather_data as pipeline
+
+    monkeypatch.setattr(pipeline, 'app', app)
+    return pipeline
+
+
+def _install_pipeline_weather(monkeypatch, pipeline, payload):
+    monkeypatch.setattr(
+        pipeline,
+        'WeatherService',
+        lambda: _PipelineWeatherService(payload),
+    )
+
+
+def _create_pair(db_session, owner, code, status='active', community='同步测试社区'):
+    pair = Pair(
+        caregiver_id=owner.id,
+        community_code=community,
+        elder_code=f'elder-{code}',
+        short_code=code,
+        short_code_hash=hash_short_code(code),
+        status=status,
+        created_at=utcnow(),
+        last_active_at=utcnow(),
+    )
+    db_session.add(pair)
+    db_session.flush()
+    return pair
+
+
+@pytest.mark.parametrize(
+    'response',
+    [
+        _Response(503, {'code': '503'}),
+        _Response(200, json_error=ValueError('invalid json')),
+        _Response(200, {'code': '401'}),
+    ],
+    ids=['http-error', 'invalid-json', 'business-error'],
+)
+def test_qweather_failures_try_openmeteo_before_mock(monkeypatch, response):
+    """和风三类失败都必须先进入 Open-Meteo。"""
+    from services import weather_service as weather_module
+
+    service = weather_module.WeatherService()
+    service.qweather_key = 'test-key'
+    service.api_base_url = 'https://qweather.invalid'
+    fallback = {
+        'temperature': 31.0,
+        'temperature_max': 34.0,
+        'temperature_min': 25.0,
+        'humidity': 65.0,
+        'is_mock': False,
+        'data_source': 'Open-Meteo',
+    }
+    fallback_calls = []
+
+    monkeypatch.setattr(weather_module.requests, 'get', lambda *_args, **_kwargs: response)
+    monkeypatch.setattr(weather_module, '_record_external_api_timing', lambda *_args: None)
+    monkeypatch.setattr(
+        service,
+        '_get_openmeteo_weather',
+        lambda city: fallback_calls.append(city) or fallback,
+    )
+    monkeypatch.setattr(
+        service,
+        '_get_mock_weather',
+        lambda: pytest.fail('Open-Meteo 成功时不应进入 Mock'),
+    )
+
+    result = service.get_current_weather('都昌')
+
+    assert result == fallback
+    assert fallback_calls == ['都昌']
+
+
+def test_qweather_and_openmeteo_failure_then_use_mock(monkeypatch):
+    """两个真实 API 都失败后才允许返回 Mock。"""
+    from services import weather_service as weather_module
+
+    service = weather_module.WeatherService()
+    service.qweather_key = 'test-key'
+    service.api_base_url = 'https://qweather.invalid'
+    mock_weather = {'is_mock': True, 'data_source': 'Mock'}
+
+    monkeypatch.setattr(
+        weather_module.requests,
+        'get',
+        lambda *_args, **_kwargs: _Response(502, {'code': '502'}),
+    )
+    monkeypatch.setattr(weather_module, '_record_external_api_timing', lambda *_args: None)
+    monkeypatch.setattr(service, '_get_openmeteo_weather', lambda _city: None)
+    monkeypatch.setattr(service, '_get_mock_weather', lambda: mock_weather)
+
+    assert service.get_current_weather('都昌') == mock_weather
+
+
+@pytest.mark.parametrize(
+    ('payload', 'reason'),
+    [
+        ({**VALID_QWEATHER, 'is_mock': True, 'data_source': 'Mock'}, 'mock_weather'),
+        ({**VALID_QWEATHER, 'data_source': 'Open-Meteo'}, 'untrusted_weather_source'),
+        ({**VALID_QWEATHER, 'temperature_max': None}, 'incomplete_weather'),
+    ],
+    ids=['mock', 'openmeteo', 'incomplete-qweather'],
+)
+def test_sync_daily_weather_rejects_untrusted_action_inputs(
+    app,
+    db_session,
+    monkeypatch,
+    payload,
+    reason,
+):
+    """日天气同步不能把兜底或不完整数据写成可信天气。"""
+    pipeline = _load_pipeline(app, monkeypatch)
+    _install_pipeline_weather(monkeypatch, pipeline, payload)
+    target_date = date(2026, 7, 10)
+
+    result = pipeline.sync_daily_weather(
+        target_date=target_date,
+        location='同步测试社区',
+    )
+
+    assert result['updated'] is False
+    assert result['skipped'] is True
+    assert result['reason'] == reason
+    assert WeatherData.query.filter_by(
+        date=target_date,
+        location='同步测试社区',
+    ).count() == 0
+
+
+def test_sync_daily_weather_writes_complete_qweather(
+    app,
+    db_session,
+    monkeypatch,
+):
+    """字段完整的真实和风天气仍能正常写入。"""
+    pipeline = _load_pipeline(app, monkeypatch)
+    _install_pipeline_weather(monkeypatch, pipeline, VALID_QWEATHER)
+    target_date = date(2026, 7, 11)
+
+    result = pipeline.sync_daily_weather(
+        target_date=target_date,
+        location='同步测试社区',
+    )
+
+    assert result['updated'] is True
+    assert result['skipped'] is False
+    assert result['weather_source'] == 'QWeather'
+    record = WeatherData.query.filter_by(
+        date=target_date,
+        location='同步测试社区',
+    ).one()
+    assert record.temperature_max == 40.0
+    assert record.temperature_min == 29.0
+
+
+@pytest.mark.parametrize(
+    ('payload', 'reason'),
+    [
+        ({**VALID_QWEATHER, 'is_mock': True, 'data_source': 'Mock'}, 'mock_weather'),
+        ({**VALID_QWEATHER, 'data_source': 'Open-Meteo'}, 'untrusted_weather_source'),
+        ({**VALID_QWEATHER, 'humidity': None}, 'incomplete_weather'),
+    ],
+    ids=['mock', 'openmeteo', 'incomplete-qweather'],
+)
+def test_sync_action_daily_skips_untrusted_weather_without_writes(
+    app,
+    db_session,
+    monkeypatch,
+    payload,
+    reason,
+):
+    """行动同步遇到非可信天气时不得落天气、风险或社区聚合。"""
+    owner = User(username=f'action-owner-{reason}', role='caregiver')
+    owner.set_password('test-password')
+    db_session.add(owner)
+    db_session.flush()
+    _create_pair(db_session, owner, f'91{len(reason):06d}')
+    db_session.commit()
+
+    pipeline = _load_pipeline(app, monkeypatch)
+    _install_pipeline_weather(monkeypatch, pipeline, payload)
+    monkeypatch.setattr(
+        pipeline,
+        'get_consecutive_hot_days',
+        lambda *_args, **_kwargs: pytest.fail('非可信天气不应进入连续高温计算'),
+    )
+    target_date = date(2026, 7, 12)
+
+    result = pipeline.sync_action_daily(target_date=target_date)
+
+    skipped = result['skipped_communities']['同步测试社区']
+    assert result['updated'] == 0
+    assert result['processed_communities'] == 0
+    assert result['reason'] == 'weather_unavailable_for_all_communities'
+    assert skipped['reason'] == reason
+    assert WeatherData.query.filter_by(date=target_date).count() == 0
+    assert DailyStatus.query.filter_by(status_date=target_date).count() == 0
+    assert CommunityDaily.query.filter_by(date=target_date).count() == 0
+
+
+def test_sync_action_daily_aggregates_active_pairs_and_backup_escalation(
+    app,
+    db_session,
+    monkeypatch,
+):
+    """聚合只统计 active Pair，并把 backup 计入升级链。"""
+    owner = User(username='active-aggregation-owner', role='caregiver')
+    owner.set_password('test-password')
+    db_session.add(owner)
+    db_session.flush()
+
+    active_backup = _create_pair(db_session, owner, '92000001')
+    active_caregiver = _create_pair(db_session, owner, '92000002')
+    inactive_emergency = _create_pair(
+        db_session,
+        owner,
+        '92000003',
+        status='inactive',
+    )
+    target_date = date(2026, 7, 13)
+    db_session.add_all([
+        DailyStatus(
+            pair_id=active_backup.id,
+            status_date=target_date,
+            community_code='同步测试社区',
+            confirmed_at=utcnow(),
+            help_flag=False,
+            relay_stage='backup',
+        ),
+        DailyStatus(
+            pair_id=active_caregiver.id,
+            status_date=target_date,
+            community_code='同步测试社区',
+            confirmed_at=None,
+            help_flag=True,
+            relay_stage='caregiver',
+        ),
+        DailyStatus(
+            pair_id=inactive_emergency.id,
+            status_date=target_date,
+            community_code='同步测试社区',
+            risk_level='极高',
+            confirmed_at=utcnow(),
+            help_flag=True,
+            relay_stage='emergency',
+        ),
+    ])
+    db_session.commit()
+
+    pipeline = _load_pipeline(app, monkeypatch)
+    _install_pipeline_weather(monkeypatch, pipeline, VALID_QWEATHER)
+    monkeypatch.setattr(pipeline, 'get_consecutive_hot_days', lambda *_args, **_kwargs: 3)
+
+    result = pipeline.sync_action_daily(target_date=target_date)
+
+    assert result['updated'] == 2
+    assert result['processed_communities'] == 1
+    assert result['skipped'] is False
+    record = CommunityDaily.query.filter_by(
+        community_code='同步测试社区',
+        date=target_date,
+    ).one()
+    assert record.total_people == 2
+    assert record.confirm_rate == 0.5
+    assert record.escalation_rate == 0.5
+    assert sum(json.loads(record.risk_distribution).values()) == 2
+    assert record.outreach_summary == '已有1个家庭进入升级链，优先安排社区跟进。'


### PR DESCRIPTION
## 这次改了什么

在保持现有 UI 布局与视觉风格的前提下，完成三轮缺陷排查，修复公共确认链路、天气数据可信边界、推送隐私、仪表盘字段、地图代理、备份部署脚本和同步失败传播等问题，并补齐自动化回归与 GitHub Actions。

## 为什么要改

现有分支仍有 Codex 审查指出的异常处理缺口，也存在会造成确认率失真、离线数据进入正式风险链路、备份对象错误、隐私字段外发和脚本失败被误报成功的风险。三轮排查用于系统性降低这些遗留问题。

## 怎么测试

- 默认测试：`280 passed, 11 deselected`
- 严格告警测试：`280 passed, 11 deselected`
- 手动测试集：`10 passed, 1 skipped, 280 deselected`，跳过项为本机未配置 QWeather 凭据
- 重点回归：`50 passed`
- 隔离 Flask 运行时检查覆盖公开、用户、管理员、试点分析、CSV 和 26 个静态资源，无 500
- `git diff --check` 通过
- 全部 12 个 `.sh` 与 hooks 已运行 `bash -n`
- CI YAML 解析、敏感信息扫描、禁入文件扫描和大文件扫描通过

## 文件去向

无文件迁移。业务修复、测试与 `.github/workflows/ci.yml` 均进入主仓库；没有写入本地归档或私有 ops。

## Notion

本任务无 Notion 依赖，本次未访问。若项目文档需要同步，待合并后回填三轮修复摘要与验证结果。
