### PR TITLE
feat: 接入和风天气 JWT 认证

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,15 @@ PAIR_TOKEN_PEPPER=change-me-min-32-chars
 DATABASE_URI=sqlite:///health_weather.db
 
 # 和风天气API配置（可选，未配置时使用 Open-Meteo / 阈值规则兜底）
-# 如需启用 QWeather，请在本地 `.env` 中显式填写 Host，不要把真实 Host 写回仓库。
-QWEATHER_KEY=your-qweather-api-key
+# 推荐 JWT。私钥必须放在仓库外，且文件权限为 0600；不要把真实 Host、私钥或令牌写回仓库。
+QWEATHER_AUTH_MODE=disabled
 QWEATHER_API_BASE=
+# JWT 模式：QWEATHER_AUTH_MODE=jwt
+QWEATHER_JWT_KID=
+QWEATHER_JWT_PROJECT_ID=
+QWEATHER_JWT_PRIVATE_KEY_PATH=
+# 人工回滚模式：QWEATHER_AUTH_MODE=api_key。单次请求只会发送一种认证头。
+QWEATHER_KEY=
 # 本项目只使用都昌县县级天气；所有村庄共享这一份天气缓存。
 QWEATHER_CANONICAL_LOCATION=116.20,29.27
 QWEATHER_MONTHLY_REQUEST_LIMIT=40000

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ backups/
 .env
 .env.*
 !.env.example
+*.pem
+*.key
 
 # 系统文件
 .DS_Store

--- a/core/config.py
+++ b/core/config.py
@@ -225,6 +225,14 @@ def configure_app(app, logger):
     secret_key_env = _normalized_env_value('SECRET_KEY')
     qweather_key = _normalized_env_value('QWEATHER_KEY', '')
     qweather_api_base = _normalized_env_value('QWEATHER_API_BASE', QWEATHER_API_BASE_DEFAULT)
+    qweather_auth_mode = _normalized_env_value('QWEATHER_AUTH_MODE', '').lower()
+    if not qweather_auth_mode:
+        qweather_auth_mode = 'api_key' if qweather_key else 'disabled'
+    if qweather_auth_mode not in {'api_key', 'jwt', 'disabled'}:
+        raise RuntimeError("QWEATHER_AUTH_MODE 必须是 api_key、jwt 或 disabled。")
+    qweather_jwt_kid = _normalized_env_value('QWEATHER_JWT_KID', '')
+    qweather_jwt_project_id = _normalized_env_value('QWEATHER_JWT_PROJECT_ID', '')
+    qweather_jwt_private_key_path = _normalized_env_value('QWEATHER_JWT_PRIVATE_KEY_PATH', '')
     amap_key = _normalized_env_value('AMAP_KEY', '')
     amap_security_js_code = _normalized_env_value('AMAP_SECURITY_JS_CODE', '')
     siliconflow_key = _normalized_env_value('SILICONFLOW_API_KEY', '')
@@ -260,6 +268,10 @@ def configure_app(app, logger):
     app.config['SECRET_KEY'] = secret_key
     app.config['QWEATHER_KEY'] = qweather_key
     app.config['QWEATHER_API_BASE'] = qweather_api_base
+    app.config['QWEATHER_AUTH_MODE'] = qweather_auth_mode
+    app.config['QWEATHER_JWT_KID'] = qweather_jwt_kid
+    app.config['QWEATHER_JWT_PROJECT_ID'] = qweather_jwt_project_id
+    app.config['QWEATHER_JWT_PRIVATE_KEY_PATH'] = qweather_jwt_private_key_path
     app.config['QWEATHER_CANONICAL_LOCATION'] = qweather_canonical_location
     app.config['AMAP_KEY'] = amap_key
     app.config['AMAP_SECURITY_JS_CODE'] = amap_security_js_code
@@ -320,10 +332,22 @@ def configure_app(app, logger):
         'QWEATHER_BUDGET_FAIL_CLOSED',
         parse_bool(os.getenv('QWEATHER_BUDGET_FAIL_CLOSED', '1'), default=True)
     )
-    if qweather_key and not qweather_api_base:
-        logger.warning("QWEATHER_KEY 已配置但 QWEATHER_API_BASE 未配置，将跳过 QWeather Host 相关调用并使用兜底链路。")
-    if qweather_api_base and not qweather_key:
-        logger.warning("QWEATHER_API_BASE 已配置但 QWEATHER_KEY 未配置，QWeather 不会生效。")
+    if qweather_auth_mode != 'disabled' and not qweather_api_base:
+        logger.warning("QWEATHER_API_BASE 未配置，将跳过 QWeather Host 相关调用并使用兜底链路。")
+    if qweather_auth_mode == 'api_key' and not qweather_key:
+        logger.warning("QWEATHER_AUTH_MODE=api_key 但 QWEATHER_KEY 未配置，QWeather 不会生效。")
+    if qweather_auth_mode == 'jwt':
+        missing_jwt_fields = [
+            name
+            for name, value in (
+                ('QWEATHER_JWT_KID', qweather_jwt_kid),
+                ('QWEATHER_JWT_PROJECT_ID', qweather_jwt_project_id),
+                ('QWEATHER_JWT_PRIVATE_KEY_PATH', qweather_jwt_private_key_path),
+            )
+            if not value
+        ]
+        if missing_jwt_fields:
+            logger.warning("QWeather JWT 配置不完整，缺少: %s", ', '.join(missing_jwt_fields))
     app.config.setdefault('NOTIFICATION_ESCALATION_DAYS', parse_int(os.getenv('NOTIFICATION_ESCALATION_DAYS', '3'), default=3))
     app.config.setdefault('NOTIFICATION_MAX_DAILY', parse_int(os.getenv('NOTIFICATION_MAX_DAILY', '5'), default=5))
     app.config.setdefault('HEAT_HOT_DAY_THRESHOLD', parse_float(os.getenv('HEAT_HOT_DAY_THRESHOLD', '35'), default=35.0))
@@ -421,8 +445,8 @@ def configure_app(app, logger):
     else:
         app.config.pop('SQLALCHEMY_ENGINE_OPTIONS', None)
 
-    if not qweather_key:
-        logger.warning("QWEATHER_KEY 未配置，天气API将无法使用（可回退 Open-Meteo）。")
+    if qweather_auth_mode == 'disabled':
+        logger.warning("QWeather 已禁用，天气API将使用 Open-Meteo 或规则兜底。")
     if not amap_key:
         logger.warning("AMAP_KEY 未配置，地图API将无法使用")
     if not amap_security_js_code:

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ python-dateutil==2.9.0.post0
 
 # HTTP请求（用于天气API）
 requests==2.32.4
+PyJWT[crypto]==2.8.0
 
 # HTML清理（XSS防护）
 bleach==6.2.0

--- a/services/qweather_auth.py
+++ b/services/qweather_auth.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+"""QWeather 请求认证。
+
+JWT 只在当前进程内短时缓存。私钥、JWT 和认证请求头不得写入日志或 Redis。
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import threading
+import time
+from pathlib import Path
+from typing import Mapping, Optional
+from urllib.parse import urlsplit
+
+import jwt
+from flask import current_app, has_app_context
+
+
+_ALLOWED_AUTH_MODES = {"api_key", "jwt", "disabled"}
+_JWT_LIFETIME_SECONDS = 900
+_JWT_CLOCK_SKEW_SECONDS = 30
+_JWT_REFRESH_MARGIN_SECONDS = 60
+_MAX_PRIVATE_KEY_BYTES = 16 * 1024
+
+_TOKEN_LOCK = threading.Lock()
+_TOKEN_CACHE = {
+    "identity": None,
+    "token": None,
+    "expires_at": 0,
+}
+
+
+class QWeatherAuthError(RuntimeError):
+    """只包含稳定错误码，避免异常文本泄露认证材料。"""
+
+
+def _value(name: str, config: Optional[Mapping] = None, default=""):
+    if config is not None and name in config:
+        value = config.get(name)
+    elif has_app_context():
+        value = current_app.config.get(name, default)
+    else:
+        value = os.getenv(name, default)
+    if isinstance(value, str):
+        return value.strip()
+    return value if value is not None else default
+
+
+def get_qweather_auth_mode(config: Optional[Mapping] = None) -> str:
+    """返回显式认证模式；旧配置默认兼容 API Key。"""
+    mode = str(_value("QWEATHER_AUTH_MODE", config, "") or "").lower()
+    if not mode:
+        mode = "api_key" if _value("QWEATHER_KEY", config, "") else "disabled"
+    if mode not in _ALLOWED_AUTH_MODES:
+        raise QWeatherAuthError("qweather_auth_mode_invalid")
+    return mode
+
+
+def is_qweather_configured(config: Optional[Mapping] = None) -> bool:
+    """判断当前认证模式是否具备生成请求头所需的配置。"""
+    try:
+        mode = get_qweather_auth_mode(config)
+    except QWeatherAuthError:
+        return False
+    if mode == "api_key":
+        return bool(_value("QWEATHER_KEY", config, ""))
+    if mode == "jwt":
+        return all(
+            (
+                _value("QWEATHER_JWT_KID", config, ""),
+                _value("QWEATHER_JWT_PROJECT_ID", config, ""),
+                _value("QWEATHER_JWT_PRIVATE_KEY_PATH", config, ""),
+            )
+        )
+    return False
+
+
+def validate_qweather_api_base(
+    api_base: str,
+    config: Optional[Mapping] = None,
+) -> str:
+    """阻止认证头发送到非 HTTPS 或非预期的 JWT Host。"""
+    value = str(api_base or "").strip().rstrip("/")
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme.lower() != "https"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise QWeatherAuthError("qweather_api_base_invalid")
+
+    if get_qweather_auth_mode(config) == "jwt":
+        hostname = parsed.hostname.lower().rstrip(".")
+        if hostname != "qweatherapi.com" and not hostname.endswith(".qweatherapi.com"):
+            raise QWeatherAuthError("qweather_jwt_host_invalid")
+        if parsed.path.rstrip("/") != "/v7":
+            raise QWeatherAuthError("qweather_jwt_base_path_invalid")
+    return value
+
+
+def _private_key_identity(path_value: str, kid: str, project_id: str):
+    path = Path(path_value).expanduser()
+    try:
+        file_stat = path.stat()
+    except OSError as exc:
+        raise QWeatherAuthError("qweather_jwt_key_unavailable") from exc
+
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise QWeatherAuthError("qweather_jwt_key_not_regular")
+    if file_stat.st_mode & 0o077:
+        raise QWeatherAuthError("qweather_jwt_key_permissions")
+    if file_stat.st_size <= 0 or file_stat.st_size > _MAX_PRIVATE_KEY_BYTES:
+        raise QWeatherAuthError("qweather_jwt_key_size_invalid")
+
+    identity = (
+        kid,
+        project_id,
+        str(path.resolve()),
+        file_stat.st_mtime_ns,
+        file_stat.st_size,
+    )
+    return path, identity
+
+
+def _generate_jwt(path: Path, kid: str, project_id: str, now: int):
+    try:
+        private_key = path.read_bytes()
+        token = jwt.encode(
+            {
+                "sub": project_id,
+                "iat": now - _JWT_CLOCK_SKEW_SECONDS,
+                "exp": now + _JWT_LIFETIME_SECONDS,
+            },
+            private_key,
+            algorithm="EdDSA",
+            headers={"kid": kid},
+        )
+    except Exception as exc:
+        raise QWeatherAuthError("qweather_jwt_sign_failed") from exc
+    if isinstance(token, bytes):
+        token = token.decode("ascii")
+    if not isinstance(token, str) or not token:
+        raise QWeatherAuthError("qweather_jwt_sign_failed")
+    return token, now + _JWT_LIFETIME_SECONDS
+
+
+def _get_cached_jwt(config: Optional[Mapping] = None) -> str:
+    kid = str(_value("QWEATHER_JWT_KID", config, "") or "")
+    project_id = str(_value("QWEATHER_JWT_PROJECT_ID", config, "") or "")
+    key_path = str(_value("QWEATHER_JWT_PRIVATE_KEY_PATH", config, "") or "")
+    if not kid or not project_id or not key_path:
+        raise QWeatherAuthError("qweather_jwt_config_missing")
+
+    path, identity = _private_key_identity(key_path, kid, project_id)
+    now = int(time.time())
+    cached_token = _TOKEN_CACHE.get("token")
+    if (
+        _TOKEN_CACHE.get("identity") == identity
+        and cached_token
+        and now < int(_TOKEN_CACHE.get("expires_at") or 0) - _JWT_REFRESH_MARGIN_SECONDS
+    ):
+        return str(cached_token)
+
+    with _TOKEN_LOCK:
+        now = int(time.time())
+        cached_token = _TOKEN_CACHE.get("token")
+        if (
+            _TOKEN_CACHE.get("identity") == identity
+            and cached_token
+            and now < int(_TOKEN_CACHE.get("expires_at") or 0) - _JWT_REFRESH_MARGIN_SECONDS
+        ):
+            return str(cached_token)
+        token, expires_at = _generate_jwt(path, kid, project_id, now)
+        _TOKEN_CACHE.update(
+            identity=identity,
+            token=token,
+            expires_at=expires_at,
+        )
+        return token
+
+
+def invalidate_qweather_token() -> None:
+    """清除当前进程的 JWT 缓存，供轮换密钥或 401 诊断使用。"""
+    with _TOKEN_LOCK:
+        _TOKEN_CACHE.update(identity=None, token=None, expires_at=0)
+
+
+def get_qweather_request_headers(
+    config: Optional[Mapping] = None,
+    api_base: Optional[str] = None,
+) -> dict:
+    """生成且只生成一种 QWeather 认证请求头。"""
+    mode = get_qweather_auth_mode(config)
+    if api_base is not None:
+        validate_qweather_api_base(api_base, config)
+    if mode == "api_key":
+        api_key = str(_value("QWEATHER_KEY", config, "") or "")
+        if not api_key:
+            raise QWeatherAuthError("qweather_api_key_missing")
+        return {"X-QW-Api-Key": api_key}
+    if mode == "jwt":
+        return {"Authorization": f"Bearer {_get_cached_jwt(config)}"}
+    raise QWeatherAuthError("qweather_auth_disabled")

--- a/services/warning_service.py
+++ b/services/warning_service.py
@@ -18,6 +18,12 @@ import requests
 from flask import current_app, has_app_context
 
 from services.external_api import record_external_api_timing as _record_external_api_timing
+from services.qweather_auth import (
+    QWeatherAuthError,
+    get_qweather_request_headers,
+    invalidate_qweather_token,
+    is_qweather_configured,
+)
 from services.qweather_budget import get_qweather_redis_client, reserve_qweather_request
 from utils.parsers import parse_int
 
@@ -147,9 +153,8 @@ def get_qweather_warnings(location_code: str) -> List[Dict[str, Any]]:
 
     location_code = _canonical_location(location_code)
 
-    qweather_key = (_cfg("QWEATHER_KEY") or "").strip()
     api_base = (_cfg("QWEATHER_API_BASE") or "").strip()
-    if not qweather_key or not api_base:
+    if not api_base or not is_qweather_configured():
         return []
 
     cached = _get_cached_warnings(location_code)
@@ -158,7 +163,12 @@ def get_qweather_warnings(location_code: str) -> List[Dict[str, Any]]:
 
     url = f"{api_base.rstrip('/')}/warning/now"
     params = {"location": location_code}
-    headers = {"X-QW-Api-Key": qweather_key}
+
+    try:
+        headers = get_qweather_request_headers(api_base=api_base)
+    except QWeatherAuthError as exc:
+        logger.warning("QWeather warning auth failed: %s", exc)
+        return []
 
     if not reserve_qweather_request("warning_now"):
         logger.warning("和风天气月度额度保护：跳过官方预警请求")
@@ -169,6 +179,8 @@ def get_qweather_warnings(location_code: str) -> List[Dict[str, Any]]:
         resp = requests.get(url, params=params, headers=headers, timeout=10)
         _record_external_api_timing("qweather_warning_now", (time.perf_counter() - start_ts) * 1000, resp.status_code)
         if resp.status_code != 200:
+            if resp.status_code == 401:
+                invalidate_qweather_token()
             logger.info("QWeather warning http=%s for location=%s", resp.status_code, location_code)
             return []
         payload = resp.json()
@@ -178,6 +190,8 @@ def get_qweather_warnings(location_code: str) -> List[Dict[str, Any]]:
 
     try:
         if str(payload.get("code")) != "200":
+            if str(payload.get("code")) == "401":
+                invalidate_qweather_token()
             return []
         raw_list = payload.get("warning") or payload.get("warnings") or []
         if not isinstance(raw_list, list):

--- a/services/weather_service.py
+++ b/services/weather_service.py
@@ -14,6 +14,12 @@ from statistics import mean, pstdev
 from urllib.parse import urlsplit
 from flask import current_app, has_app_context
 from services.external_api import record_external_api_timing as _record_external_api_timing
+from services.qweather_auth import (
+    QWeatherAuthError,
+    get_qweather_request_headers,
+    invalidate_qweather_token,
+    is_qweather_configured,
+)
 from services.qweather_budget import reserve_qweather_request
 from core.time_utils import today_local
 
@@ -21,7 +27,11 @@ class WeatherService:
     """天气服务类"""
     
     def __init__(self):
+        self.qweather_auth_mode = 'api_key'
         self.qweather_key = None
+        self.qweather_jwt_kid = None
+        self.qweather_jwt_project_id = None
+        self.qweather_jwt_private_key_path = None
         self.api_base_url = None
         self.city_map = {}
         self.default_location = '116.20,29.27'  # 都昌县
@@ -38,7 +48,23 @@ class WeatherService:
             except Exception:
                 app_config = {}
 
+        configured_auth_mode = app_config.get('QWEATHER_AUTH_MODE')
+        if configured_auth_mode is None:
+            configured_auth_mode = os.getenv('QWEATHER_AUTH_MODE', 'api_key')
+        self.qweather_auth_mode = str(configured_auth_mode or 'api_key').strip().lower()
         self.qweather_key = app_config.get('QWEATHER_KEY') or os.getenv('QWEATHER_KEY')
+        self.qweather_jwt_kid = (
+            app_config.get('QWEATHER_JWT_KID')
+            or os.getenv('QWEATHER_JWT_KID')
+        )
+        self.qweather_jwt_project_id = (
+            app_config.get('QWEATHER_JWT_PROJECT_ID')
+            or os.getenv('QWEATHER_JWT_PROJECT_ID')
+        )
+        self.qweather_jwt_private_key_path = (
+            app_config.get('QWEATHER_JWT_PRIVATE_KEY_PATH')
+            or os.getenv('QWEATHER_JWT_PRIVATE_KEY_PATH')
+        )
         configured_api_base = app_config.get('QWEATHER_API_BASE')
         if configured_api_base is None:
             configured_api_base = os.getenv('QWEATHER_API_BASE')
@@ -54,9 +80,25 @@ class WeatherService:
             or self.default_location
         )
 
+    def _qweather_auth_config(self):
+        """返回当前实例的认证配置，不包含任何日志输出。"""
+        return {
+            'QWEATHER_AUTH_MODE': self.qweather_auth_mode,
+            'QWEATHER_KEY': self.qweather_key,
+            'QWEATHER_JWT_KID': self.qweather_jwt_kid,
+            'QWEATHER_JWT_PROJECT_ID': self.qweather_jwt_project_id,
+            'QWEATHER_JWT_PRIVATE_KEY_PATH': self.qweather_jwt_private_key_path,
+        }
+
+    def _qweather_is_configured(self):
+        return bool(self.api_base_url) and is_qweather_configured(self._qweather_auth_config())
+
     def _qweather_headers(self):
-        """通过请求头发送密钥，避免密钥出现在 URL 与代理日志中。"""
-        return {'X-QW-Api-Key': self.qweather_key}
+        """生成单一认证请求头，并在预占额度前完成签名与 Host 校验。"""
+        return get_qweather_request_headers(
+            self._qweather_auth_config(),
+            api_base=self.api_base_url,
+        )
     
     def _get_location(self, city):
         """获取城市的location参数"""
@@ -119,7 +161,7 @@ class WeatherService:
         """
         logger = logging.getLogger(__name__)
         # 尝试调用和风天气API
-        if self.qweather_key and self.api_base_url:
+        if self._qweather_is_configured():
             try:
                 # 获取城市location
                 location = self._get_location(city)
@@ -130,6 +172,7 @@ class WeatherService:
                     'location': location
                 }
 
+                headers = self._qweather_headers()
                 if not reserve_qweather_request('weather_now'):
                     logger.warning("和风天气月度额度保护：跳过实况请求并使用备用源")
                     return self._get_fallback_weather(city, logger)
@@ -137,13 +180,15 @@ class WeatherService:
                 weather_response = requests.get(
                     weather_url,
                     params=weather_params,
-                    headers=self._qweather_headers(),
+                    headers=headers,
                     timeout=10,
                 )
                 _record_external_api_timing('qweather_now', (time.perf_counter() - start_ts) * 1000, weather_response.status_code)
                 
                 # 检查HTTP状态码
                 if weather_response.status_code != 200:
+                    if weather_response.status_code == 401:
+                        invalidate_qweather_token()
                     logger.warning("API HTTP状态码: %s，尝试备用API", weather_response.status_code)
                     return self._get_fallback_weather(city, logger)
                 
@@ -157,6 +202,8 @@ class WeatherService:
                 # 检查返回状态
                 code = weather_data.get('code')
                 if code != '200':
+                    if str(code) == '401':
+                        invalidate_qweather_token()
                     if code is None:
                         logger.warning("和风天气API响应格式异常，尝试备用API")
                         logger.debug("响应内容: %s", str(weather_data)[:200])
@@ -218,6 +265,8 @@ class WeatherService:
                 logger.info("成功获取%s的真实天气数据 (温度: %s°C)", city, result['temperature'])
                 return result
                     
+            except QWeatherAuthError as auth_error:
+                logger.warning("和风天气认证失败: %s，尝试备用API", auth_error)
             except requests.exceptions.Timeout:
                 logger.warning("和风天气API请求超时，尝试备用API")
             except requests.exceptions.ConnectionError:
@@ -235,7 +284,7 @@ class WeatherService:
         """获取错误码对应的说明"""
         error_codes = {
             '400': '请求错误',
-            '401': 'API密钥无效或过期',
+            '401': 'API认证无效或过期',
             '402': '超过访问次数限制',
             '403': '无访问权限',
             '404': '查询的数据不存在',
@@ -261,16 +310,16 @@ class WeatherService:
         api_origin = f"{parsed_base.scheme}://{parsed_base.netloc}"
         air_url = f"{api_origin}/airquality/v1/current/{lat:.2f}/{lon:.2f}"
 
-        if not reserve_qweather_request('airquality_v1_current'):
-            logger.debug("和风天气月度额度保护：跳过空气质量请求")
-            return {}
-
         try:
+            headers = self._qweather_headers()
+            if not reserve_qweather_request('airquality_v1_current'):
+                logger.debug("和风天气月度额度保护：跳过空气质量请求")
+                return {}
             start_ts = time.perf_counter()
             response = requests.get(
                 air_url,
                 params={'lang': 'zh'},
-                headers=self._qweather_headers(),
+                headers=headers,
                 timeout=10,
             )
             _record_external_api_timing(
@@ -279,6 +328,8 @@ class WeatherService:
                 response.status_code,
             )
             if response.status_code != 200:
+                if response.status_code == 401:
+                    invalidate_qweather_token()
                 logger.debug("空气质量 v1 HTTP 状态码: %s", response.status_code)
                 return {}
 
@@ -481,20 +532,21 @@ class WeatherService:
     def _get_qweather_hourly_extremes(self, location):
         """从和风 24 小时温度序列推导温差。"""
         logger = logging.getLogger(__name__)
-        if not self.qweather_key or not self.api_base_url:
+        if not self._qweather_is_configured():
             return None, None, 'none'
         try:
             hourly_url = f"{self.api_base_url}/weather/24h"
             hourly_params = {
                 'location': location
             }
+            headers = self._qweather_headers()
             if not reserve_qweather_request('weather_24h_current_range'):
                 return None, None, 'none'
             start_ts = time.perf_counter()
             response = requests.get(
                 hourly_url,
                 params=hourly_params,
-                headers=self._qweather_headers(),
+                headers=headers,
                 timeout=10,
             )
             _record_external_api_timing(
@@ -503,9 +555,13 @@ class WeatherService:
                 response.status_code
             )
             if response.status_code != 200:
+                if response.status_code == 401:
+                    invalidate_qweather_token()
                 return None, None, 'none'
             payload = response.json()
             if payload.get('code') != '200':
+                if str(payload.get('code')) == '401':
+                    invalidate_qweather_token()
                 return None, None, 'none'
             hourly = payload.get('hourly') or []
             temps = [item.get('temp') for item in hourly if isinstance(item, dict)]
@@ -565,20 +621,21 @@ class WeatherService:
     def _get_qweather_today_extremes(self, location):
         """获取和风当日最高/最低温（用于修正实况无日温差的问题）。"""
         logger = logging.getLogger(__name__)
-        if not self.qweather_key or not self.api_base_url:
+        if not self._qweather_is_configured():
             return None, None
         try:
             forecast_url = f"{self.api_base_url}/weather/7d"
             forecast_params = {
                 'location': location
             }
+            headers = self._qweather_headers()
             if not reserve_qweather_request('weather_7d_current_range'):
                 return None, None
             start_ts = time.perf_counter()
             response = requests.get(
                 forecast_url,
                 params=forecast_params,
-                headers=self._qweather_headers(),
+                headers=headers,
                 timeout=10,
             )
             _record_external_api_timing(
@@ -587,9 +644,13 @@ class WeatherService:
                 response.status_code
             )
             if response.status_code != 200:
+                if response.status_code == 401:
+                    invalidate_qweather_token()
                 return None, None
             payload = response.json()
             if payload.get('code') != '200':
+                if str(payload.get('code')) == '401':
+                    invalidate_qweather_token()
                 return None, None
             daily = payload.get('daily') or []
             if not daily:
@@ -659,7 +720,7 @@ class WeatherService:
             days = 7
 
         meta = {'source': 'QWeather'}
-        if not self.qweather_key or not self.api_base_url:
+        if not self._qweather_is_configured():
             meta['error'] = 'qweather_not_configured'
             logger.warning("和风天气预报未配置，跳过和风-only预报")
             return {'success': False, 'daily': [], 'meta': meta}
@@ -672,6 +733,7 @@ class WeatherService:
             forecast_params = {
                 'location': location
             }
+            headers = self._qweather_headers()
             if not reserve_qweather_request('weather_7d_forecast'):
                 meta['error'] = 'qweather_budget_exhausted'
                 return {'success': False, 'daily': [], 'meta': meta}
@@ -679,7 +741,7 @@ class WeatherService:
             response = requests.get(
                 forecast_url,
                 params=forecast_params,
-                headers=self._qweather_headers(),
+                headers=headers,
                 timeout=10,
             )
             _record_external_api_timing(
@@ -688,6 +750,8 @@ class WeatherService:
                 response.status_code
             )
             if response.status_code != 200:
+                if response.status_code == 401:
+                    invalidate_qweather_token()
                 meta['error'] = f'http_{response.status_code}'
                 logger.warning("和风-only预报HTTP状态码: %s", response.status_code)
                 return {'success': False, 'daily': [], 'meta': meta}
@@ -701,6 +765,8 @@ class WeatherService:
 
             code = payload.get('code')
             if code != '200':
+                if str(code) == '401':
+                    invalidate_qweather_token()
                 meta['error'] = f'qweather_{code or "unknown"}'
                 meta['error_message'] = self._get_error_message(code or 'unknown')
                 logger.warning("和风-only预报返回错误[%s]: %s", code, meta['error_message'])
@@ -730,6 +796,9 @@ class WeatherService:
                 logger.warning("和风-only预报关键字段不完整，整组数据不进入缓存: city=%s count=%s", city, len(daily))
                 return {'success': False, 'daily': [], 'meta': meta}
             return {'success': True, 'daily': daily, 'meta': meta}
+        except QWeatherAuthError as auth_error:
+            meta['error'] = str(auth_error)
+            logger.warning("和风-only预报认证失败: %s", auth_error)
         except requests.exceptions.Timeout:
             meta['error'] = 'timeout'
             logger.warning("和风-only预报请求超时")
@@ -1023,7 +1092,7 @@ class WeatherService:
         # 限制最多7天
         days = min(days, 7)
         qweather_forecast = []
-        if self.qweather_key and self.api_base_url:
+        if self._qweather_is_configured():
             try:
                 location = self._get_location(city)
 
@@ -1033,13 +1102,14 @@ class WeatherService:
                     'location': location
                 }
 
+                headers = self._qweather_headers()
                 if not reserve_qweather_request('weather_7d_forecast'):
                     raise RuntimeError('qweather_budget_exhausted')
                 start_ts = time.perf_counter()
                 response = requests.get(
                     forecast_url,
                     params=forecast_params,
-                    headers=self._qweather_headers(),
+                    headers=headers,
                     timeout=10,
                 )
                 _record_external_api_timing(
@@ -1056,10 +1126,16 @@ class WeatherService:
                         ]
                         logger.info("成功获取%s的和风%s天预报数据", city, len(qweather_forecast))
                     else:
+                        if str(data.get('code')) == '401':
+                            invalidate_qweather_token()
                         error_msg = self._get_error_message(data.get('code', 'unknown'))
                         logger.warning("和风预报获取失败: %s", error_msg)
                 else:
+                    if response.status_code == 401:
+                        invalidate_qweather_token()
                     logger.warning("和风预报HTTP状态码: %s", response.status_code)
+            except QWeatherAuthError as auth_error:
+                logger.warning("和风预报认证失败: %s", auth_error)
             except requests.exceptions.Timeout:
                 logger.warning("和风预报请求超时")
             except requests.exceptions.ConnectionError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,11 @@ def setup_test_environment():
         'DATABASE_URI': f'sqlite:///{temp_db_path}',
         'SECRET_KEY': 'test-secret-key-for-pytest',
         'DEBUG': 'true',
+        'QWEATHER_AUTH_MODE': 'api_key',
         'QWEATHER_KEY': '',  # 测试中禁用外部 API
+        'QWEATHER_JWT_KID': '',
+        'QWEATHER_JWT_PROJECT_ID': '',
+        'QWEATHER_JWT_PRIVATE_KEY_PATH': '',
         'AMAP_KEY': '',
         'SILICONFLOW_API_KEY': '',
         'DEMO_MODE': '1',  # 启用演示模式，使用 mock 数据

--- a/tests/manual/test_weather_api.py
+++ b/tests/manual/test_weather_api.py
@@ -8,6 +8,13 @@ from urllib.parse import urlsplit
 import requests
 import pytest
 
+from services.qweather_auth import (
+    QWeatherAuthError,
+    get_qweather_auth_mode,
+    get_qweather_request_headers,
+    is_qweather_configured,
+)
+
 pytestmark = pytest.mark.manual
 
 def test_qweather_api():
@@ -17,12 +24,11 @@ def test_qweather_api():
     print("=" * 50)
     
     # API配置（如使用付费订阅版，请在本地环境变量里显式提供专属域名）
-    key = os.getenv("QWEATHER_KEY")
     base_url = os.getenv("QWEATHER_API_BASE")
     location = "116.20,29.27"  # 都昌县
 
-    if not key:
-        pytest.skip("未设置 QWEATHER_KEY")
+    if not is_qweather_configured():
+        pytest.skip("未完整配置 QWeather 认证")
     if not base_url:
         pytest.skip("未设置 QWEATHER_API_BASE")
     if "your-qweather-host.example.com" in base_url:
@@ -30,9 +36,12 @@ def test_qweather_api():
 
     parsed_base = urlsplit(base_url)
     api_origin = f"{parsed_base.scheme}://{parsed_base.netloc}"
-    headers = {'X-QW-Api-Key': key}
+    try:
+        headers = get_qweather_request_headers(api_base=base_url)
+    except QWeatherAuthError as exc:
+        pytest.fail(f"QWeather 认证配置错误: {exc}")
     
-    print("\nAPI Key: 已配置")
+    print(f"\n认证模式: {get_qweather_auth_mode()}")
     print(f"Base URL: {base_url}")
     print(f"Location: {location}")
     

--- a/tests/test_qweather_auth.py
+++ b/tests/test_qweather_auth.py
@@ -1,0 +1,279 @@
+# -*- coding: utf-8 -*-
+
+import threading
+import time as stdlib_time
+from concurrent.futures import ThreadPoolExecutor
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from services import qweather_auth
+
+
+@pytest.fixture(autouse=True)
+def clear_token_cache():
+    qweather_auth.invalidate_qweather_token()
+    yield
+    qweather_auth.invalidate_qweather_token()
+
+
+@pytest.fixture
+def jwt_material(tmp_path):
+    private_key = Ed25519PrivateKey.generate()
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    key_path = tmp_path / "qweather-ed25519-private.pem"
+    key_path.write_bytes(private_pem)
+    key_path.chmod(0o600)
+    config = {
+        "QWEATHER_AUTH_MODE": "jwt",
+        "QWEATHER_JWT_KID": "KID1234567",
+        "QWEATHER_JWT_PROJECT_ID": "PROJECT1234",
+        "QWEATHER_JWT_PRIVATE_KEY_PATH": str(key_path),
+    }
+    return config, key_path, public_pem
+
+
+def test_api_key_mode_sends_only_api_key_header():
+    config = {
+        "QWEATHER_AUTH_MODE": "api_key",
+        "QWEATHER_KEY": "unit-test-key",
+    }
+
+    headers = qweather_auth.get_qweather_request_headers(
+        config,
+        api_base="https://example.com/v7",
+    )
+
+    assert headers == {"X-QW-Api-Key": "unit-test-key"}
+
+
+def test_jwt_header_signature_and_claims(jwt_material, monkeypatch):
+    config, _key_path, public_pem = jwt_material
+    now = int(stdlib_time.time())
+    monkeypatch.setattr(qweather_auth.time, "time", lambda: now)
+
+    headers = qweather_auth.get_qweather_request_headers(
+        config,
+        api_base="https://unit-test.qweatherapi.com/v7",
+    )
+
+    assert set(headers) == {"Authorization"}
+    token = headers["Authorization"].removeprefix("Bearer ")
+    token_header = jwt.get_unverified_header(token)
+    claims = jwt.decode(token, public_pem, algorithms=["EdDSA"])
+    assert token_header["alg"] == "EdDSA"
+    assert token_header["kid"] == "KID1234567"
+    assert claims == {
+        "sub": "PROJECT1234",
+        "iat": now - 30,
+        "exp": now + 900,
+    }
+
+
+def test_jwt_cache_refreshes_one_minute_before_expiry(jwt_material, monkeypatch):
+    config, _key_path, _public_pem = jwt_material
+    clock = {"now": 1000}
+    generated = []
+
+    def fake_generate(_path, _kid, _project_id, now):
+        generated.append(now)
+        return f"token-{len(generated)}", now + 900
+
+    monkeypatch.setattr(qweather_auth.time, "time", lambda: clock["now"])
+    monkeypatch.setattr(qweather_auth, "_generate_jwt", fake_generate)
+
+    first = qweather_auth.get_qweather_request_headers(config)
+    clock["now"] = 1839
+    second = qweather_auth.get_qweather_request_headers(config)
+    clock["now"] = 1840
+    third = qweather_auth.get_qweather_request_headers(config)
+
+    assert first == second == {"Authorization": "Bearer token-1"}
+    assert third == {"Authorization": "Bearer token-2"}
+    assert generated == [1000, 1840]
+
+
+def test_concurrent_requests_sign_only_once(jwt_material, monkeypatch):
+    config, _key_path, _public_pem = jwt_material
+    calls = []
+    calls_lock = threading.Lock()
+
+    def fake_generate(_path, _kid, _project_id, now):
+        with calls_lock:
+            calls.append(now)
+        stdlib_time.sleep(0.02)
+        return "shared-token", now + 900
+
+    monkeypatch.setattr(qweather_auth, "_generate_jwt", fake_generate)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        headers = list(executor.map(lambda _index: qweather_auth.get_qweather_request_headers(config), range(16)))
+
+    assert headers == [{"Authorization": "Bearer shared-token"}] * 16
+    assert len(calls) == 1
+
+
+def test_jwt_rejects_private_key_with_open_permissions(jwt_material):
+    config, key_path, _public_pem = jwt_material
+    key_path.chmod(0o644)
+
+    with pytest.raises(qweather_auth.QWeatherAuthError, match="qweather_jwt_key_permissions"):
+        qweather_auth.get_qweather_request_headers(config)
+
+
+@pytest.mark.parametrize(
+    "api_base,error_code",
+    [
+        ("http://unit-test.qweatherapi.com/v7", "qweather_api_base_invalid"),
+        ("https://example.com/v7", "qweather_jwt_host_invalid"),
+        ("https://unit-test.qweatherapi.com/weather", "qweather_jwt_base_path_invalid"),
+        ("https://user@unit-test.qweatherapi.com/v7", "qweather_api_base_invalid"),
+    ],
+)
+def test_jwt_rejects_untrusted_api_base(jwt_material, api_base, error_code):
+    config, _key_path, _public_pem = jwt_material
+
+    with pytest.raises(qweather_auth.QWeatherAuthError, match=error_code):
+        qweather_auth.get_qweather_request_headers(config, api_base=api_base)
+
+
+def test_disabled_and_incomplete_modes_fail_closed():
+    assert not qweather_auth.is_qweather_configured({"QWEATHER_AUTH_MODE": "disabled"})
+    assert not qweather_auth.is_qweather_configured({"QWEATHER_AUTH_MODE": "jwt"})
+    with pytest.raises(qweather_auth.QWeatherAuthError, match="qweather_auth_disabled"):
+        qweather_auth.get_qweather_request_headers({"QWEATHER_AUTH_MODE": "disabled"})
+
+
+def test_auth_failure_does_not_use_budget_or_network(monkeypatch, tmp_path):
+    from services import weather_service as weather_module
+
+    service = weather_module.WeatherService()
+    service.qweather_auth_mode = "jwt"
+    service.qweather_jwt_kid = "KID1234567"
+    service.qweather_jwt_project_id = "PROJECT1234"
+    service.qweather_jwt_private_key_path = str(tmp_path / "missing.pem")
+    service.api_base_url = "https://unit-test.qweatherapi.com/v7"
+    service.canonical_location = "116.20,29.27"
+    fallback = {"data_source": "Open-Meteo"}
+    budget_calls = []
+
+    monkeypatch.setattr(
+        weather_module,
+        "reserve_qweather_request",
+        lambda endpoint: budget_calls.append(endpoint) or True,
+    )
+    monkeypatch.setattr(
+        weather_module.requests,
+        "get",
+        lambda *_args, **_kwargs: pytest.fail("认证失败后不应发送网络请求"),
+    )
+    monkeypatch.setattr(service, "_get_fallback_weather", lambda *_args: fallback)
+
+    assert service.get_current_weather("都昌") == fallback
+    assert budget_calls == []
+
+
+@pytest.mark.parametrize(
+    "method_name,args",
+    [
+        ("_get_qweather_air_quality", ("116.20,29.27",)),
+        ("_get_qweather_hourly_extremes", ("116.20,29.27",)),
+        ("_get_qweather_today_extremes", ("116.20,29.27",)),
+        ("get_qweather_daily_forecast", ("都昌", 7)),
+        ("get_weather_forecast", ("都昌", 7)),
+    ],
+)
+def test_each_weather_path_authenticates_before_budget(
+    method_name,
+    args,
+    monkeypatch,
+    tmp_path,
+):
+    from services import weather_service as weather_module
+
+    service = weather_module.WeatherService()
+    service.qweather_auth_mode = "jwt"
+    service.qweather_jwt_kid = "KID1234567"
+    service.qweather_jwt_project_id = "PROJECT1234"
+    service.qweather_jwt_private_key_path = str(tmp_path / "missing.pem")
+    service.api_base_url = "https://unit-test.qweatherapi.com/v7"
+    service.canonical_location = "116.20,29.27"
+    service.use_openmeteo_fallback = False
+    budget_calls = []
+
+    monkeypatch.setattr(
+        weather_module,
+        "reserve_qweather_request",
+        lambda endpoint: budget_calls.append(endpoint) or True,
+    )
+    monkeypatch.setattr(
+        weather_module.requests,
+        "get",
+        lambda *_args, **_kwargs: pytest.fail("认证失败后不应发送网络请求"),
+    )
+
+    getattr(service, method_name)(*args)
+
+    assert budget_calls == []
+
+
+def test_weather_service_uses_jwt_for_seven_day_forecast(jwt_material, monkeypatch):
+    from services import weather_service as weather_module
+
+    config, _key_path, _public_pem = jwt_material
+    service = weather_module.WeatherService()
+    service.qweather_auth_mode = "jwt"
+    service.qweather_jwt_kid = config["QWEATHER_JWT_KID"]
+    service.qweather_jwt_project_id = config["QWEATHER_JWT_PROJECT_ID"]
+    service.qweather_jwt_private_key_path = config["QWEATHER_JWT_PRIVATE_KEY_PATH"]
+    service.api_base_url = "https://unit-test.qweatherapi.com/v7"
+    service.canonical_location = "116.20,29.27"
+    requests_seen = []
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "code": "200",
+                "updateTime": "2026-07-17T12:00+08:00",
+                "daily": [
+                    {
+                        "fxDate": f"2026-07-{17 + index:02d}",
+                        "tempMax": "35",
+                        "tempMin": "27",
+                        "humidity": "70",
+                        "textDay": "晴",
+                    }
+                    for index in range(7)
+                ],
+            }
+
+    def fake_get(url, **kwargs):
+        requests_seen.append((url, kwargs))
+        return FakeResponse()
+
+    monkeypatch.setattr(weather_module.requests, "get", fake_get)
+    monkeypatch.setattr(weather_module, "_record_external_api_timing", lambda *_args: None)
+    monkeypatch.setattr(weather_module, "reserve_qweather_request", lambda _endpoint: True)
+
+    result = service.get_qweather_daily_forecast("任意村庄", days=7)
+
+    assert result["success"] is True
+    assert len(result["daily"]) == 7
+    assert len(requests_seen) == 1
+    url, kwargs = requests_seen[0]
+    assert url == "https://unit-test.qweatherapi.com/v7/weather/7d"
+    assert kwargs["params"] == {"location": "116.20,29.27"}
+    assert set(kwargs["headers"]) == {"Authorization"}
+    assert kwargs["headers"]["Authorization"].startswith("Bearer ")

--- a/tests/test_warning_service.py
+++ b/tests/test_warning_service.py
@@ -88,3 +88,74 @@ def test_warning_service_reuses_duchang_cache_and_hides_key_from_url(app, monkey
     _url, kwargs = calls[0]
     assert kwargs["params"] == {"location": "116.20,29.27"}
     assert kwargs["headers"] == {"X-QW-Api-Key": "secret-test-key"}
+
+
+def test_warning_service_uses_only_jwt_header(app, monkeypatch):
+    from services import warning_service
+
+    calls = []
+
+    class FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {"code": "200", "warning": []}
+
+    monkeypatch.setattr(
+        warning_service,
+        "get_qweather_request_headers",
+        lambda **_kwargs: {"Authorization": "Bearer unit-test-token"},
+    )
+    monkeypatch.setattr(
+        warning_service.requests,
+        "get",
+        lambda url, **kwargs: calls.append((url, kwargs)) or FakeResp(),
+    )
+
+    with app.app_context():
+        app.config.update(
+            QWEATHER_AUTH_MODE="jwt",
+            QWEATHER_API_BASE="https://unit-test.qweatherapi.com/v7",
+            QWEATHER_JWT_KID="KID1234567",
+            QWEATHER_JWT_PROJECT_ID="PROJECT1234",
+            QWEATHER_JWT_PRIVATE_KEY_PATH="/server-only/private.pem",
+            QWEATHER_CANONICAL_LOCATION="116.20,29.27",
+        )
+        assert warning_service.get_qweather_warnings("任意村庄") == []
+
+    assert len(calls) == 1
+    assert calls[0][1]["headers"] == {"Authorization": "Bearer unit-test-token"}
+
+
+def test_warning_auth_failure_does_not_use_budget_or_network(app, monkeypatch):
+    from services import warning_service
+    from services.qweather_auth import QWeatherAuthError
+
+    budget_calls = []
+    monkeypatch.setattr(
+        warning_service,
+        "get_qweather_request_headers",
+        lambda **_kwargs: (_ for _ in ()).throw(QWeatherAuthError("qweather_jwt_sign_failed")),
+    )
+    monkeypatch.setattr(
+        warning_service,
+        "reserve_qweather_request",
+        lambda endpoint: budget_calls.append(endpoint) or True,
+    )
+    monkeypatch.setattr(
+        warning_service.requests,
+        "get",
+        lambda *_args, **_kwargs: pytest.fail("认证失败后不应发送网络请求"),
+    )
+
+    with app.app_context():
+        app.config.update(
+            QWEATHER_AUTH_MODE="jwt",
+            QWEATHER_API_BASE="https://unit-test.qweatherapi.com/v7",
+            QWEATHER_JWT_KID="KID1234567",
+            QWEATHER_JWT_PROJECT_ID="PROJECT1234",
+            QWEATHER_JWT_PRIVATE_KEY_PATH="/server-only/private.pem",
+        )
+        assert warning_service.get_qweather_warnings("116.20,29.27") == []
+
+    assert budget_calls == []


### PR DESCRIPTION
## 这次改了什么

为天气实况、24 小时、7 天预报、天气预警和 Air Quality v1 接入共享 Ed25519 JWT 认证，同时保留显式 `api_key` 人工回滚模式。

## 为什么要改

生产当前仍依赖旧 API Key。新实现让单次请求只发送一种认证头，并在 JWT 签名与专属 Host 校验成功后才预占月度请求额度，避免认证故障消耗 40,000 次硬上限。

## 怎么测试

- 专项回归：50 passed
- 完整回归：394 passed, 11 deselected
- `git diff --check`、Python compileall、真实 Ed25519 签名/claims、并发缓存、提前刷新、私钥权限、401 清缓存均已验证
- 生产切换前只读检查：专属 HTTPS Host 与 `/v7` 路径正确，服务器 NTP 已同步，私钥权限为 0600
- 合并后仍需执行生产六类接口 JWT 直测与正式域名验收

## 文件与密钥去向

- 主仓库：认证代码、占位环境变量、测试
- 生产服务器：Ed25519 私钥继续只保存在 `/opt/case-weather/secrets/qweather-jwt/`
- GitHub / Cloudflare：不上传私钥、JWT、真实 Host 或旧 API Key

## 其他

- 未修改 `.sh` 或 `.githooks`，无需 `bash -n`
- Notion 不在本次范围，无待回填内容
