### PR TITLE
fix: 修复后台定时任务入口与导入路径

### DIFF
--- a/docs/guides/heat_action_cron.txt
+++ b/docs/guides/heat_action_cron.txt
@@ -2,8 +2,8 @@ Heat Action Weather Sync (QWeather)
 =================================
 
 CLI
-- python services/pipelines/sync_weather_data.py --daily --action-daily
-- python services/pipelines/sync_weather_data.py --action-daily --community "YourCommunity"
+- python -m services.pipelines.sync_weather_data --daily --action-daily
+- python -m services.pipelines.sync_weather_data --action-daily --community "YourCommunity"
 
 Shell
 - ./scripts/weather_sync.sh

--- a/scripts/dispatch_alerts.sh
+++ b/scripts/dispatch_alerts.sh
@@ -15,5 +15,7 @@ fi
 
 VENV_PY="${VENV_PY:-python}"
 
-exec "$VENV_PY" "$ROOT_DIR/services/pipelines/dispatch_alerts.py" "$@"
+cd "$ROOT_DIR"
+export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"
 
+exec "$VENV_PY" -m services.pipelines.dispatch_alerts "$@"

--- a/scripts/weather_cache_sync.sh
+++ b/scripts/weather_cache_sync.sh
@@ -15,4 +15,7 @@ fi
 
 VENV_PY="${VENV_PY:-python}"
 
-exec "$VENV_PY" "$ROOT_DIR/services/pipelines/sync_weather_cache.py" "$@"
+cd "$ROOT_DIR"
+export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"
+
+exec "$VENV_PY" -m services.pipelines.sync_weather_cache "$@"

--- a/scripts/weather_sync.sh
+++ b/scripts/weather_sync.sh
@@ -22,4 +22,7 @@ if [ -n "$TARGET_DATE" ]; then
   ARGS+=("--date" "$TARGET_DATE")
 fi
 
-exec "$VENV_PY" "$ROOT_DIR/services/pipelines/sync_weather_data.py" "${ARGS[@]}"
+cd "$ROOT_DIR"
+export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"
+
+exec "$VENV_PY" -m services.pipelines.sync_weather_data "${ARGS[@]}"

--- a/services/pipelines/analyze_surnames.py
+++ b/services/pipelines/analyze_surnames.py
@@ -3,10 +3,17 @@
 分析姓氏和社区分配情况
 """
 from collections import Counter
+from pathlib import Path
+import sys
 
-from core.app import create_app
-from core.db_models import MedicalRecord
-from core.extensions import db
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    # 兼容旧定时任务和手工命令从任意目录直接执行脚本。
+    sys.path.insert(0, str(ROOT_DIR))
+
+from core.app import create_app  # noqa: E402
+from core.db_models import MedicalRecord  # noqa: E402
+from core.extensions import db  # noqa: E402
 
 app = create_app(register_blueprints=False)
 

--- a/services/pipelines/dispatch_alerts.py
+++ b/services/pipelines/dispatch_alerts.py
@@ -3,9 +3,16 @@
 
 import argparse
 import logging
+from pathlib import Path
+import sys
 
-from core.app import create_app
-from services.push.dispatch import dispatch_alerts
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    # 兼容旧定时任务和手工命令从任意目录直接执行脚本。
+    sys.path.insert(0, str(ROOT_DIR))
+
+from core.app import create_app  # noqa: E402
+from services.push.dispatch import dispatch_alerts  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -24,4 +31,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/services/pipelines/import_data.py
+++ b/services/pipelines/import_data.py
@@ -6,16 +6,20 @@ from collections import Counter
 from datetime import datetime
 from pathlib import Path
 import random
+import sys
 
 import pandas as pd
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    # 兼容旧定时任务和手工命令从任意目录直接执行脚本。
+    sys.path.insert(0, str(ROOT_DIR))
 DATA_PATH = ROOT_DIR / 'data' / 'research' / '数据.xlsx'
 
-from core.app import create_app
-from core.db_models import MedicalRecord, Community, WeatherData
-from core.extensions import db
-from core.time_utils import local_datetime_to_utc, today_local
+from core.app import create_app  # noqa: E402
+from core.db_models import MedicalRecord, Community, WeatherData  # noqa: E402
+from core.extensions import db  # noqa: E402
+from core.time_utils import local_datetime_to_utc, today_local  # noqa: E402
 
 app = create_app(register_blueprints=False)
 

--- a/services/pipelines/precompute_community_risk.py
+++ b/services/pipelines/precompute_community_risk.py
@@ -3,8 +3,15 @@
 import argparse
 import logging
 import os
+from pathlib import Path
+import sys
 
-from core.app import create_app
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    # 兼容旧定时任务和手工命令从任意目录直接执行脚本。
+    sys.path.insert(0, str(ROOT_DIR))
+
+from core.app import create_app  # noqa: E402
 from core.constants import DEFAULT_CITY_LABEL  # noqa: E402
 from core.time_utils import today_local  # noqa: E402
 from core.weather import (  # noqa: E402

--- a/services/pipelines/sync_weather_cache.py
+++ b/services/pipelines/sync_weather_cache.py
@@ -5,8 +5,15 @@ import json
 import logging
 import os
 from datetime import datetime
+from pathlib import Path
+import sys
 
-from core.app import create_app
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    # 兼容旧定时任务和手工命令从任意目录直接执行脚本。
+    sys.path.insert(0, str(ROOT_DIR))
+
+from core.app import create_app  # noqa: E402
 from core.constants import DEFAULT_CITY_LABEL  # noqa: E402
 from core.db_models import WeatherCache, WeatherData  # noqa: E402
 from core.extensions import db  # noqa: E402

--- a/services/pipelines/sync_weather_data.py
+++ b/services/pipelines/sync_weather_data.py
@@ -5,12 +5,16 @@ import json
 import math
 from datetime import date, datetime
 from pathlib import Path
+import sys
 
 import pandas as pd
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    # 兼容旧定时任务和手工命令从任意目录直接执行脚本。
+    sys.path.insert(0, str(ROOT_DIR))
 
-from core.app import create_app
+from core.app import create_app  # noqa: E402
 from core.constants import DEFAULT_CITY_LABEL  # noqa: E402
 from core.db_models import CommunityDaily, DailyStatus, Pair, WeatherData  # noqa: E402
 from core.extensions import db  # noqa: E402

--- a/tests/test_pipeline_entrypoints.py
+++ b/tests/test_pipeline_entrypoints.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+"""后台 pipeline 入口契约测试。"""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+DIRECT_PIPELINES = (
+    'services/pipelines/analyze_surnames.py',
+    'services/pipelines/dispatch_alerts.py',
+    'services/pipelines/import_data.py',
+    'services/pipelines/precompute_community_risk.py',
+    'services/pipelines/sync_weather_cache.py',
+    'services/pipelines/sync_weather_data.py',
+)
+PRODUCTION_MODULES = (
+    'services.pipelines.dispatch_alerts',
+    'services.pipelines.sync_weather_cache',
+    'services.pipelines.sync_weather_data',
+)
+
+
+def _subprocess_env(tmp_path):
+    env = os.environ.copy()
+    env.pop('PYTHONPATH', None)
+    env.update({
+        'DATABASE_URI': f"sqlite:///{tmp_path / 'entrypoint.db'}",
+        'SECRET_KEY': 'pipeline-entrypoint-test-key',
+        'DEBUG': 'true',
+        'DEMO_MODE': '1',
+        'QWEATHER_KEY': '',
+        'AMAP_KEY': '',
+        'SILICONFLOW_API_KEY': '',
+        'RATE_LIMIT_STORAGE_URI': 'memory://',
+        'REDIS_URL': '',
+    })
+    return env
+
+
+@pytest.mark.parametrize('relative_path', DIRECT_PIPELINES)
+def test_pipeline_file_imports_when_repo_is_not_cwd(tmp_path, relative_path):
+    """旧 unit 直接运行深层脚本时，也必须能导入项目包。"""
+    script_path = ROOT_DIR / relative_path
+    result = subprocess.run(
+        [
+            sys.executable,
+            '-E',
+            '-c',
+            (
+                "import runpy, sys; "
+                "runpy.run_path(sys.argv[1], run_name='pipeline_entrypoint_contract')"
+            ),
+            str(script_path),
+        ],
+        cwd=tmp_path,
+        env=_subprocess_env(tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "No module named 'core'" not in result.stderr
+
+
+@pytest.mark.parametrize('module_name', PRODUCTION_MODULES)
+def test_production_pipeline_modules_expose_help(tmp_path, module_name):
+    """标准模块入口必须完成导入并安全返回帮助。"""
+    result = subprocess.run(
+        [sys.executable, '-m', module_name, '--help'],
+        cwd=ROOT_DIR,
+        env=_subprocess_env(tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert 'usage:' in result.stdout.lower()
+
+
+@pytest.mark.parametrize(
+    ('script_name', 'arguments', 'expected_arguments'),
+    (
+        (
+            'dispatch_alerts.sh',
+            ('--dedupe-hours', '9'),
+            ('-m', 'services.pipelines.dispatch_alerts', '--dedupe-hours', '9'),
+        ),
+        (
+            'weather_cache_sync.sh',
+            ('--no-daily',),
+            ('-m', 'services.pipelines.sync_weather_cache', '--no-daily'),
+        ),
+        (
+            'weather_sync.sh',
+            ('2026-07-11',),
+            (
+                '-m',
+                'services.pipelines.sync_weather_data',
+                '--daily',
+                '--action-daily',
+                '--date',
+                '2026-07-11',
+            ),
+        ),
+    ),
+)
+def test_shell_wrapper_uses_repo_root_and_module_entrypoint(
+    tmp_path,
+    script_name,
+    arguments,
+    expected_arguments,
+):
+    """wrapper 从任意目录启动时，固定切到仓库根并使用 python -m。"""
+    fake_python = tmp_path / 'fake-python'
+    fake_python.write_text(
+        '#!/bin/sh\n'
+        'printf "cwd=%s\\n" "$PWD"\n'
+        'for arg in "$@"; do printf "arg=%s\\n" "$arg"; done\n',
+        encoding='utf-8',
+    )
+    fake_python.chmod(0o755)
+
+    env = _subprocess_env(tmp_path)
+    env['VENV_PY'] = str(fake_python)
+    result = subprocess.run(
+        ['bash', str(ROOT_DIR / 'scripts' / script_name), *arguments],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f'cwd={ROOT_DIR}' in result.stdout
+    actual_arguments = tuple(
+        line.removeprefix('arg=')
+        for line in result.stdout.splitlines()
+        if line.startswith('arg=')
+    )
+    assert actual_arguments == expected_arguments


### PR DESCRIPTION
## 1. 这次改了什么
修复后台 pipeline 从 systemd、shell 或仓库外目录启动时无法导入 `core` / `services` 的问题。

- 6 个可直接执行的 pipeline 增加仓库根目录兼容引导
- 3 个生产 shell wrapper 统一切换到仓库根并使用 `python -m`
- 天气行动 cron 文档改用模块入口
- 新增 12 个入口契约测试，覆盖旧式文件入口、模块入口和 wrapper 参数传递

## 2. 为什么要改
生产审计发现天气缓存、提醒分发和每日天气同步任务会在导入阶段退出，错误为 `ModuleNotFoundError: No module named 'core'`。

根因是 Python 直接执行 `services/pipelines/*.py` 时，`sys.path[0]` 指向深层脚本目录；systemd 的 `WorkingDirectory` 不会自动把仓库根加入模块搜索路径。

## 3. 怎么测试/验证
### 合并前
- 新增入口契约：12 passed
- 部署、天气同步、推送、社区风险相关回归：40 passed
- Python 3.12 完整回归：336 passed，11 deselected
- Python 3.12 严格弃用检查：336 passed，11 deselected
- manual 契约：10 passed，1 skipped，336 deselected
- `bash -n scripts/dispatch_alerts.sh scripts/weather_cache_sync.sh scripts/weather_sync.sh`：通过
- `git diff --check`：通过
- 独立代码审查：未发现阻断性问题
- PR head `a345b0f`：GitHub Actions、Vercel、Vercel Preview Comments 全部通过

### 合并与发布后
- PR 已 squash 合并，最终 `main` SHA：`193e90cd922a10fb827290883015fd6e49f6b552`
- main GitHub Actions：completed / success
- Vercel Production：success
- VPS 已完成部署前快照、最小增量同步和部署后验收
- 天气缓存、每日同步、提醒分发的受控验收全部成功；验收过程未触发外部发送
- 自动天气缓存周期已真实触发并成功完成，后续周期继续正常排期
- 数据库幂等与唯一性检查通过，未发现重复写入
- Web 服务、相关定时任务及系统失败单元检查均正常
- 修复部署后未再出现同类模块导入错误
- 源站、Cloudflare apex 与 www 的目标页面和版本化样式资源验收通过

## 4. 文件去向
没有文件迁移。改动保留在主仓库的 pipeline、shell wrapper、运维文档和测试目录。

## 5. 脚本检查
本次修改 3 个 `.sh`，均已运行 `bash -n` 并通过。

## 6. 最终部署状态
- 使用 checksum 最小增量同步本 PR 涉及的运行文件
- 同步排除了环境配置、数据库、模型、备份、日志及其他持久化或敏感文件
- 发布过程中未关闭或修改 Clash/TUN，未覆盖生产持久化数据
- GitHub main、Vercel Production、VPS 与 Cloudflare 公开域名已完成最终验收