### PR TITLE
fix: 修复都昌天气缓存与额度保护

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ DATABASE_URI=sqlite:///health_weather.db
 # 如需启用 QWeather，请在本地 `.env` 中显式填写 Host，不要把真实 Host 写回仓库。
 QWEATHER_KEY=your-qweather-api-key
 QWEATHER_API_BASE=
+# 本项目只使用都昌县县级天气；所有村庄共享这一份天气缓存。
+QWEATHER_CANONICAL_LOCATION=116.20,29.27
+QWEATHER_MONTHLY_REQUEST_LIMIT=40000
+QWEATHER_BUDGET_FAIL_CLOSED=1
 
 # 高德地图API配置（推荐前后端分离，避免把 Web 服务 Key 用到前端）
 # 前端地图 JS Key（会出现在浏览器请求里，请在高德后台做好域名绑定）
@@ -85,7 +89,9 @@ AI_MAX_TOKENS=800
 
 # 缓存 TTL（分钟）
 WEATHER_CACHE_TTL_MINUTES=30
-FORECAST_CACHE_TTL_MINUTES=20
+FORECAST_CACHE_TTL_MINUTES=30
+QWEATHER_WARNING_CACHE_TTL_MINUTES=30
+WEATHER_SYNC_LOCATIONS=都昌县
 # 社区风险分析结果缓存（秒，略大于 20 分钟预热周期，避免空档）
 COMMUNITY_RISK_CACHE_TTL_SECONDS=1500
 # 社区风险缓存锁（秒，避免多人同时重复计算）

--- a/core/config.py
+++ b/core/config.py
@@ -236,6 +236,10 @@ def configure_app(app, logger):
     demo_mode = os.getenv('DEMO_MODE')
     default_city = _normalized_env_value('DEFAULT_CITY', DEFAULT_CITY)
     default_location = _normalized_env_value('DEFAULT_LOCATION', DEFAULT_LOCATION)
+    qweather_canonical_location = _normalized_env_value(
+        'QWEATHER_CANONICAL_LOCATION',
+        default_location,
+    )
     redis_url = _normalized_env_value('REDIS_URL', '')
     weather_cache_redis_url = _normalized_env_value('WEATHER_CACHE_REDIS_URL', redis_url)
 
@@ -256,6 +260,7 @@ def configure_app(app, logger):
     app.config['SECRET_KEY'] = secret_key
     app.config['QWEATHER_KEY'] = qweather_key
     app.config['QWEATHER_API_BASE'] = qweather_api_base
+    app.config['QWEATHER_CANONICAL_LOCATION'] = qweather_canonical_location
     app.config['AMAP_KEY'] = amap_key
     app.config['AMAP_SECURITY_JS_CODE'] = amap_security_js_code
     app.config['SILICONFLOW_API_KEY'] = siliconflow_key
@@ -291,11 +296,29 @@ def configure_app(app, logger):
     app.config.setdefault('TRUSTED_PROXY_CIDRS', os.getenv('TRUSTED_PROXY_CIDRS', '127.0.0.1/32,::1/128'))
     app.config.setdefault(
         'FORECAST_CACHE_TTL_MINUTES',
-        parse_int(os.getenv('FORECAST_CACHE_TTL_MINUTES', '20'), default=20)
+        max(parse_int(os.getenv('FORECAST_CACHE_TTL_MINUTES', '30'), default=30), 10)
     )
     app.config.setdefault(
         'WEATHER_CACHE_TTL_MINUTES',
-        parse_int(os.getenv('WEATHER_CACHE_TTL_MINUTES', str(WEATHER_CACHE_TTL_MINUTES)), default=WEATHER_CACHE_TTL_MINUTES)
+        max(
+            parse_int(
+                os.getenv('WEATHER_CACHE_TTL_MINUTES', str(WEATHER_CACHE_TTL_MINUTES)),
+                default=WEATHER_CACHE_TTL_MINUTES,
+            ),
+            10,
+        )
+    )
+    app.config.setdefault(
+        'QWEATHER_WARNING_CACHE_TTL_MINUTES',
+        max(parse_int(os.getenv('QWEATHER_WARNING_CACHE_TTL_MINUTES', '30'), default=30), 10)
+    )
+    app.config.setdefault(
+        'QWEATHER_MONTHLY_REQUEST_LIMIT',
+        max(parse_int(os.getenv('QWEATHER_MONTHLY_REQUEST_LIMIT', '40000'), default=40000), 0)
+    )
+    app.config.setdefault(
+        'QWEATHER_BUDGET_FAIL_CLOSED',
+        parse_bool(os.getenv('QWEATHER_BUDGET_FAIL_CLOSED', '1'), default=True)
     )
     if qweather_key and not qweather_api_base:
         logger.warning("QWEATHER_KEY 已配置但 QWEATHER_API_BASE 未配置，将跳过 QWeather Host 相关调用并使用兜底链路。")

--- a/core/weather.py
+++ b/core/weather.py
@@ -216,7 +216,12 @@ def get_demo_forecast_data(days=7):
 def get_location_options():
     """获取可选地点列表"""
     options = set()
-    options.update(current_app.config.get('CITY_LOCATION_MAP', {}).keys())
+    canonical_location = current_app.config.get('QWEATHER_CANONICAL_LOCATION')
+    if canonical_location:
+        # 网站只服务都昌县：保留县内社区名称，移除北京、上海等旧测试城市。
+        options.update(current_app.config.get('COMMUNITY_COORDS_GCJ', {}).keys())
+    else:
+        options.update(current_app.config.get('CITY_LOCATION_MAP', {}).keys())
     try:
         communities = Community.query.with_entities(Community.name).all()
         options.update([c[0] for c in communities if c and c[0]])
@@ -224,8 +229,12 @@ def get_location_options():
         logger.warning("Failed to load community locations: %s", exc)
     options = {opt.strip() for opt in options if opt and isinstance(opt, str)}
     default_city = current_app.config.get('DEFAULT_CITY', DEFAULT_CITY_LABEL) or DEFAULT_CITY_LABEL
+    options.update({default_city, DEFAULT_CITY_LABEL})
     ordered = []
-    for item in (default_city, DEFAULT_CITY_LABEL, '北京', '上海', '广州', '深圳'):
+    preferred = (default_city, DEFAULT_CITY_LABEL)
+    if not canonical_location:
+        preferred += ('北京', '上海', '广州', '深圳')
+    for item in preferred:
         if item in options and item not in ordered:
             ordered.append(item)
             options.discard(item)
@@ -315,6 +324,8 @@ def ensure_user_location_valid():
 
 def resolve_weather_city_label(location):
     """显示天气来源城市"""
+    if current_app.config.get('QWEATHER_CANONICAL_LOCATION'):
+        return DEFAULT_CITY_LABEL
     default_city = current_app.config.get('DEFAULT_CITY', DEFAULT_CITY_LABEL) or DEFAULT_CITY_LABEL
     default_location = current_app.config.get('DEFAULT_LOCATION', '116.20,29.27')
     city_map = current_app.config.get('CITY_LOCATION_MAP', {})
@@ -330,11 +341,19 @@ def resolve_weather_city_label(location):
     return location
 
 
+def _weather_cache_location(location):
+    """把所有县内页面请求归并到唯一的都昌县天气缓存。"""
+    normalized = normalize_location_name(location)
+    if current_app.config.get('QWEATHER_CANONICAL_LOCATION'):
+        return DEFAULT_CITY_LABEL
+    return normalized
+
+
 def get_weather_with_cache(location, ttl_minutes=None):
     """获取带缓存的天气数据"""
     if is_demo_mode():
         return get_demo_weather_data(), False
-    location = normalize_location_name(location)
+    location = _weather_cache_location(location)
     if ttl_minutes is None:
         ttl_minutes = current_app.config.get('WEATHER_CACHE_TTL_MINUTES', WEATHER_CACHE_TTL_MINUTES)
     ttl_seconds = max(int(ttl_minutes * 60), 60)
@@ -408,7 +427,7 @@ def get_forecast_with_cache(location, days=7, ttl_minutes=None):
     """获取带缓存的天气预报"""
     if is_demo_mode():
         return get_demo_forecast_data(days=days), True
-    location = normalize_location_name(location)
+    location = _weather_cache_location(location)
     if ttl_minutes is None:
         ttl_minutes = current_app.config.get('FORECAST_CACHE_TTL_MINUTES', 20)
     ttl_seconds = max(int(ttl_minutes * 60), 60)
@@ -522,7 +541,7 @@ def get_qweather_forecast_with_cache(location, days=7, ttl_minutes=None):
     if is_demo_mode():
         return [], False, {'source': 'QWeather', 'error': 'demo_mode'}
 
-    location = normalize_location_name(location)
+    location = _weather_cache_location(location)
     if ttl_minutes is None:
         ttl_minutes = current_app.config.get('FORECAST_CACHE_TTL_MINUTES', 20)
     ttl_seconds = max(int(ttl_minutes * 60), 60)

--- a/docs/systemd/case-weather-cache.timer
+++ b/docs/systemd/case-weather-cache.timer
@@ -1,9 +1,9 @@
 [Unit]
-Description=Run Case Weather cache sync every 5 minutes
+Description=Run Case Weather cache sync every 30 minutes
 
 [Timer]
 OnBootSec=2min
-OnUnitActiveSec=5min
+OnUnitActiveSec=30min
 Persistent=true
 Unit=case-weather-cache.service
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -225,6 +225,14 @@ DATABASE_URI=sqlite:///health_weather.db
 REDIS_URL=redis://127.0.0.1:6379/0
 RATE_LIMIT_STORAGE_URI=redis://127.0.0.1:6379/0
 QWEATHER_KEY=
+QWEATHER_API_BASE=
+QWEATHER_CANONICAL_LOCATION=116.20,29.27
+QWEATHER_MONTHLY_REQUEST_LIMIT=40000
+QWEATHER_BUDGET_FAIL_CLOSED=1
+WEATHER_CACHE_TTL_MINUTES=30
+FORECAST_CACHE_TTL_MINUTES=30
+QWEATHER_WARNING_CACHE_TTL_MINUTES=30
+WEATHER_SYNC_LOCATIONS=都昌县
 AMAP_KEY=
 WXPUSHER_APP_TOKEN=
 WXPUSHER_API_BASE=https://wxpusher.zjiecode.com/api
@@ -235,6 +243,13 @@ echo '已创建新的 .env 文件'; else echo '.env 文件已存在，跳过创�
 echo ""
 echo "步骤6.1: 确保数据库目录与关键配置存在..."
 remote_exec "mkdir -p $PROJECT_DIR/instance && (grep -q '^DATABASE_URI=' $PROJECT_DIR/.env || echo 'DATABASE_URI=sqlite:///health_weather.db' >> $PROJECT_DIR/.env)"
+remote_exec "grep -q '^QWEATHER_CANONICAL_LOCATION=' $PROJECT_DIR/.env || echo 'QWEATHER_CANONICAL_LOCATION=116.20,29.27' >> $PROJECT_DIR/.env"
+remote_exec "grep -q '^QWEATHER_MONTHLY_REQUEST_LIMIT=' $PROJECT_DIR/.env || echo 'QWEATHER_MONTHLY_REQUEST_LIMIT=40000' >> $PROJECT_DIR/.env"
+remote_exec "grep -q '^QWEATHER_BUDGET_FAIL_CLOSED=' $PROJECT_DIR/.env || echo 'QWEATHER_BUDGET_FAIL_CLOSED=1' >> $PROJECT_DIR/.env"
+remote_exec "grep -q '^WEATHER_CACHE_TTL_MINUTES=' $PROJECT_DIR/.env || echo 'WEATHER_CACHE_TTL_MINUTES=30' >> $PROJECT_DIR/.env"
+remote_exec "grep -q '^FORECAST_CACHE_TTL_MINUTES=' $PROJECT_DIR/.env || echo 'FORECAST_CACHE_TTL_MINUTES=30' >> $PROJECT_DIR/.env"
+remote_exec "grep -q '^QWEATHER_WARNING_CACHE_TTL_MINUTES=' $PROJECT_DIR/.env || echo 'QWEATHER_WARNING_CACHE_TTL_MINUTES=30' >> $PROJECT_DIR/.env"
+remote_exec "grep -q '^WEATHER_SYNC_LOCATIONS=' $PROJECT_DIR/.env || echo 'WEATHER_SYNC_LOCATIONS=都昌县' >> $PROJECT_DIR/.env"
 
 echo ""
 echo "步骤6.1.1: 写入必要的 API Key（仅在服务器端为空/缺失时写入）..."
@@ -275,7 +290,7 @@ fi
 echo ""
 echo "步骤6.2: 初始化/迁移数据库（安全 stamp + upgrade）..."
 remote_exec "cd '$PROJECT_DIR' && PROJECT_DIR='$PROJECT_DIR' ENV_FILE='$PROJECT_DIR/.env' bash scripts/backup.sh --if-present"
-remote_exec "systemctl stop case-weather || true; systemctl stop case-weather-dispatch.timer || true; systemctl stop case-weather-risk-precompute.timer || true"
+remote_exec "systemctl stop case-weather || true; systemctl stop case-weather-cache.timer || true; systemctl stop case-weather-dispatch.timer || true; systemctl stop case-weather-risk-precompute.timer || true"
 remote_exec "cd $PROJECT_DIR && VENV_PY=$VENV_DIR/bin/python bash scripts/server_migrate.sh"
 
 echo ""
@@ -303,7 +318,38 @@ WantedBy=multi-user.target
 EOF"
 
 echo ""
-echo "步骤7.1: 创建预警推送定时任务（systemd timer）..."
+echo "步骤7.1: 创建天气缓存定时任务（systemd timer）..."
+remote_exec "cat > /etc/systemd/system/case-weather-cache.service << 'EOF'
+[Unit]
+Description=Case Weather - refresh Duchang weather cache
+After=network.target case-weather.service
+
+[Service]
+Type=oneshot
+User=root
+WorkingDirectory=$PROJECT_DIR
+EnvironmentFile=$PROJECT_DIR/.env
+Environment=PYTHONUNBUFFERED=1
+Environment=VENV_PY=$VENV_DIR/bin/python
+ExecStart=/bin/bash $PROJECT_DIR/scripts/weather_cache_sync.sh
+EOF
+
+cat > /etc/systemd/system/case-weather-cache.timer << 'EOF'
+[Unit]
+Description=Case Weather - refresh Duchang weather cache every 30 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=30min
+Persistent=true
+Unit=case-weather-cache.service
+
+[Install]
+WantedBy=timers.target
+EOF"
+
+echo ""
+echo "步骤7.2: 创建预警推送定时任务（systemd timer）..."
 remote_exec "cat > /etc/systemd/system/case-weather-dispatch.service << 'EOF'
 [Unit]
 Description=Case Weather - dispatch alerts (WxPusher)
@@ -332,7 +378,7 @@ WantedBy=timers.target
 EOF"
 
 echo ""
-echo "步骤7.2: 创建社区风险预计算定时任务（systemd timer）..."
+echo "步骤7.3: 创建社区风险预计算定时任务（systemd timer）..."
 remote_exec "cat > /etc/systemd/system/case-weather-risk-precompute.service << 'EOF'
 [Unit]
 Description=Case Weather - precompute community risk cache
@@ -370,13 +416,19 @@ remote_exec "systemctl status --no-pager case-weather"
 check_remote_unit_active "case-weather"
 
 echo ""
-echo "步骤8.1: 启动定时器..."
+echo "步骤8.1: 启动天气缓存定时器..."
+remote_exec "systemctl enable --now case-weather-cache.timer"
+remote_exec "systemctl status --no-pager case-weather-cache.timer"
+check_remote_unit_active "case-weather-cache.timer"
+
+echo ""
+echo "步骤8.2: 启动预警推送定时器..."
 remote_exec "systemctl enable --now case-weather-dispatch.timer"
 remote_exec "systemctl status --no-pager case-weather-dispatch.timer"
 check_remote_unit_active "case-weather-dispatch.timer"
 
 echo ""
-echo "步骤8.2: 启动社区风险预计算定时器..."
+echo "步骤8.3: 启动社区风险预计算定时器..."
 remote_exec "systemctl enable --now case-weather-risk-precompute.timer"
 remote_exec "systemctl status --no-pager case-weather-risk-precompute.timer"
 check_remote_unit_active "case-weather-risk-precompute.timer"

--- a/services/pipelines/sync_weather_cache.py
+++ b/services/pipelines/sync_weather_cache.py
@@ -17,7 +17,7 @@ from core.app import create_app  # noqa: E402
 from core.constants import DEFAULT_CITY_LABEL  # noqa: E402
 from core.db_models import WeatherCache, WeatherData  # noqa: E402
 from core.extensions import db  # noqa: E402
-from core.weather import get_location_options, normalize_location_name  # noqa: E402
+from core.weather import normalize_location_name  # noqa: E402
 from core.time_utils import today_local, utcnow  # noqa: E402
 from services.weather_service import WeatherService  # noqa: E402
 
@@ -79,9 +79,7 @@ def _resolve_locations(locations):
     env_locations = os.getenv('WEATHER_SYNC_LOCATIONS', '').strip()
     if env_locations:
         return [item.strip() for item in env_locations.split(',') if item.strip()]
-    options = get_location_options()
-    if options:
-        return options
+    # 后台默认只预热都昌县。村庄与页面选项共享县级缓存，禁止把 UI 选项批量当成 API 任务。
     return [DEFAULT_CITY_LABEL]
 
 

--- a/services/qweather_budget.py
+++ b/services/qweather_budget.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+"""和风天气月度调用预算保护。"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+import logging
+import os
+import threading
+
+from flask import current_app, has_app_context
+
+from core.time_utils import now_local
+from utils.parsers import parse_bool, parse_int
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MONTHLY_LIMIT = 40000
+_REDIS_BUDGET_PREFIX = "qweather:budget:app:v2"
+_REDIS_CLIENT_EXTENSION_KEY = "qweather_budget_redis_client"
+_LOCAL_LOCK = threading.Lock()
+_LOCAL_TOTALS = defaultdict(int)
+_LOCAL_ENDPOINTS = defaultdict(lambda: defaultdict(int))
+_BLOCKED_LOGGED = set()
+
+
+def _config_value(key, default=None):
+    if has_app_context():
+        return current_app.config.get(key, default)
+    return os.getenv(key, default)
+
+
+def _monthly_limit():
+    return max(
+        parse_int(
+            _config_value("QWEATHER_MONTHLY_REQUEST_LIMIT", DEFAULT_MONTHLY_LIMIT),
+            default=DEFAULT_MONTHLY_LIMIT,
+        ),
+        0,
+    )
+
+
+def _redis_url():
+    value = (
+        _config_value("WEATHER_CACHE_REDIS_URL", "")
+        or _config_value("REDIS_URL", "")
+        or ""
+    )
+    return str(value).strip()
+
+
+def _fail_closed():
+    return parse_bool(
+        _config_value("QWEATHER_BUDGET_FAIL_CLOSED", "1"),
+        default=True,
+    )
+
+
+def _month_key(now=None):
+    now = now or now_local()
+    return now.strftime("%Y-%m")
+
+
+def _seconds_until_expiry(now=None):
+    """预算键保留到下月开始后两天，便于跨月审计。"""
+    now = now or now_local()
+    if now.month == 12:
+        next_month = datetime(now.year + 1, 1, 1)
+    else:
+        next_month = datetime(now.year, now.month + 1, 1)
+    return max(int((next_month - now).total_seconds()) + 2 * 86400, 86400)
+
+
+def _redis_budget_keys(month):
+    """使用应用专属键，供应商控制台历史总量不得写入这里。"""
+    prefix = f"{_REDIS_BUDGET_PREFIX}:{month}"
+    return f"{prefix}:total", f"{prefix}:endpoints"
+
+
+def get_qweather_redis_client():
+    """返回预算与短期天气缓存共用的 Redis 客户端。"""
+    if not has_app_context():
+        return None
+    cached = current_app.extensions.get(_REDIS_CLIENT_EXTENSION_KEY)
+    if cached is not None:
+        return cached
+    redis_url = _redis_url()
+    if not redis_url:
+        return None
+    try:
+        import redis  # type: ignore
+
+        client = redis.Redis.from_url(redis_url, decode_responses=True)
+    except Exception as exc:
+        logger.warning("和风天气预算 Redis 初始化失败: %s", exc)
+        return None
+    current_app.extensions[_REDIS_CLIENT_EXTENSION_KEY] = client
+    return client
+
+
+def _log_blocked_once(month, limit, backend):
+    key = (month, backend)
+    if key in _BLOCKED_LOGGED:
+        return
+    _BLOCKED_LOGGED.add(key)
+    logger.error(
+        "和风天气月度调用保护已生效: month=%s limit=%s backend=%s，后续请求将使用备用源。",
+        month,
+        limit,
+        backend,
+    )
+
+
+def _reserve_local(month, endpoint, limit):
+    with _LOCAL_LOCK:
+        if _LOCAL_TOTALS[month] >= limit:
+            _log_blocked_once(month, limit, "local")
+            return False
+        _LOCAL_TOTALS[month] += 1
+        _LOCAL_ENDPOINTS[month][endpoint] += 1
+        return True
+
+
+def reserve_qweather_request(endpoint):
+    """在发出一次和风请求前预占月度额度。"""
+    endpoint = str(endpoint or "unknown").strip() or "unknown"
+    limit = _monthly_limit()
+    if limit <= 0:
+        _log_blocked_once(_month_key(), limit, "disabled")
+        return False
+
+    now = now_local()
+    month = _month_key(now)
+    client = get_qweather_redis_client()
+    redis_configured = bool(_redis_url())
+    if client is not None:
+        total_key, endpoint_key = _redis_budget_keys(month)
+        try:
+            count = int(client.incr(total_key))
+            if count == 1:
+                ttl = _seconds_until_expiry(now)
+                client.expire(total_key, ttl)
+            if count > limit:
+                try:
+                    client.decr(total_key)
+                except Exception:
+                    pass
+                _log_blocked_once(month, limit, "redis")
+                return False
+            client.hincrby(endpoint_key, endpoint, 1)
+            if count == 1:
+                client.expire(endpoint_key, ttl)
+            return True
+        except Exception as exc:
+            logger.error("和风天气预算 Redis 计数失败: %s", exc)
+            if redis_configured and _fail_closed():
+                _log_blocked_once(month, limit, "redis-unavailable")
+                return False
+
+    if redis_configured and _fail_closed():
+        _log_blocked_once(month, limit, "redis-unavailable")
+        return False
+
+    return _reserve_local(month, endpoint, limit)
+
+
+def get_qweather_budget_snapshot():
+    """返回当前月预算快照，供运维核验使用。"""
+    now = now_local()
+    month = _month_key(now)
+    limit = _monthly_limit()
+    client = get_qweather_redis_client()
+    if client is not None:
+        try:
+            total_key, endpoint_key = _redis_budget_keys(month)
+            total = int(client.get(total_key) or 0)
+            endpoints = client.hgetall(endpoint_key) or {}
+            return {
+                "month": month,
+                "limit": limit,
+                "used": total,
+                "remaining": max(limit - total, 0),
+                "backend": "redis",
+                "endpoints": {key: int(value) for key, value in endpoints.items()},
+            }
+        except Exception as exc:
+            logger.warning("读取和风天气预算快照失败: %s", exc)
+
+    with _LOCAL_LOCK:
+        total = int(_LOCAL_TOTALS.get(month, 0))
+        endpoints = dict(_LOCAL_ENDPOINTS.get(month, {}))
+    return {
+        "month": month,
+        "limit": limit,
+        "used": total,
+        "remaining": max(limit - total, 0),
+        "backend": "local",
+        "endpoints": endpoints,
+    }

--- a/services/warning_service.py
+++ b/services/warning_service.py
@@ -8,7 +8,9 @@ Pilot strategy:
 
 from __future__ import annotations
 
+import json
 import logging
+import threading
 import time
 from typing import Any, Dict, List
 
@@ -16,8 +18,15 @@ import requests
 from flask import current_app, has_app_context
 
 from services.external_api import record_external_api_timing as _record_external_api_timing
+from services.qweather_budget import get_qweather_redis_client, reserve_qweather_request
+from utils.parsers import parse_int
 
 logger = logging.getLogger(__name__)
+
+_CACHE_MISS = object()
+_LOCAL_WARNING_CACHE = {}
+_LOCAL_WARNING_CACHE_LOCK = threading.Lock()
+_LOCAL_WARNING_CACHE_MAX_ITEMS = 128
 
 _CAP_SEVERITY_ALLOWED = {"Extreme", "Severe", "Moderate", "Minor", "Unknown"}
 _CAP_CERTAINTY_ALLOWED = {"Observed", "Likely", "Possible", "Unlikely", "Unknown"}
@@ -34,6 +43,68 @@ def _cfg(key: str, default=None):
     if has_app_context():
         return current_app.config.get(key, default)
     return default
+
+
+def _warning_cache_ttl_seconds():
+    minutes = max(
+        parse_int(_cfg("QWEATHER_WARNING_CACHE_TTL_MINUTES", 30), default=30),
+        10,
+    )
+    return minutes * 60
+
+
+def _canonical_location(location_code):
+    """当前产品只提供都昌县天气，所有村庄共用县级预警。"""
+    canonical = _cfg("QWEATHER_CANONICAL_LOCATION") or _cfg("DEFAULT_LOCATION")
+    return str(canonical or location_code or "").strip()
+
+
+def _warning_cache_key(location_code):
+    return f"weather:qweather_warnings:{location_code}"
+
+
+def _get_cached_warnings(location_code):
+    cache_key = _warning_cache_key(location_code)
+    client = get_qweather_redis_client()
+    if client is not None:
+        try:
+            payload = client.get(cache_key)
+            if payload is not None:
+                parsed = json.loads(payload)
+                if isinstance(parsed, list):
+                    return parsed
+        except Exception as exc:
+            logger.warning("和风预警 Redis 缓存读取失败: %s", exc)
+
+    now = time.monotonic()
+    with _LOCAL_WARNING_CACHE_LOCK:
+        item = _LOCAL_WARNING_CACHE.get(cache_key)
+        if item and item[0] > now:
+            return item[1]
+        if item:
+            _LOCAL_WARNING_CACHE.pop(cache_key, None)
+    return _CACHE_MISS
+
+
+def _set_cached_warnings(location_code, warnings):
+    cache_key = _warning_cache_key(location_code)
+    ttl_seconds = _warning_cache_ttl_seconds()
+    client = get_qweather_redis_client()
+    if client is not None:
+        try:
+            client.setex(cache_key, ttl_seconds, json.dumps(warnings, ensure_ascii=False))
+        except Exception as exc:
+            logger.warning("和风预警 Redis 缓存写入失败: %s", exc)
+
+    expires_at = time.monotonic() + ttl_seconds
+    with _LOCAL_WARNING_CACHE_LOCK:
+        _LOCAL_WARNING_CACHE[cache_key] = (expires_at, warnings)
+        if len(_LOCAL_WARNING_CACHE) > _LOCAL_WARNING_CACHE_MAX_ITEMS:
+            oldest_key = min(
+                _LOCAL_WARNING_CACHE,
+                key=lambda key: _LOCAL_WARNING_CACHE[key][0],
+            )
+            _LOCAL_WARNING_CACHE.pop(oldest_key, None)
 
 
 def _normalize_cap_enum(value, allowed, default):
@@ -74,17 +145,28 @@ def get_qweather_warnings(location_code: str) -> List[Dict[str, Any]]:
     if not location_code:
         return []
 
+    location_code = _canonical_location(location_code)
+
     qweather_key = (_cfg("QWEATHER_KEY") or "").strip()
     api_base = (_cfg("QWEATHER_API_BASE") or "").strip()
     if not qweather_key or not api_base:
         return []
 
+    cached = _get_cached_warnings(location_code)
+    if cached is not _CACHE_MISS:
+        return cached
+
     url = f"{api_base.rstrip('/')}/warning/now"
-    params = {"key": qweather_key, "location": location_code}
+    params = {"location": location_code}
+    headers = {"X-QW-Api-Key": qweather_key}
+
+    if not reserve_qweather_request("warning_now"):
+        logger.warning("和风天气月度额度保护：跳过官方预警请求")
+        return []
 
     start_ts = time.perf_counter()
     try:
-        resp = requests.get(url, params=params, timeout=10)
+        resp = requests.get(url, params=params, headers=headers, timeout=10)
         _record_external_api_timing("qweather_warning_now", (time.perf_counter() - start_ts) * 1000, resp.status_code)
         if resp.status_code != 200:
             logger.info("QWeather warning http=%s for location=%s", resp.status_code, location_code)
@@ -143,4 +225,5 @@ def get_qweather_warnings(location_code: str) -> List[Dict[str, Any]]:
                 "raw": item,
             }
         )
+    _set_cached_warnings(location_code, normalized)
     return normalized

--- a/services/weather_service.py
+++ b/services/weather_service.py
@@ -13,6 +13,7 @@ import time
 from statistics import mean, pstdev
 from flask import current_app, has_app_context
 from services.external_api import record_external_api_timing as _record_external_api_timing
+from services.qweather_budget import reserve_qweather_request
 from core.time_utils import today_local
 
 class WeatherService:
@@ -23,6 +24,7 @@ class WeatherService:
         self.api_base_url = None
         self.city_map = {}
         self.default_location = '116.20,29.27'  # 都昌县
+        self.canonical_location = self.default_location
         self.use_openmeteo_fallback = True  # 启用Open-Meteo备用API
 
         self._load_config()
@@ -45,9 +47,20 @@ class WeatherService:
             app_config.get('DEFAULT_LOCATION')
             or os.getenv('DEFAULT_LOCATION', self.default_location)
         )
+        self.canonical_location = (
+            app_config.get('QWEATHER_CANONICAL_LOCATION')
+            or os.getenv('QWEATHER_CANONICAL_LOCATION')
+            or self.default_location
+        )
+
+    def _qweather_headers(self):
+        """通过请求头发送密钥，避免密钥出现在 URL 与代理日志中。"""
+        return {'X-QW-Api-Key': self.qweather_key}
     
     def _get_location(self, city):
         """获取城市的location参数"""
+        if self.canonical_location:
+            return str(self.canonical_location).strip()
         city = str(city).strip() if city is not None else ''
         if not city:
             return self.default_location
@@ -113,12 +126,19 @@ class WeatherService:
                 # 调用实况天气API
                 weather_url = f"{self.api_base_url}/weather/now"
                 weather_params = {
-                    'key': self.qweather_key,
                     'location': location
                 }
-                
+
+                if not reserve_qweather_request('weather_now'):
+                    logger.warning("和风天气月度额度保护：跳过实况请求并使用备用源")
+                    return self._get_fallback_weather(city, logger)
                 start_ts = time.perf_counter()
-                weather_response = requests.get(weather_url, params=weather_params, timeout=10)
+                weather_response = requests.get(
+                    weather_url,
+                    params=weather_params,
+                    headers=self._qweather_headers(),
+                    timeout=10,
+                )
                 _record_external_api_timing('qweather_now', (time.perf_counter() - start_ts) * 1000, weather_response.status_code)
                 
                 # 检查HTTP状态码
@@ -193,12 +213,18 @@ class WeatherService:
                 try:
                     air_url = f"{self.api_base_url}/air/now"
                     air_params = {
-                        'key': self.qweather_key,
                         'location': location
                     }
-                    
+
+                    if not reserve_qweather_request('air_now'):
+                        raise RuntimeError('qweather_budget_exhausted')
                     air_start = time.perf_counter()
-                    air_response = requests.get(air_url, params=air_params, timeout=10)
+                    air_response = requests.get(
+                        air_url,
+                        params=air_params,
+                        headers=self._qweather_headers(),
+                        timeout=10,
+                    )
                     _record_external_api_timing('qweather_air', (time.perf_counter() - air_start) * 1000, air_response.status_code)
                     try:
                         air_data = air_response.json()
@@ -389,11 +415,17 @@ class WeatherService:
         try:
             hourly_url = f"{self.api_base_url}/weather/24h"
             hourly_params = {
-                'key': self.qweather_key,
                 'location': location
             }
+            if not reserve_qweather_request('weather_24h_current_range'):
+                return None, None, 'none'
             start_ts = time.perf_counter()
-            response = requests.get(hourly_url, params=hourly_params, timeout=10)
+            response = requests.get(
+                hourly_url,
+                params=hourly_params,
+                headers=self._qweather_headers(),
+                timeout=10,
+            )
             _record_external_api_timing(
                 'qweather_hourly_for_now',
                 (time.perf_counter() - start_ts) * 1000,
@@ -467,11 +499,17 @@ class WeatherService:
         try:
             forecast_url = f"{self.api_base_url}/weather/7d"
             forecast_params = {
-                'key': self.qweather_key,
                 'location': location
             }
+            if not reserve_qweather_request('weather_7d_current_range'):
+                return None, None
             start_ts = time.perf_counter()
-            response = requests.get(forecast_url, params=forecast_params, timeout=10)
+            response = requests.get(
+                forecast_url,
+                params=forecast_params,
+                headers=self._qweather_headers(),
+                timeout=10,
+            )
             _record_external_api_timing(
                 'qweather_daily_for_now',
                 (time.perf_counter() - start_ts) * 1000,
@@ -561,11 +599,18 @@ class WeatherService:
         try:
             forecast_url = f"{self.api_base_url}/weather/7d"
             forecast_params = {
-                'key': self.qweather_key,
                 'location': location
             }
+            if not reserve_qweather_request('weather_7d_forecast'):
+                meta['error'] = 'qweather_budget_exhausted'
+                return {'success': False, 'daily': [], 'meta': meta}
             start_ts = time.perf_counter()
-            response = requests.get(forecast_url, params=forecast_params, timeout=10)
+            response = requests.get(
+                forecast_url,
+                params=forecast_params,
+                headers=self._qweather_headers(),
+                timeout=10,
+            )
             _record_external_api_timing(
                 'qweather_forecast_only',
                 (time.perf_counter() - start_ts) * 1000,
@@ -914,12 +959,18 @@ class WeatherService:
                 # 调用7天预报API
                 forecast_url = f"{self.api_base_url}/weather/7d"
                 forecast_params = {
-                    'key': self.qweather_key,
                     'location': location
                 }
 
+                if not reserve_qweather_request('weather_7d_forecast'):
+                    raise RuntimeError('qweather_budget_exhausted')
                 start_ts = time.perf_counter()
-                response = requests.get(forecast_url, params=forecast_params, timeout=10)
+                response = requests.get(
+                    forecast_url,
+                    params=forecast_params,
+                    headers=self._qweather_headers(),
+                    timeout=10,
+                )
                 _record_external_api_timing(
                     'qweather_forecast',
                     (time.perf_counter() - start_ts) * 1000,

--- a/tests/test_deploy_script.py
+++ b/tests/test_deploy_script.py
@@ -18,6 +18,7 @@ def test_deploy_script_checks_units_with_is_active():
     content = _load_deploy_script()
 
     assert 'check_remote_unit_active "case-weather"' in content
+    assert 'check_remote_unit_active "case-weather-cache.timer"' in content
     assert 'check_remote_unit_active "case-weather-dispatch.timer"' in content
     assert 'check_remote_unit_active "case-weather-risk-precompute.timer"' in content
     assert 'systemctl is-active --quiet $unit' in content
@@ -29,6 +30,16 @@ def test_deploy_script_no_longer_swallows_systemctl_failures():
     assert 'case-weather && systemctl restart case-weather && systemctl status --no-pager case-weather || true' not in content
     assert 'case-weather-dispatch.timer && systemctl status --no-pager case-weather-dispatch.timer || true' not in content
     assert 'case-weather-risk-precompute.timer && systemctl status --no-pager case-weather-risk-precompute.timer || true' not in content
+
+
+def test_deploy_script_pins_duchang_cache_to_free_tier_budget():
+    content = _load_deploy_script()
+
+    assert 'WEATHER_SYNC_LOCATIONS=都昌县' in content
+    assert 'QWEATHER_CANONICAL_LOCATION=116.20,29.27' in content
+    assert 'QWEATHER_MONTHLY_REQUEST_LIMIT=40000' in content
+    assert 'OnUnitActiveSec=30min' in content
+    assert 'ExecStart=/bin/bash $PROJECT_DIR/scripts/weather_cache_sync.sh' in content
 
 
 def test_deploy_script_sets_precompute_python_path():

--- a/tests/test_key_paths.py
+++ b/tests/test_key_paths.py
@@ -130,7 +130,8 @@ def test_forecast_cache_prefers_redis(app, db_session):
             'temperature_min': 18,
             'is_mock': True
         }]
-        redis_key = 'weather:forecast:北京:3'
+        # 产品只使用都昌县天气；旧城市参数也必须命中同一份县级缓存。
+        redis_key = 'weather:forecast:都昌县:3'
         fake_redis.setex(redis_key, 600, json.dumps(cached_forecast, ensure_ascii=False))
 
         fetcher = DummyWeatherFetcher()

--- a/tests/test_qweather_budget.py
+++ b/tests/test_qweather_budget.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+"""和风天气单地点缓存与月度预算保护测试。"""
+
+import logging
+
+from flask import Flask
+
+
+def _reset_local_budget(budget):
+    budget._LOCAL_TOTALS.clear()
+    budget._LOCAL_ENDPOINTS.clear()
+    budget._BLOCKED_LOGGED.clear()
+
+
+class _FakeBudgetRedis:
+    """只实现预算保护测试需要的 Redis 方法。"""
+
+    def __init__(self, values=None):
+        self.values = dict(values or {})
+        self.hashes = {}
+
+    def incr(self, key):
+        self.values[key] = int(self.values.get(key, 0)) + 1
+        return self.values[key]
+
+    def decr(self, key):
+        self.values[key] = int(self.values.get(key, 0)) - 1
+        return self.values[key]
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def expire(self, key, ttl):
+        del key, ttl
+        return True
+
+    def hincrby(self, key, field, amount):
+        bucket = self.hashes.setdefault(key, {})
+        bucket[field] = int(bucket.get(field, 0)) + int(amount)
+        return bucket[field]
+
+    def hgetall(self, key):
+        return dict(self.hashes.get(key, {}))
+
+
+def test_monthly_budget_blocks_after_safety_limit(app, monkeypatch):
+    from services import qweather_budget as budget
+
+    _reset_local_budget(budget)
+    monkeypatch.setattr(budget, "get_qweather_redis_client", lambda: None)
+    with app.app_context():
+        app.config["REDIS_URL"] = ""
+        app.config["WEATHER_CACHE_REDIS_URL"] = ""
+        app.config["QWEATHER_MONTHLY_REQUEST_LIMIT"] = 2
+
+        assert budget.reserve_qweather_request("weather_now") is True
+        assert budget.reserve_qweather_request("air_now") is True
+        assert budget.reserve_qweather_request("weather_7d") is False
+
+        snapshot = budget.get_qweather_budget_snapshot()
+        assert snapshot["used"] == 2
+        assert snapshot["remaining"] == 0
+        assert snapshot["endpoints"] == {"weather_now": 1, "air_now": 1}
+
+
+def test_budget_fails_closed_when_configured_redis_is_unavailable(app, monkeypatch):
+    from services import qweather_budget as budget
+
+    _reset_local_budget(budget)
+    monkeypatch.setattr(budget, "get_qweather_redis_client", lambda: None)
+    with app.app_context():
+        app.config["REDIS_URL"] = "redis://127.0.0.1:6379/0"
+        app.config["QWEATHER_BUDGET_FAIL_CLOSED"] = True
+
+        assert budget.reserve_qweather_request("weather_now") is False
+
+
+def test_zero_budget_disables_qweather(app, monkeypatch):
+    from services import qweather_budget as budget
+
+    _reset_local_budget(budget)
+    monkeypatch.setattr(budget, "get_qweather_redis_client", lambda: None)
+    with app.app_context():
+        app.config["REDIS_URL"] = ""
+        app.config["QWEATHER_MONTHLY_REQUEST_LIMIT"] = 0
+
+        assert budget.reserve_qweather_request("weather_now") is False
+
+
+def test_legacy_provider_total_does_not_block_app_counter(app, monkeypatch):
+    from services import qweather_budget as budget
+
+    month = budget._month_key()
+    legacy_key = f"qweather:budget:{month}:total"
+    app_total_key, _ = budget._redis_budget_keys(month)
+    fake_redis = _FakeBudgetRedis({legacy_key: 60000})
+    monkeypatch.setattr(budget, "get_qweather_redis_client", lambda: fake_redis)
+
+    with app.app_context():
+        app.config["REDIS_URL"] = "redis://127.0.0.1:6379/0"
+        app.config["WEATHER_CACHE_REDIS_URL"] = ""
+        app.config["QWEATHER_MONTHLY_REQUEST_LIMIT"] = 40000
+
+        assert budget.reserve_qweather_request("weather_7d_forecast") is True
+        snapshot = budget.get_qweather_budget_snapshot()
+
+    assert fake_redis.get(legacy_key) == 60000
+    assert fake_redis.get(app_total_key) == 1
+    assert snapshot["used"] == 1
+    assert snapshot["remaining"] == 39999
+    assert snapshot["endpoints"] == {"weather_7d_forecast": 1}
+
+
+def test_cache_ttl_has_ten_minute_floor(monkeypatch):
+    from core import config
+
+    monkeypatch.setenv("DEBUG", "true")
+    monkeypatch.setenv("WEATHER_CACHE_TTL_MINUTES", "1")
+    monkeypatch.setenv("FORECAST_CACHE_TTL_MINUTES", "2")
+    monkeypatch.setenv("QWEATHER_WARNING_CACHE_TTL_MINUTES", "3")
+
+    app = Flask(__name__)
+    config.configure_app(app, logging.getLogger(__name__))
+
+    assert app.config["WEATHER_CACHE_TTL_MINUTES"] == 10
+    assert app.config["FORECAST_CACHE_TTL_MINUTES"] == 10
+    assert app.config["QWEATHER_WARNING_CACHE_TTL_MINUTES"] == 10
+
+
+def test_weather_cache_uses_one_duchang_key(app):
+    from core.weather import _weather_cache_location
+
+    with app.app_context():
+        app.config["QWEATHER_CANONICAL_LOCATION"] = "116.20,29.27"
+
+        assert _weather_cache_location("牛家垄周村") == "都昌县"
+        assert _weather_cache_location("北京") == "都昌县"
+        assert _weather_cache_location("都昌") == "都昌县"
+
+
+def test_weather_sync_defaults_to_duchang_only(monkeypatch):
+    from services.pipelines import sync_weather_cache
+
+    monkeypatch.delenv("WEATHER_SYNC_LOCATIONS", raising=False)
+
+    assert sync_weather_cache._resolve_locations(None) == ["都昌县"]
+
+
+def test_weather_sync_allows_explicit_location_override(monkeypatch):
+    from services.pipelines import sync_weather_cache
+
+    monkeypatch.setenv("WEATHER_SYNC_LOCATIONS", "都昌县,九江")
+
+    assert sync_weather_cache._resolve_locations(None) == ["都昌县", "九江"]

--- a/tests/test_warning_service.py
+++ b/tests/test_warning_service.py
@@ -1,5 +1,16 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_warning_cache(monkeypatch):
+    from services import warning_service
+
+    warning_service._LOCAL_WARNING_CACHE.clear()
+    monkeypatch.setattr(warning_service, "get_qweather_redis_client", lambda: None)
+    monkeypatch.setattr(warning_service, "reserve_qweather_request", lambda _endpoint: True)
+
 
 def test_warning_service_no_key_returns_empty(app):
     from services.warning_service import get_qweather_warnings
@@ -46,3 +57,34 @@ def test_warning_service_parses_payload(app, monkeypatch):
         assert item["severity"] == "Minor"
         assert item["certainty"] == "Likely"
         assert item["urgency"] == "Expected"
+
+
+def test_warning_service_reuses_duchang_cache_and_hides_key_from_url(app, monkeypatch):
+    from services.warning_service import get_qweather_warnings
+
+    calls = []
+
+    class FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {"code": "200", "warning": []}
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return FakeResp()
+
+    monkeypatch.setattr("services.warning_service.requests.get", fake_get)
+
+    with app.app_context():
+        app.config["QWEATHER_KEY"] = "secret-test-key"
+        app.config["QWEATHER_API_BASE"] = "https://example.com/v7"
+        app.config["QWEATHER_CANONICAL_LOCATION"] = "116.20,29.27"
+
+        assert get_qweather_warnings("101010100") == []
+        assert get_qweather_warnings("101020100") == []
+
+    assert len(calls) == 1
+    _url, kwargs = calls[0]
+    assert kwargs["params"] == {"location": "116.20,29.27"}
+    assert kwargs["headers"] == {"X-QW-Api-Key": "secret-test-key"}

--- a/tests/test_weather_sync_pipeline.py
+++ b/tests/test_weather_sync_pipeline.py
@@ -147,6 +147,26 @@ def test_qweather_and_openmeteo_failure_then_use_mock(monkeypatch):
     assert service.get_current_weather('都昌') == mock_weather
 
 
+def test_qweather_budget_guard_blocks_http_and_uses_fallback(monkeypatch):
+    """月度保护触发后不得再发和风请求。"""
+    from services import weather_service as weather_module
+
+    service = weather_module.WeatherService()
+    service.qweather_key = 'test-key'
+    service.api_base_url = 'https://qweather.invalid'
+    fallback = {'is_mock': False, 'data_source': 'Open-Meteo'}
+
+    monkeypatch.setattr(weather_module, 'reserve_qweather_request', lambda _endpoint: False)
+    monkeypatch.setattr(
+        weather_module.requests,
+        'get',
+        lambda *_args, **_kwargs: pytest.fail('预算保护后不应发送和风请求'),
+    )
+    monkeypatch.setattr(service, '_get_openmeteo_weather', lambda _city: fallback)
+
+    assert service.get_current_weather('都昌') == fallback
+
+
 @pytest.mark.parametrize(
     ('payload', 'reason'),
     [


### PR DESCRIPTION
## 这次改了什么
将天气获取收敛为都昌县唯一坐标和 30 分钟共享缓存，并加入应用专属的月度调用预算保护。

## 为什么要改
后台曾把页面地点列表当作同步清单，每 5 分钟对多个地点和多个接口重复调用。旧的供应商历史用量又被误写进应用增量预算计数器，导致真实和风 7 日预报被本地保护器提前拦截。

## 怎么验证
- 完整回归：368 passed，11 deselected
- 和风、缓存、部署专项：40 passed
- git diff --cached --check 通过
- Python 编译检查通过
- bash -n scripts/deploy.sh 通过
- 新增回归测试，确认旧的 60000 历史记录不会阻断应用专属计数器

## 文件去向
全部进入主仓库；未迁移私有密钥、服务器备份或本机 .claude 配置。

## Notion
本次是生产故障修复，不改变产品需求或健康风险模型，无需 Notion 回填。