### PR TITLE
fix: 修复 GIS 缩放后网格消失

### DIFF
--- a/static/js/heat-exposure-gis.js
+++ b/static/js/heat-exposure-gis.js
@@ -131,8 +131,8 @@
         geometryMode: 'rectified',
         renderFrame: null,
         resizeFrame: null,
-        mapMoving: false,
-        mapZooming: false
+        cameraInMotion: false,
+        cameraSettleFrame: null
     };
 
     const GCJ_PI = Math.PI;
@@ -818,8 +818,7 @@
         state.renderFrame = null;
         if (
             !state.map
-            || state.mapMoving
-            || state.mapZooming
+            || state.cameraInMotion
             || !ui.gridCanvas
             || !resizeGridCanvas()
         ) return;
@@ -851,7 +850,7 @@
     }
 
     function scheduleMapRender() {
-        if (!state.map || state.mapMoving || state.mapZooming || state.renderFrame) return;
+        if (!state.map || state.cameraInMotion || state.renderFrame) return;
         state.renderFrame = window.requestAnimationFrame(renderMapCanvas);
     }
 
@@ -878,8 +877,7 @@
 
     function cellAtPixel(point) {
         if (
-            state.mapMoving
-            || state.mapZooming
+            state.cameraInMotion
             || ui.gridCanvas.hidden
         ) return null;
         const key = hitBucketKey(
@@ -1013,8 +1011,12 @@
         if (error) console.error('高德热暴露地图初始化失败', error);
     }
 
-    function suspendMapCanvas(motionType) {
-        state[motionType] = true;
+    function beginCameraTransaction() {
+        if (state.cameraSettleFrame !== null) {
+            window.cancelAnimationFrame(state.cameraSettleFrame);
+            state.cameraSettleFrame = null;
+        }
+        state.cameraInMotion = true;
         state.hoverIndex = null;
         // 手势结束后的下一帧之前禁用旧像素索引，避免点击命中移动前的网格。
         state.drawCache = [];
@@ -1023,10 +1025,16 @@
         ui.gridCanvas.hidden = true;
     }
 
-    function resumeMapCanvas(motionType) {
-        state[motionType] = false;
-        if (state.mapMoving || state.mapZooming) return;
-        scheduleMapRender();
+    function settleCameraTransaction() {
+        if (state.cameraSettleFrame !== null) {
+            window.cancelAnimationFrame(state.cameraSettleFrame);
+        }
+        // 高德的缩放和移动事件可能交错或缺少配对 end；任一 end 都以相机稳定帧为准完成事务。
+        state.cameraSettleFrame = window.requestAnimationFrame(function () {
+            state.cameraSettleFrame = null;
+            state.cameraInMotion = false;
+            scheduleMapRender();
+        });
     }
 
     function initializeMap() {
@@ -1074,16 +1082,16 @@
         });
         // 手势期间只移动高德底图，结束后一次性重投影网格，避免低端手机逐帧计算全部顶点。
         state.map.on('movestart', function () {
-            suspendMapCanvas('mapMoving');
+            beginCameraTransaction();
         });
         state.map.on('moveend', function () {
-            resumeMapCanvas('mapMoving');
+            settleCameraTransaction();
         });
         state.map.on('zoomstart', function () {
-            suspendMapCanvas('mapZooming');
+            beginCameraTransaction();
         });
         state.map.on('zoomend', function () {
-            resumeMapCanvas('mapZooming');
+            settleCameraTransaction();
         });
         state.map.on('mousemove', function (event) {
             const longitude = Number(event.lnglat?.getLng?.());

--- a/templates/heat_vulnerability_preview.html
+++ b/templates/heat_vulnerability_preview.html
@@ -78,6 +78,8 @@
 {% endblock %}
 
 {% block content %}
+{% set full_gis_url = url_for('user.heat_exposure_gis') %}
+{% set has_full_gis_access = current_user.is_authenticated and current_user.role != 'guest' %}
 <div class="hv-shell">
     <section class="hv-hero yl-fade-up" aria-labelledby="heat-preview-title">
         <div class="hv-hero-copy">
@@ -91,6 +93,13 @@
             </p>
             <div class="hv-actions">
                 <a class="btn btn-primary" href="#heat-map">查看聚合地图</a>
+                {% if heat_summary.available and gis_data_url %}
+                {% if has_full_gis_access %}
+                <a class="btn btn-outline-primary" href="{{ full_gis_url }}">打开完整 GIS</a>
+                {% else %}
+                <a class="btn btn-outline-primary" href="{{ url_for('public.login', next=full_gis_url) }}">完整 GIS（需登录）</a>
+                {% endif %}
+                {% endif %}
                 <a class="btn btn-outline-secondary" href="{{ url_for('public.cooling_resources') }}">查看已核验避暑资源</a>
                 {% if heat_summary.available and gis_data_url %}
                 <a class="btn btn-link" href="{{ gis_data_url }}" download="duchang_heat_exposure_cells.geojson">下载公开 GeoJSON</a>
@@ -294,7 +303,13 @@
         </p>
         <div class="hv-actions">
             <a class="btn btn-outline-secondary" href="{{ url_for('public.transparency') }}">查看指标透明度</a>
-            <a class="btn btn-primary" href="{{ url_for('public.login', next=url_for('user.heat_exposure_gis')) }}">登录使用完整 GIS</a>
+            {% if heat_summary.available and gis_data_url %}
+            {% if has_full_gis_access %}
+            <a class="btn btn-primary" href="{{ full_gis_url }}">打开完整 GIS</a>
+            {% else %}
+            <a class="btn btn-primary" href="{{ url_for('public.login', next=full_gis_url) }}">登录使用完整 GIS</a>
+            {% endif %}
+            {% endif %}
         </div>
     </section>
 </div>

--- a/tests/heat_exposure_gis_amap.test.js
+++ b/tests/heat_exposure_gis_amap.test.js
@@ -67,6 +67,72 @@ function loadPercentileText() {
   return Function(source)();
 }
 
+function loadCameraTransactionHarness() {
+  const frames = new Map();
+  let nextFrameId = 1;
+  const state = {
+    map: {},
+    renderFrame: null,
+    cameraInMotion: false,
+    cameraSettleFrame: null,
+    hoverIndex: 8,
+    drawCache: [{polygons: []}],
+    hitBuckets: new Map([['0:0', [0]]]),
+    renderCalls: 0,
+  };
+  const ui = {gridCanvas: {hidden: false}};
+  const window = {
+    requestAnimationFrame(callback) {
+      const frameId = nextFrameId;
+      nextFrameId += 1;
+      frames.set(frameId, callback);
+      return frameId;
+    },
+    cancelAnimationFrame(frameId) {
+      frames.delete(frameId);
+    },
+  };
+  let tooltipHides = 0;
+  const hideMapTooltip = () => {
+    tooltipHides += 1;
+  };
+  const factory = Function(
+    'state',
+    'ui',
+    'window',
+    'hideMapTooltip',
+    [
+      'function renderMapCanvas() {',
+      '  state.renderFrame = null;',
+      '  state.renderCalls += 1;',
+      '  ui.gridCanvas.hidden = false;',
+      '}',
+      functionSource('scheduleMapRender'),
+      functionSource('beginCameraTransaction'),
+      functionSource('settleCameraTransaction'),
+      'return {beginCameraTransaction, settleCameraTransaction};',
+    ].join('\n'),
+  );
+  const camera = factory(state, ui, window, hideMapTooltip);
+
+  function flushNextFrame() {
+    const next = frames.entries().next();
+    assert.equal(next.done, false, '预期存在待执行的动画帧');
+    const [frameId, callback] = next.value;
+    frames.delete(frameId);
+    callback();
+  }
+
+  return {
+    ...camera,
+    state,
+    ui,
+    frames,
+    flushNextFrame,
+    tooltipHides: () => tooltipHides,
+  };
+}
+
 test('高德显示转换只生成 GCJ-02 副本，不修改科研 WGS84 几何', () => {
   const { wgs84ToGcj02, displayShape } = loadDisplayTransform();
   const feature = {
@@ -132,13 +198,81 @@ test('地图手势结束后才重绘，命中索引不会逐次扫描全部网�
   assert.match(script, /map\.on\('moveend'/);
   assert.match(script, /map\.on\('zoomstart'/);
   assert.match(script, /map\.on\('zoomend'/);
-  assert.match(functionSource('suspendMapCanvas'), /state\.drawCache = \[\]/);
-  assert.match(functionSource('suspendMapCanvas'), /state\.hitBuckets = new Map\(\)/);
+  assert.match(functionSource('beginCameraTransaction'), /state\.drawCache = \[\]/);
+  assert.match(functionSource('beginCameraTransaction'), /state\.hitBuckets = new Map\(\)/);
   assert.match(functionSource('cellAtPixel'), /ui\.gridCanvas\.hidden/);
   assert.doesNotMatch(functionSource('updateMapHover'), /scheduleMapRender/);
   assert.doesNotMatch(functionSource('renderMapCanvas'), /hoverIndex/);
   assert.doesNotMatch(script, /map\.on\('mapmove'/);
   assert.doesNotMatch(script, /map\.on\('zoomchange'/);
+});
+
+test('zoomstart 后交错 movestart，即使缺少 moveend 也会恢复 Canvas', () => {
+  const harness = loadCameraTransactionHarness();
+
+  harness.beginCameraTransaction();
+  harness.beginCameraTransaction();
+  harness.settleCameraTransaction();
+
+  assert.equal(harness.state.cameraInMotion, true);
+  assert.equal(harness.ui.gridCanvas.hidden, true);
+  assert.deepEqual(harness.state.drawCache, []);
+  assert.equal(harness.state.hitBuckets.size, 0);
+  assert.equal(harness.tooltipHides(), 2);
+  harness.flushNextFrame();
+  assert.equal(harness.state.cameraInMotion, false);
+  assert.notEqual(harness.state.renderFrame, null, '结束事务后应安排重绘');
+  harness.flushNextFrame();
+  assert.equal(harness.ui.gridCanvas.hidden, false);
+  assert.equal(harness.state.renderCalls, 1);
+});
+
+test('movestart 后交错 zoomstart，即使缺少 zoomend 也会恢复 Canvas', () => {
+  const harness = loadCameraTransactionHarness();
+
+  harness.beginCameraTransaction();
+  harness.beginCameraTransaction();
+  harness.settleCameraTransaction();
+  harness.flushNextFrame();
+
+  assert.equal(harness.state.cameraInMotion, false);
+  assert.notEqual(harness.state.renderFrame, null, '结束事务后应安排重绘');
+  harness.flushNextFrame();
+  assert.equal(harness.ui.gridCanvas.hidden, false);
+  assert.equal(harness.state.renderCalls, 1);
+});
+
+test('新的 start 会取消待结算帧，长拖拽期间不会提前重绘', () => {
+  const harness = loadCameraTransactionHarness();
+
+  harness.beginCameraTransaction();
+  harness.settleCameraTransaction();
+  assert.equal(harness.frames.size, 1);
+  harness.beginCameraTransaction();
+
+  assert.equal(harness.frames.size, 0);
+  assert.equal(harness.state.cameraInMotion, true);
+  assert.equal(harness.ui.gridCanvas.hidden, true);
+  assert.equal(harness.state.renderCalls, 0);
+  assert.doesNotMatch(functionSource('settleCameraTransaction'), /setTimeout/);
+});
+
+test('后续 end 会重新校准稳定帧并再次重绘', () => {
+  const harness = loadCameraTransactionHarness();
+
+  harness.beginCameraTransaction();
+  harness.settleCameraTransaction();
+  harness.settleCameraTransaction();
+  assert.equal(harness.frames.size, 1);
+  harness.flushNextFrame();
+  harness.flushNextFrame();
+  assert.equal(harness.state.renderCalls, 1);
+
+  harness.settleCameraTransaction();
+  harness.flushNextFrame();
+  harness.flushNextFrame();
+  assert.equal(harness.ui.gridCanvas.hidden, false);
+  assert.equal(harness.state.renderCalls, 2);
 });
 
 test('温差图层的对称中性色带包含正负边界值', () => {

--- a/tests/test_public_heat_vulnerability_preview.py
+++ b/tests/test_public_heat_vulnerability_preview.py
@@ -81,6 +81,27 @@ def test_public_heat_preview_is_indexable_aggregate_dataset(client):
     assert "不含姓名、手机号、家庭关系、微信身份或用户精确位置" in body
 
 
+def test_public_heat_preview_hero_exposes_safe_full_gis_cta(client):
+    body = client.get("/duchang-heat-vulnerability-map").get_data(as_text=True)
+    hero = body.split('<section class="hv-hero', 1)[1].split("</section>", 1)[0]
+
+    assert "完整 GIS（需登录）" in hero
+    assert 'href="/login?next=/heat-exposure-gis"' in hero
+    assert 'href="/heat-exposure-gis"' not in hero
+
+
+def test_authenticated_heat_preview_hero_links_directly_to_full_gis(
+    authenticated_client,
+):
+    body = authenticated_client.get(
+        "/duchang-heat-vulnerability-map"
+    ).get_data(as_text=True)
+    hero = body.split('<section class="hv-hero', 1)[1].split("</section>", 1)[0]
+
+    assert 'href="/heat-exposure-gis"' in hero
+    assert "完整 GIS（需登录）" not in hero
+
+
 def test_public_heat_preview_has_machine_readable_dataset_contract(client):
     body = client.get(
         "/duchang-heat-vulnerability-map"
@@ -130,6 +151,7 @@ def test_public_heat_preview_feature_flag_removes_dead_data_links(app, client):
     assert response.status_code == 200
     assert "/data/duchang-heat-exposure.geojson" not in body
     assert "/static/js/heat-vulnerability-preview.js" not in body
+    assert "完整 GIS" not in body
     assert "distribution" not in dataset
     assert client.get("/data/duchang-heat-exposure.geojson").status_code == 404
 


### PR DESCRIPTION
## 这次改了什么

将高德地图缩放和移动的两枚独立状态合并为统一相机事务，补齐公开地图首屏完整 GIS 入口，并增加事件交错回归测试。

## 为什么要改

高德可能交错触发 `zoomstart`、`movestart` 及单个 end 事件，旧实现会让其中一枚状态永久停留，导致 Canvas 网格持续隐藏。公开页的完整 GIS 入口也埋在页面底部。

## 怎么测试

- `node --test tests/heat_exposure_gis_amap.test.js`，9 项通过
- `/opt/anaconda3/envs/case-weather-py312/bin/python -m pytest -q tests/test_heat_exposure_gis.py tests/test_public_heat_vulnerability_preview.py`，37 项通过
- 本地浏览器验证桌面及 390px 首屏 CTA 可见、无横向溢出、Console 无错误
- 点击匿名 CTA 后进入 `/login?next=/heat-exposure-gis`

## 文件迁移

无文件迁移。全部修改保留在主仓库。

## Shell 与 hooks

未修改 `.sh` 或 `.githooks`，`bash -n` 不适用。

## Notion

当前无法访问 Notion，待回填本次 GIS 缩放缺陷、验证证据与发布状态。