### PR TITLE
fix: 兼容和风空气质量 v1

### DIFF
--- a/services/weather_service.py
+++ b/services/weather_service.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 import json
 import time
 from statistics import mean, pstdev
+from urllib.parse import urlsplit
 from flask import current_app, has_app_context
 from services.external_api import record_external_api_timing as _record_external_api_timing
 from services.qweather_budget import reserve_qweather_request
@@ -209,42 +210,10 @@ class WeatherService:
                     result['temperature_range_source'] = range_source
                     result['temperature_range_confidence'] = range_confidence
                 
-                # 尝试获取空气质量数据
-                try:
-                    air_url = f"{self.api_base_url}/air/now"
-                    air_params = {
-                        'location': location
-                    }
-
-                    if not reserve_qweather_request('air_now'):
-                        raise RuntimeError('qweather_budget_exhausted')
-                    air_start = time.perf_counter()
-                    air_response = requests.get(
-                        air_url,
-                        params=air_params,
-                        headers=self._qweather_headers(),
-                        timeout=10,
-                    )
-                    _record_external_api_timing('qweather_air', (time.perf_counter() - air_start) * 1000, air_response.status_code)
-                    try:
-                        air_data = air_response.json()
-                    except Exception as json_error:
-                        logger.debug("空气质量JSON解析失败: %s", json_error)
-                        air_data = {}
-                    
-                    if air_data.get('code') == '200' and 'now' in air_data:
-                        air_now = air_data['now']
-                        result['pm25'] = float(air_now.get('pm2p5', 0))
-                        result['aqi'] = int(air_now.get('aqi', 0))
-                        result['air_quality'] = air_now.get('category', '良')
-                except requests.exceptions.Timeout:
-                    logger.debug("空气质量请求超时")
-                except requests.exceptions.ConnectionError:
-                    logger.debug("空气质量网络连接失败")
-                except requests.exceptions.RequestException as air_error:
-                    logger.debug("空气质量请求失败: %s", air_error)
-                except Exception as air_error:
-                    logger.debug("空气质量解析失败: %s", air_error)
+                # 空气质量失败不影响实时天气主链路。
+                air_quality = self._get_qweather_air_quality(location, logger)
+                if air_quality:
+                    result.update(air_quality)
                 
                 logger.info("成功获取%s的真实天气数据 (温度: %s°C)", city, result['temperature'])
                 return result
@@ -274,6 +243,108 @@ class WeatherService:
             '204': '请求成功，但无数据返回'
         }
         return error_codes.get(str(code), f'未知错误(代码:{code})')
+
+    def _get_qweather_air_quality(self, location, logger=None):
+        """调用新版空气质量接口，返回本地标准 AQI 与 PM2.5。"""
+        logger = logger or logging.getLogger(__name__)
+        coordinates = self._parse_lon_lat(location)
+        if not coordinates:
+            logger.debug("空气质量 v1 需要经纬度，当前 location 无法解析")
+            return {}
+
+        parsed_base = urlsplit(self.api_base_url or '')
+        if parsed_base.scheme not in {'http', 'https'} or not parsed_base.netloc:
+            logger.debug("空气质量 v1 缺少有效 API Host")
+            return {}
+
+        lon, lat = coordinates
+        api_origin = f"{parsed_base.scheme}://{parsed_base.netloc}"
+        air_url = f"{api_origin}/airquality/v1/current/{lat:.2f}/{lon:.2f}"
+
+        if not reserve_qweather_request('airquality_v1_current'):
+            logger.debug("和风天气月度额度保护：跳过空气质量请求")
+            return {}
+
+        try:
+            start_ts = time.perf_counter()
+            response = requests.get(
+                air_url,
+                params={'lang': 'zh'},
+                headers=self._qweather_headers(),
+                timeout=10,
+            )
+            _record_external_api_timing(
+                'qweather_air_v1',
+                (time.perf_counter() - start_ts) * 1000,
+                response.status_code,
+            )
+            if response.status_code != 200:
+                logger.debug("空气质量 v1 HTTP 状态码: %s", response.status_code)
+                return {}
+
+            payload = response.json()
+            if not isinstance(payload, dict):
+                return {}
+
+            indexes = payload.get('indexes') or []
+            # 健康风险阈值优先采用中国 AQI 标准，不能依赖上游数组顺序。
+            local_index = None
+            for preferred_code in ('cn-mee', 'cn-mee-1h'):
+                local_index = next(
+                    (
+                        item for item in indexes
+                        if isinstance(item, dict)
+                        and str(item.get('code') or '').lower() == preferred_code
+                    ),
+                    None,
+                )
+                if local_index:
+                    break
+            if local_index is None:
+                # 非中国部署仍允许使用当地标准，排除 0-10 量纲的通用 QAQI。
+                local_index = next(
+                    (
+                        item for item in indexes
+                        if isinstance(item, dict)
+                        and str(item.get('code') or '').lower() != 'qaqi'
+                    ),
+                    None,
+                )
+
+            result = {}
+            if local_index:
+                aqi = self._safe_float(local_index.get('aqi'))
+                if aqi is not None and math.isfinite(aqi) and 0 <= aqi <= 500:
+                    result['aqi'] = int(round(aqi))
+                category = str(local_index.get('category') or '').strip()
+                if category:
+                    result['air_quality'] = category
+
+            pollutants = payload.get('pollutants') or []
+            pm25_item = next(
+                (
+                    item for item in pollutants
+                    if isinstance(item, dict)
+                    and str(item.get('code') or '').lower() == 'pm2p5'
+                ),
+                None,
+            )
+            concentration = pm25_item.get('concentration') if pm25_item else None
+            pm25 = self._safe_float(
+                concentration.get('value') if isinstance(concentration, dict) else None
+            )
+            if pm25 is not None and math.isfinite(pm25) and pm25 >= 0:
+                result['pm25'] = pm25
+            return result
+        except requests.exceptions.Timeout:
+            logger.debug("空气质量 v1 请求超时")
+        except requests.exceptions.ConnectionError:
+            logger.debug("空气质量 v1 网络连接失败")
+        except requests.exceptions.RequestException as air_error:
+            logger.debug("空气质量 v1 请求失败: %s", air_error)
+        except Exception as air_error:
+            logger.debug("空气质量 v1 解析失败: %s", air_error)
+        return {}
     
     def _get_openmeteo_weather(self, city="都昌"):
         """使用Open-Meteo免费API获取天气数据（无需API Key）"""

--- a/tests/manual/test_weather_api.py
+++ b/tests/manual/test_weather_api.py
@@ -4,6 +4,7 @@
 用于诊断API调用问题
 """
 import os
+from urllib.parse import urlsplit
 import requests
 import pytest
 
@@ -26,6 +27,10 @@ def test_qweather_api():
         pytest.skip("未设置 QWEATHER_API_BASE")
     if "your-qweather-host.example.com" in base_url:
         pytest.skip("QWEATHER_API_BASE 仍是占位值")
+
+    parsed_base = urlsplit(base_url)
+    api_origin = f"{parsed_base.scheme}://{parsed_base.netloc}"
+    headers = {'X-QW-Api-Key': key}
     
     print("\nAPI Key: 已配置")
     print(f"Base URL: {base_url}")
@@ -38,10 +43,10 @@ def test_qweather_api():
     
     try:
         url = f"{base_url}/weather/now"
-        params = {'key': key, 'location': location}
+        params = {'location': location}
         
         print(f"请求URL: {url}")
-        response = requests.get(url, params=params, timeout=10)
+        response = requests.get(url, params=params, headers=headers, timeout=10)
         
         print(f"HTTP状态码: {response.status_code}")
         
@@ -63,9 +68,9 @@ def test_qweather_api():
     
     try:
         url = f"{base_url}/weather/7d"
-        params = {'key': key, 'location': location}
+        params = {'location': location}
         
-        response = requests.get(url, params=params, timeout=10)
+        response = requests.get(url, params=params, headers=headers, timeout=10)
         print(f"HTTP状态码: {response.status_code}")
         
         assert response.status_code == 200, f"7天预报 HTTP {response.status_code}"
@@ -80,24 +85,23 @@ def test_qweather_api():
     
     # 测试3: 空气质量
     print("\n" + "-" * 40)
-    print("测试3: 空气质量 (/air/now)")
+    print("测试3: 空气质量 (/airquality/v1/current)")
     print("-" * 40)
     
     try:
-        url = f"{base_url}/air/now"
-        params = {'key': key, 'location': location}
+        lon, lat = location.split(',')
+        url = f"{api_origin}/airquality/v1/current/{lat}/{lon}"
+        params = {'lang': 'zh'}
         
-        response = requests.get(url, params=params, timeout=10)
+        response = requests.get(url, params=params, headers=headers, timeout=10)
         print(f"HTTP状态码: {response.status_code}")
         
         assert response.status_code == 200, f"空气质量 HTTP {response.status_code}"
         data = response.json()
-        code = data.get('code')
-        assert code in {'200', '204'}, f"空气质量业务码 {code}"
-        if code == '200':
-            now = data.get('now') or {}
-            assert now.get('aqi') is not None
-            assert now.get('pm2p5') is not None
+        indexes = data.get('indexes') or []
+        pollutants = data.get('pollutants') or []
+        assert any(item.get('code') in {'cn-mee', 'cn-mee-1h'} for item in indexes)
+        assert any(item.get('code') == 'pm2p5' for item in pollutants)
             
     except requests.RequestException as exc:
         pytest.fail(f"空气质量请求失败: {type(exc).__name__}")

--- a/tests/test_weather_sync_pipeline.py
+++ b/tests/test_weather_sync_pipeline.py
@@ -167,6 +167,176 @@ def test_qweather_budget_guard_blocks_http_and_uses_fallback(monkeypatch):
     assert service.get_current_weather('都昌') == fallback
 
 
+def test_qweather_air_quality_v1_uses_origin_and_lat_lon(monkeypatch):
+    """空气质量 v1 应去掉 /v7，并按纬度、经度顺序请求。"""
+    from services import weather_service as weather_module
+
+    service = weather_module.WeatherService()
+    service.qweather_key = 'test-key'
+    service.api_base_url = 'https://api.qweather.invalid/v7'
+    service.canonical_location = '116.20,29.27'
+    calls = []
+    reserved_endpoints = []
+
+    weather_response = _Response(200, {
+        'code': '200',
+        'now': {
+            'temp': '30',
+            'humidity': '70',
+            'pressure': '1005',
+            'text': '晴',
+            'windSpeed': '3',
+            'feelsLike': '33',
+        },
+    })
+    air_response = _Response(200, {
+        'indexes': [
+            {'code': 'cn-mee-1h', 'aqi': 99, 'category': '良'},
+            {'code': 'qaqi', 'aqi': 2.4, 'category': 'Good'},
+            {'code': 'cn-mee', 'aqi': 83, 'category': '良'},
+        ],
+        'pollutants': [
+            {'code': 'pm2p5', 'concentration': {'value': 27.5, 'unit': 'μg/m3'}},
+        ],
+    })
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return weather_response if len(calls) == 1 else air_response
+
+    monkeypatch.setattr(weather_module.requests, 'get', fake_get)
+    monkeypatch.setattr(weather_module, '_record_external_api_timing', lambda *_args: None)
+    monkeypatch.setattr(
+        weather_module,
+        'reserve_qweather_request',
+        lambda endpoint: reserved_endpoints.append(endpoint) or True,
+    )
+    monkeypatch.setattr(
+        service,
+        '_resolve_qweather_current_temperature_range',
+        lambda _location: (34.0, 25.0, 'daily', 'high'),
+    )
+
+    result = service.get_current_weather('牛家垄周村')
+
+    assert result['aqi'] == 83
+    assert result['pm25'] == 27.5
+    assert result['air_quality'] == '良'
+    assert calls[0][0] == 'https://api.qweather.invalid/v7/weather/now'
+    assert calls[1][0] == 'https://api.qweather.invalid/airquality/v1/current/29.27/116.20'
+    assert calls[1][1]['params'] == {'lang': 'zh'}
+    assert calls[1][1]['headers'] == {'X-QW-Api-Key': 'test-key'}
+    assert reserved_endpoints == ['weather_now', 'airquality_v1_current']
+
+
+def test_qweather_air_quality_failure_keeps_weather_available(monkeypatch):
+    """空气质量失败时，已成功取得的天气实况仍应返回。"""
+    from services import weather_service as weather_module
+
+    service = weather_module.WeatherService()
+    service.qweather_key = 'test-key'
+    service.api_base_url = 'https://api.qweather.invalid/v7'
+    service.canonical_location = '116.20,29.27'
+    responses = iter([
+        _Response(200, {
+            'code': '200',
+            'now': {'temp': '30', 'humidity': '70', 'text': '晴'},
+        }),
+        _Response(403, {}),
+    ])
+
+    monkeypatch.setattr(weather_module.requests, 'get', lambda *_args, **_kwargs: next(responses))
+    monkeypatch.setattr(weather_module, '_record_external_api_timing', lambda *_args: None)
+    monkeypatch.setattr(weather_module, 'reserve_qweather_request', lambda _endpoint: True)
+    monkeypatch.setattr(
+        service,
+        '_resolve_qweather_current_temperature_range',
+        lambda _location: (34.0, 25.0, 'daily', 'high'),
+    )
+    monkeypatch.setattr(
+        service,
+        '_get_fallback_weather',
+        lambda *_args: pytest.fail('空气质量失败不应让天气实况降级'),
+    )
+
+    result = service.get_current_weather('都昌')
+
+    assert result['data_source'] == 'QWeather'
+    assert result['temperature'] == 30.0
+    assert result['aqi'] is None
+    assert result['pm25'] is None
+
+
+def test_qweather_air_quality_does_not_use_generic_qaqi(monkeypatch):
+    """通用 QAQI 的量纲不得进入本地 0-500 AQI 健康阈值。"""
+    from services import weather_service as weather_module
+
+    service = weather_module.WeatherService()
+    service.qweather_key = 'test-key'
+    service.api_base_url = 'https://api.qweather.invalid/v7'
+    response = _Response(200, {
+        'indexes': [{'code': 'qaqi', 'aqi': 2.1, 'category': 'Good'}],
+        'pollutants': [
+            {'code': 'pm2p5', 'concentration': {'value': 18, 'unit': 'μg/m3'}},
+        ],
+    })
+
+    monkeypatch.setattr(weather_module.requests, 'get', lambda *_args, **_kwargs: response)
+    monkeypatch.setattr(weather_module, '_record_external_api_timing', lambda *_args: None)
+    monkeypatch.setattr(weather_module, 'reserve_qweather_request', lambda _endpoint: True)
+
+    result = service._get_qweather_air_quality('116.20,29.27')
+
+    assert result == {'pm25': 18.0}
+
+
+def test_qweather_air_quality_budget_guard_skips_http(monkeypatch):
+    """空气质量预算被阻断后，不得继续发送 HTTP 请求。"""
+    from services import weather_service as weather_module
+
+    service = weather_module.WeatherService()
+    service.qweather_key = 'test-key'
+    service.api_base_url = 'https://api.qweather.invalid/v7'
+
+    monkeypatch.setattr(weather_module, 'reserve_qweather_request', lambda _endpoint: False)
+    monkeypatch.setattr(
+        weather_module.requests,
+        'get',
+        lambda *_args, **_kwargs: pytest.fail('预算阻断后不应发送空气质量请求'),
+    )
+
+    assert service._get_qweather_air_quality('116.20,29.27') == {}
+
+
+@pytest.mark.parametrize(
+    'response',
+    [
+        _Response(200, json_error=ValueError('invalid json')),
+        _Response(200, {'indexes': None, 'pollutants': None}),
+        _Response(200, {
+            'indexes': [{'code': 'cn-mee', 'aqi': float('inf'), 'category': ''}],
+            'pollutants': [
+                {'code': 'pm2p5', 'concentration': {'value': float('nan')}},
+            ],
+        }),
+    ],
+    ids=['invalid-json', 'empty-lists', 'non-finite-values'],
+)
+def test_qweather_air_quality_invalid_payload_stays_unknown(monkeypatch, response):
+    """无效空气质量响应应保持未知，不能伪装为零值。"""
+    from services import weather_service as weather_module
+
+    service = weather_module.WeatherService()
+    service.qweather_key = 'test-key'
+    service.api_base_url = 'https://api.qweather.invalid/v7'
+
+    monkeypatch.setattr(weather_module.requests, 'get', lambda *_args, **_kwargs: response)
+    monkeypatch.setattr(weather_module, '_record_external_api_timing', lambda *_args: None)
+    monkeypatch.setattr(weather_module, 'reserve_qweather_request', lambda _endpoint: True)
+
+    assert service._get_qweather_air_quality('116.20,29.27') == {}
+
+
 @pytest.mark.parametrize(
     ('payload', 'reason'),
     [


### PR DESCRIPTION
## 这次改了什么

将都昌空气质量从已返回 403 的旧 `/v7/air/now` 迁移到 QWeather Air Quality v1，解析中国 AQI 与 PM2.5，并更新自动化和人工诊断测试。

## 为什么要改

旧接口失效导致线上 AQI、PM2.5 为空。新版接口与天气主链路隔离，空气质量失败时仍保留已取得的实时天气，同时继续受 40,000 次/月应用预算保护和 30 分钟单都昌缓存约束。

## 怎么测试

- 定向回归：47 passed
- 全量回归：375 passed, 11 deselected
- `py_compile`：通过
- `git diff --check`：通过
- 生产凭证只读诊断：新版接口 HTTP 200，返回中国 AQI 与 PM2.5 字段

## 文件去向

3 个文件均留在主仓库，无文件迁移、删除或本地归档。

## 脚本说明

未修改 `.sh` 或 `.githooks`。Notion 不在本次修复范围内。