### PR TITLE
fix: 修正注册首登与中文错误边界

### DIFF
--- a/blueprints/public.py
+++ b/blueprints/public.py
@@ -38,7 +38,7 @@ from core.extensions import limiter
 from core.extensions import db
 from core.audit import log_audit
 from core.guest import is_guest_user
-from core.security import rate_limit_key
+from core.security import client_rate_limit_key, rate_limit_key
 from core.time_utils import ensure_utc_aware, utcnow
 from core.usage import log_usage_event
 from core.db_models import AlertDelivery, WeatherAlert
@@ -457,7 +457,14 @@ def role_entry():
 
 
 @bp.route('/login', methods=['GET', 'POST'], endpoint='login')
-@limiter.limit(lambda: current_app.config.get('RATE_LIMIT_LOGIN', '5 per 5 minutes'), methods=['POST'], key_func=rate_limit_key)
+@limiter.limit(
+    lambda: current_app.config.get('RATE_LIMIT_LOGIN', '5 per 5 minutes'),
+    methods=['POST'],
+    key_func=client_rate_limit_key,
+    deduct_when=lambda response: response.status_code not in {
+        301, 302, 303, 307, 308,
+    },
+)
 def login():
     """登录"""
     # URL 不经过 HTML 清理，避免把 & 重复转义为 &amp;。
@@ -470,7 +477,7 @@ def login():
 @limiter.limit(
     lambda: current_app.config.get('RATE_LIMIT_REGISTER', '5 per hour'),
     methods=['POST'],
-    key_func=rate_limit_key,
+    key_func=client_rate_limit_key,
 )
 def register():
     """注册"""

--- a/core/app.py
+++ b/core/app.py
@@ -18,6 +18,7 @@ from core.config import configure_app
 from core.constants import CHRONIC_OPTIONS, DEFAULT_CITY_LABEL, GUEST_ID_PREFIX, RISK_TAG_OPTIONS
 from core.extensions import db, init_extensions, login_manager
 from core.hooks import register_hooks
+from core.http_errors import register_http_error_handlers
 from core.logging_privacy import install_formal_logging_privacy
 from core.db_models import (
     AlertDelivery,
@@ -105,6 +106,7 @@ def create_app(register_blueprints=True):
     init_extensions(app)
     register_user_loader(login_manager)
     register_hooks(app)
+    register_http_error_handlers(app)
     if register_blueprints:
         _register_blueprints(app)
     register_cli(app)

--- a/core/http_errors.py
+++ b/core/http_errors.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""站内 HTML 与 API 的统一 HTTP 错误响应。"""
+import math
+import time
+
+from flask import current_app, g, jsonify, make_response, render_template, request
+from flask_limiter.errors import RateLimitExceeded
+
+from core.extensions import limiter
+
+
+_ERROR_COPY = {
+    403: ('没有访问权限', '此页面仅向具备相应身份的账号开放。'),
+    404: ('页面没有找到', '链接可能已经变化，也可能暂时不可用。'),
+    429: ('操作太频繁', '为保护账号安全，请等待倒计时结束后再试。'),
+    500: ('页面暂时不可用', '我们已经记录问题，请稍后再试。'),
+}
+
+_ERROR_CODES = {
+    403: 'forbidden',
+    404: 'not_found',
+    429: 'rate_limit_exceeded',
+    500: 'internal_server_error',
+}
+
+
+def _request_id():
+    return str(getattr(g, 'request_id', '') or '')
+
+
+def _wants_json_error():
+    path = request.path or ''
+    if path.startswith(('/api/', '/mp/api/')) or request.is_json:
+        return True
+    best = request.accept_mimetypes.best_match(
+        ('text/html', 'application/json')
+    )
+    return bool(
+        best == 'application/json'
+        and request.accept_mimetypes['application/json']
+        > request.accept_mimetypes['text/html']
+    )
+
+
+def _retry_after_seconds():
+    try:
+        current_limit = limiter.current_limit
+        reset_at = getattr(current_limit, 'reset_at', None)
+        if reset_at is not None:
+            return max(1, math.ceil(float(reset_at) - time.time()))
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        pass
+    try:
+        return max(
+            1,
+            int(current_app.config.get('LOGIN_LOCKOUT_SECONDS', 300)),
+        )
+    except (TypeError, ValueError):
+        return 300
+
+
+def _build_error_response(status_code, *, retry_after=None):
+    title, message = _ERROR_COPY[status_code]
+    request_id = _request_id()
+    if _wants_json_error():
+        payload = {
+            'success': False,
+            'error': _ERROR_CODES[status_code],
+            'message': message,
+            'request_id': request_id,
+        }
+        if retry_after is not None:
+            payload['retry_after_seconds'] = retry_after
+        response = make_response(jsonify(payload), status_code)
+    else:
+        response = make_response(
+            render_template(
+                'http_error.html',
+                status_code=status_code,
+                error_title=title,
+                error_message=message,
+                request_id=request_id,
+                retry_after_seconds=retry_after,
+            ),
+            status_code,
+        )
+
+    response.headers['Cache-Control'] = 'no-store, private, max-age=0'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['X-Request-ID'] = request_id
+    if retry_after is not None:
+        response.headers['Retry-After'] = str(retry_after)
+    return response
+
+
+def register_http_error_handlers(app):
+    """注册中文页面和保持结构化的 API 错误响应。"""
+
+    @app.errorhandler(RateLimitExceeded)
+    def handle_rate_limit(_error):
+        return _build_error_response(
+            429,
+            retry_after=_retry_after_seconds(),
+        )
+
+    @app.errorhandler(403)
+    def handle_forbidden(_error):
+        return _build_error_response(403)
+
+    @app.errorhandler(404)
+    def handle_not_found(_error):
+        return _build_error_response(404)
+
+    @app.errorhandler(500)
+    def handle_internal_error(error):
+        app.logger.error(
+            '请求处理失败 request_id=%s',
+            _request_id(),
+            exc_info=(type(error), error, error.__traceback__),
+        )
+        return _build_error_response(500)

--- a/core/security.py
+++ b/core/security.py
@@ -9,14 +9,16 @@ from flask import abort, current_app, has_app_context, jsonify, request, session
 
 logger = logging.getLogger(__name__)
 from flask_login import current_user
-from flask_limiter.util import get_remote_address
 
 
 def rate_limit_key():
-    """按用户或IP进行限流"""
-    if current_user.is_authenticated:
-        return str(getattr(current_user, 'id', 'anonymous'))
-    return get_remote_address()
+    """正式账号按账号限流，匿名与游客按临时客户端摘要限流。"""
+    if (
+        current_user.is_authenticated
+        and not bool(getattr(current_user, 'is_guest', False))
+    ):
+        return f'user:{getattr(current_user, "id", "anonymous")}'
+    return client_rate_limit_key()
 
 
 def generate_csrf_token():
@@ -51,6 +53,21 @@ def csrf_failure_response():
 
 
 _AUTO_PEPPER: str | None = None  # 进程级自动生成的 pepper 回退
+_RATE_LIMIT_CLIENT_SECRET = secrets.token_bytes(32)
+
+
+def client_rate_limit_key():
+    """按受信代理边界解析客户端，并生成只在本进程有效的限流摘要。"""
+    # 延迟导入避免 core.audit 在模块加载时与本模块形成循环依赖。
+    from core.audit import _get_client_ip
+
+    client_ip = _get_client_ip() or request.remote_addr or 'unknown'
+    digest = hashlib.blake2s(
+        str(client_ip).encode('utf-8'),
+        key=_RATE_LIMIT_CLIENT_SECRET,
+        digest_size=20,
+    ).hexdigest()
+    return f'client:{digest}'
 
 
 def _pair_token_pepper():

--- a/services/public_service.py
+++ b/services/public_service.py
@@ -1279,6 +1279,10 @@ def handle_account_link_code():
 
 def handle_login(next_url):
     safe_next = _safe_next_url(next_url)
+    login_form = {
+        'username': '',
+        'remember': False,
+    }
     if request.method == 'POST':
         # 输入验证
         username = request.form.get('username', '').strip()
@@ -1289,16 +1293,28 @@ def handle_login(next_url):
             normalized_phone = None
         password = request.form.get('password', '')
         remember_flag = request.form.get('remember') in ('1', 'on', 'true', 'yes')
+        login_form = {
+            'username': username,
+            'remember': remember_flag,
+        }
 
         # 基本验证
         if not username or not password:
-            flash('请输入用户名或已验证手机号和密码', 'error')
-            return render_template('login.html', next=safe_next)
+            flash('请输入用户名和密码', 'error')
+            return render_template(
+                'login.html',
+                next=safe_next,
+                login_form=login_form,
+            )
 
         # 限制长度防止攻击
         if len(username) > 50 or len(password) > 100:
             flash('输入内容过长', 'error')
-            return render_template('login.html', next=safe_next)
+            return render_template(
+                'login.html',
+                next=safe_next,
+                login_form=login_form,
+            )
 
         if normalized_phone:
             user = User.query.filter(
@@ -1342,7 +1358,11 @@ def handle_login(next_url):
                         remaining,
                     )
                     flash(f'登录失败次数过多，请 {remaining // 60 + 1} 分钟后再试', 'error')
-                    return render_template('login.html', next=safe_next)
+                    return render_template(
+                        'login.html',
+                        next=safe_next,
+                        login_form=login_form,
+                    )
             except Exception:
                 logger.warning("Redis 锁定检查失败，回退数据库兜底", exc_info=True)
                 redis_client = None
@@ -1362,7 +1382,11 @@ def handle_login(next_url):
                         db_remaining,
                     )
                     flash(f'登录失败次数过多，请 {db_remaining // 60 + 1} 分钟后再试', 'error')
-                    return render_template('login.html', next=safe_next)
+                    return render_template(
+                        'login.html',
+                        next=safe_next,
+                        login_form=login_form,
+                    )
             except Exception:
                 logger.warning("数据库锁定检查失败", exc_info=True)
 
@@ -1434,98 +1458,114 @@ def handle_login(next_url):
                 logger.warning("数据库递增失败计数失败", exc_info=True)
 
         logger.warning("登录失败: identifier_len=%s", len(username))
-        flash('用户名、已验证手机号或密码错误', 'error')
+        # 页面只承诺用户名登录；后端继续兼容已经完成验证的历史手机号。
+        flash('用户名或密码错误', 'error')
 
-    return render_template('login.html', next=safe_next)
+    return render_template(
+        'login.html',
+        next=safe_next,
+        login_form=login_form,
+    )
 
 
 def handle_register():
+    communities = Community.query.all()
+    form_data = {
+        'username': '',
+        'email': '',
+        'age': '',
+        'gender': '',
+        'community': '',
+    }
+    form_errors = {}
     if request.method == 'POST':
-        # 验证用户名
-        valid, result = validate_username(request.form.get('username'))
+        form_data = {
+            'username': str(request.form.get('username') or '').strip()[:25],
+            'email': str(request.form.get('email') or '').strip()[:120],
+            'age': str(request.form.get('age') or '').strip()[:3],
+            'gender': str(request.form.get('gender') or '').strip()[:10],
+            'community': str(request.form.get('community') or '').strip()[:100],
+        }
+
+        valid, username_result = validate_username(request.form.get('username'))
+        username = username_result if valid else None
         if not valid:
-            flash(result, 'error')
-            return redirect(url_for('public.register'))
-        username = result
-        if is_reserved_internal_username(username):
-            flash('该用户名属于系统保留命名空间，请换一个用户名。', 'error')
-            return redirect(url_for('public.register'))
-        try:
-            username_as_phone = normalize_phone(username)
-        except ValueError:
-            username_as_phone = None
-        if username_as_phone:
-            flash('用户名不能使用手机号格式，请换一个用户名。', 'error')
-            return redirect(url_for('public.register'))
+            form_errors['username'] = username_result
+        elif is_reserved_internal_username(username):
+            form_errors['username'] = '该用户名属于系统保留命名空间，请换一个用户名。'
+        else:
+            try:
+                username_as_phone = normalize_phone(username)
+            except ValueError:
+                username_as_phone = None
+            if username_as_phone:
+                form_errors['username'] = '用户名不能使用手机号格式，请换一个用户名。'
 
-        # 验证密码
-        valid, result = validate_password(request.form.get('password'))
+        raw_password = request.form.get('password', '')
+        valid, password_result = validate_password(raw_password)
+        password = password_result if valid else None
         if not valid:
-            flash(result, 'error')
-            return redirect(url_for('public.register'))
-        password = result
+            form_errors['password'] = password_result
 
-        # 验证邮箱
-        valid, result = validate_email(request.form.get('email'))
+        confirm_password = request.form.get('confirm_password', '')
+        if not confirm_password:
+            form_errors['confirm_password'] = '请再次输入密码'
+        elif confirm_password != raw_password:
+            form_errors['confirm_password'] = '两次输入的密码不一致'
+
+        valid, email_result = validate_email(request.form.get('email'))
+        email = email_result if valid else None
         if not valid:
-            flash(result, 'error')
-            return redirect(url_for('public.register'))
-        email = result
+            form_errors['email'] = email_result
 
-        # 手机号只保存为待验证标识；接入短信校验前不能用于登录。
-        try:
-            phone_normalized = normalize_phone(request.form.get('phone'))
-        except ValueError as exc:
-            flash(str(exc), 'error')
-            return redirect(url_for('public.register'))
-
-        # 验证年龄
-        valid, result = validate_age(request.form.get('age'))
+        valid, age_result = validate_age(request.form.get('age'))
+        age = age_result if valid else None
         if not valid:
-            flash(result, 'error')
-            return redirect(url_for('public.register'))
-        age = result
+            form_errors['age'] = age_result
 
-        # 验证性别
-        valid, result = validate_gender(request.form.get('gender'))
+        valid, gender_result = validate_gender(request.form.get('gender'))
+        gender = gender_result if valid else None
         if not valid:
-            flash(result, 'error')
-            return redirect(url_for('public.register'))
-        gender = result
+            form_errors['gender'] = gender_result
 
-        # 社区信息
-        community = sanitize_input(request.form.get('community'), max_length=100)
+        community = sanitize_input(
+            request.form.get('community'),
+            max_length=100,
+        )
+
+        if form_errors:
+            return render_template(
+                'register.html',
+                communities=communities,
+                form_data=form_data,
+                form_errors=form_errors,
+            ), 422
 
         user = User(
             username=username,
             email=email,
-            phone_normalized=phone_normalized,
             age=age,
             gender=gender,
             community=community
         )
         user.set_password(password)
 
-        # 所有占用结果使用相同提示与跳转，减少匿名访客据此枚举手机号或邮箱。
-        processed_message = (
-            '注册申请已处理，请尝试登录。若无法登录，请更换用户名或联系管理员。'
-        )
         username_taken = User.query.filter(
             db.func.lower(User.username) == _normalize_login_identifier(username)
         ).first() is not None
         email_taken = bool(
             email and User.query.filter_by(email=email).first() is not None
         )
-        if any(
-            (
-                username_taken,
-                email_taken,
+        if username_taken or email_taken:
+            form_errors['account'] = (
+                '这些账号信息暂时无法使用，请更换用户名或邮箱后重试。'
             )
-        ):
-            flash(processed_message, 'success')
-            return redirect(
-                url_for('public.login', next=url_for('public.account_link'))
-            )
+            return render_template(
+                'register.html',
+                communities=communities,
+                form_data=form_data,
+                form_errors=form_errors,
+            ), 422
 
         try:
             db.session.add(user)
@@ -1533,19 +1573,35 @@ def handle_register():
         except IntegrityError:
             # 用户名与邮箱唯一索引负责处理并发注册竞争。
             db.session.rollback()
-            flash(processed_message, 'success')
-            return redirect(
-                url_for('public.login', next=url_for('public.account_link'))
+            form_errors['account'] = (
+                '这些账号信息暂时无法使用，请更换用户名或邮箱后重试。'
             )
+            return render_template(
+                'register.html',
+                communities=communities,
+                form_data=form_data,
+                form_errors=form_errors,
+            ), 422
 
         logger.info("新用户注册: user_id=%s", user.id)
-        flash(processed_message, 'success')
-        return redirect(
-            url_for('public.login', next=url_for('public.account_link'))
-        )
+        _clear_identity_scoped_session()
+        login_user(user, remember=False)
+        user.last_login = utcnow()
+        db.session.commit()
+        flash('注册成功，已登录。现在可以添加需要照护的家人。', 'success')
+        if (
+            current_app.config.get('WECHAT_FORMAL_RUNTIME')
+            and not current_app.config.get('WEB_PRIVATE_FEATURES_ENABLED')
+        ):
+            return redirect(url_for('public.account_link'))
+        return redirect(url_for('user.pair_management', welcome=1))
 
-    communities = Community.query.all()
-    return render_template('register.html', communities=communities)
+    return render_template(
+        'register.html',
+        communities=communities,
+        form_data=form_data,
+        form_errors=form_errors,
+    )
 
 
 def _verified_cooling_map_point(resource):

--- a/services/user/_common.py
+++ b/services/user/_common.py
@@ -290,5 +290,8 @@ def _normalize_code(value):
 def _require_roles(*roles):
     if getattr(current_user, 'role', None) in roles:
         return True
-    flash('权限不足', 'error')
+    if 'community' in roles:
+        flash('该页面仅限社区工作人员或管理员使用，请切换对应账号。', 'error')
+    else:
+        flash('当前账号没有此页面所需权限。', 'error')
     return False

--- a/services/user/profile_service.py
+++ b/services/user/profile_service.py
@@ -320,10 +320,17 @@ def profile():
         if form_id == 'password':
             old_password = request.form.get('old_password', '')
             new_password = request.form.get('new_password')
+            confirm_password = request.form.get('confirm_password', '')
             if not old_password:
                 flash('请输入当前密码', 'error')
                 return redirect(url_for('user.profile'))
             if new_password:
+                if not confirm_password:
+                    flash('请再次输入新密码', 'error')
+                    return redirect(url_for('user.profile'))
+                if new_password != confirm_password:
+                    flash('两次输入的新密码不一致', 'error')
+                    return redirect(url_for('user.profile'))
                 valid, result = validate_password(new_password)
                 if not valid:
                     flash(result, 'error')

--- a/templates/account_link.html
+++ b/templates/account_link.html
@@ -9,22 +9,22 @@
         <span class="section-kicker">网页版与微信小程序</span>
         <h1 class="mt-2 mb-2">把两端串成同一个账号</h1>
         <p class="text-muted mb-0">
-            手机号当前只保存为待验证标识，不发送短信验证码，也不能用于登录。
+            生成一次性绑定码只需要确认当前密码并同意绑定说明，不需要填写手机号。
         </p>
     </header>
 
     <div class="alert alert-light border" role="note">
         <strong>推荐顺序：</strong>
-        先保存手机号，再到微信小程序完成微信登录，最后输入这里生成的 8 位码。绑定完成后，两端会读取同一份家庭照护数据。
+        先在这里生成 8 位码，再到微信小程序登录并输入。绑定完成后，两端会读取同一份家庭照护数据。
     </div>
 
     <div class="row g-4">
-        <div class="col-lg-6">
+        <div class="col-lg-6 order-2">
             <section class="card shadow-sm h-100">
                 <div class="card-body p-4">
                     <div class="d-flex align-items-center gap-2 mb-3">
-                        <span class="badge text-bg-primary">1</span>
-                        <h2 class="h5 mb-0">保存待验证手机号</h2>
+                        <span class="badge text-bg-secondary">可选</span>
+                        <h2 class="h5 mb-0">保存联系手机号</h2>
                     </div>
                     <form method="POST" action="{{ url_for('public.account_link_phone') }}">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -41,7 +41,7 @@
                                 placeholder="例如 13800138000"
                                 required
                             >
-                            <div class="form-text">保存后仍需使用用户名登录。状态：待验证。</div>
+                            <div class="form-text">当前仅保存为待验证联系信息，不用于登录，也不影响小程序绑定。</div>
                         </div>
                         <div class="mb-3">
                             <label class="form-label" for="phoneCurrentPassword">当前密码</label>
@@ -53,11 +53,11 @@
             </section>
         </div>
 
-        <div class="col-lg-6">
+        <div class="col-lg-6 order-1">
             <section class="card shadow-sm h-100">
                 <div class="card-body p-4">
                     <div class="d-flex align-items-center gap-2 mb-3">
-                        <span class="badge text-bg-primary">2</span>
+                        <span class="badge text-bg-primary">1</span>
                         <h2 class="h5 mb-0">生成一次性绑定码</h2>
                     </div>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -240,7 +240,14 @@
             {% endif %}
 
             <div class="d-flex align-items-center gap-2 ms-auto">
-                {% if current_user.is_authenticated %}
+                {% if nav_is_guest %}
+                    <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('public.login') }}">登录正式账号</a>
+                    <a class="btn btn-sm btn-primary nav-auth-register" data-nav-auth="register" href="{{ url_for('public.register') }}">注册</a>
+                    <form method="POST" action="{{ url_for('public.logout') }}" class="d-none d-md-inline m-0">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button class="btn btn-sm btn-outline-secondary" type="submit">结束体验</button>
+                    </form>
+                {% elif current_user.is_authenticated %}
                     {% if current_user.role == 'admin' %}
                         <a class="btn btn-sm btn-outline-secondary d-none d-md-inline-flex" href="{{ url_for('admin.admin_dashboard') }}">
                             <i class="bi bi-speedometer2 me-1"></i>后台
@@ -278,7 +285,7 @@
 
             {% if current_user.is_authenticated %}
                 <div class="mb-3 p-3" style="background:var(--yl-orange-50); border-radius:12px;">
-                    <div class="small text-muted">当前账号</div>
+                    <div class="small text-muted">{% if nav_is_guest %}当前为游客体验{% else %}当前账号{% endif %}</div>
                     <div class="fw-semibold"><i class="bi bi-person-circle me-1"></i>{{ current_user.username }}</div>
                     <div class="small text-muted mt-1">
                         <i class="bi bi-geo-alt"></i> {{ current_location or '未设置定位' }}
@@ -400,11 +407,12 @@
                         </div>
                     {% endif %}
                 {% else %}
+                    <a class="nav-link" href="{{ url_for('public.login') }}"><i class="bi bi-box-arrow-in-right me-2"></i>登录正式账号</a>
                     <a class="nav-link" href="{{ url_for('public.register') }}"><i class="bi bi-person-plus me-2"></i>注册账号</a>
                 {% endif %}
                 <form method="POST" action="{{ url_for('public.logout') }}" class="mt-2">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <button class="btn btn-outline-secondary btn-sm w-100" type="submit"><i class="bi bi-box-arrow-right me-1"></i>退出登录</button>
+                    <button class="btn btn-outline-secondary btn-sm w-100" type="submit"><i class="bi bi-box-arrow-right me-1"></i>{% if nav_is_guest %}结束游客体验{% else %}退出登录{% endif %}</button>
                 </form>
             </nav>
             {% else %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -97,7 +97,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/yilao-data-fx.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/yilao-data-fx-extra.css') }}">
 
-    <noscript><style>.page-loader{display:none !important;}[data-motion] .yl-fade-up,[data-motion] .yl-section,[data-motion] .narrative-step,[data-motion] [data-animate-in]{opacity:1 !important;transform:none !important;}</style></noscript>
+    <noscript><style>[data-motion] .yl-fade-up,[data-motion] .yl-section,[data-motion] .narrative-step,[data-motion] [data-animate-in]{opacity:1 !important;transform:none !important;}</style></noscript>
     {% block extra_css %}{% endblock %}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/apple-polish.css') }}">
 </head>
@@ -134,11 +134,6 @@
     {% set nav_care_active = nav_care_primary_active or nav_family_active %}
 
     <a class="visually-hidden-focusable skip-link" href="#main-content">跳到主要内容</a>
-
-    <div class="page-loader" id="pageLoader">
-        <div class="loader-spinner"></div>
-        <div class="loader-text">加载中…</div>
-    </div>
 
     {# ===================== 顶部导航 ===================== #}
     <nav class="navbar sticky-top" aria-label="主导航">
@@ -469,14 +464,6 @@
     {% endif %}
 
     <script>
-        function hideLoader() {
-            const loader = document.getElementById('pageLoader');
-            if (loader) loader.classList.add('hidden');
-        }
-        document.addEventListener('DOMContentLoaded', function() { setTimeout(hideLoader, 100); });
-        window.addEventListener('load', function() { setTimeout(hideLoader, 100); });
-        setTimeout(hideLoader, 3000);
-
         document.addEventListener('DOMContentLoaded', function() {
             document.querySelectorAll('form').forEach(form => {
                 form.addEventListener('submit', function() {
@@ -490,7 +477,6 @@
                 });
             });
         });
-        window.addEventListener('error', function() { hideLoader(); });
     </script>
 
     <script>

--- a/templates/http_error.html
+++ b/templates/http_error.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+
+{% block title %}{{ error_title }} · 宜老天气通{% endblock %}
+{% block body_class %}http-error-page{% endblock %}
+
+{% block content %}
+<div class="container py-5" style="max-width: 720px;">
+    <section class="card border-0 shadow-sm text-center">
+        <div class="card-body p-4 p-md-5">
+            <div class="display-5 fw-bold text-primary mb-2">{{ status_code }}</div>
+            <h1 class="h3 mb-3">{{ error_title }}</h1>
+            <p class="text-muted mb-3">{{ error_message }}</p>
+
+            {% if retry_after_seconds is not none %}
+            <p class="mb-4" role="status" aria-live="polite">
+                可在 <strong id="retryCountdown" data-retry-seconds="{{ retry_after_seconds }}">{{ retry_after_seconds }}</strong> 秒后重试。
+            </p>
+            {% endif %}
+
+            <div class="d-flex flex-wrap justify-content-center gap-2">
+                <a class="btn btn-primary" href="{{ url_for('public.index') }}">返回首页</a>
+                <button class="btn btn-outline-secondary" type="button" onclick="history.back()">返回上一页</button>
+            </div>
+
+            {% if request_id %}
+            <div class="small text-muted mt-4">请求编号：{{ request_id }}</div>
+            {% endif %}
+        </div>
+    </section>
+</div>
+
+{% if retry_after_seconds is not none %}
+<script>
+(function () {
+    const counter = document.getElementById('retryCountdown');
+    if (!counter) return;
+    let remaining = Number.parseInt(counter.dataset.retrySeconds || '0', 10);
+    const timer = window.setInterval(function () {
+        remaining = Math.max(0, remaining - 1);
+        counter.textContent = String(remaining);
+        if (remaining === 0) window.clearInterval(timer);
+    }, 1000);
+})();
+</script>
+{% endif %}
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -71,23 +71,22 @@
 
                 <div class="card auth-form-card">
                     <div class="card-body p-4">
-                        <form method="POST" action="{{ url_for('public.login') }}">
+                        <form method="POST" action="{{ url_for('public.login') }}" novalidate>
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             {% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
 
                             <div class="mb-3">
-                                <label for="username" class="form-label">用户名或已验证手机号</label>
-                                <input type="text" class="form-control" id="username" name="username" placeholder="请输入用户名" autocomplete="username" required autofocus>
-                                <small class="text-muted">手机号尚未接入短信验证，保存后仍需使用用户名登录。</small>
+                                <label for="username" class="form-label">用户名</label>
+                                <input type="text" class="form-control" id="username" name="username" value="{{ login_form.get('username', '') }}" placeholder="请输入用户名" autocomplete="username" autofocus>
                             </div>
                             <div class="mb-3">
                                 <label for="password" class="form-label">密码</label>
-                                <input type="password" class="form-control" id="password" name="password" placeholder="请输入密码" required>
+                                <input type="password" class="form-control" id="password" name="password" placeholder="请输入密码" autocomplete="current-password">
                             </div>
 
                             <div class="mb-3 d-flex justify-content-between align-items-center">
                                 <div class="form-check">
-                                    <input type="checkbox" class="form-check-input" id="remember" name="remember" value="1">
+                                    <input type="checkbox" class="form-check-input" id="remember" name="remember" value="1" {% if login_form.get('remember') %}checked{% endif %}>
                                     <label class="form-check-label" for="remember" style="font-size:.9rem;">记住我(30 天)</label>
                                 </div>
                             </div>

--- a/templates/pair_management.html
+++ b/templates/pair_management.html
@@ -12,6 +12,17 @@
                 为家中老人设置所在地，高温或寒潮来临时及时收到提醒。慢病类别可选填，用于提供更贴合的日常建议。
                 所在地和关联档案仅用于天气查询与提醒，请勿填写精确门牌信息。
             </p>
+            {% if request.args.get('welcome') == '1' and not pair_cards %}
+            <div class="alert alert-success mt-3 mb-0" role="status">
+                <div class="fw-semibold">账号已准备好，按这 3 步开始照护</div>
+                <ol class="mb-0 mt-2 ps-3">
+                    <li>在下方添加需要关注的家人。</li>
+                    <li>核对家人所在县、市或乡镇，无需填写门牌地址。</li>
+                    <li>查看今日风险，再复制提醒发给家人。</li>
+                </ol>
+                <div class="small mt-2">绑定微信小程序是可选步骤，可稍后在个人设置中完成。</div>
+            </div>
+            {% endif %}
             {% if wxpusher_feature_enabled %}
             {% if not current_user.push_enabled or not current_user.wxpusher_uid %}
                 <div class="alert alert-warning mt-3 mb-0">
@@ -256,6 +267,11 @@
                         <div class="text-muted small mt-3">升级链仅记录状态，请结合实际情况与社区沟通。</div>
                     {% else %}
                         <div class="text-muted">暂无监测对象，请先在左侧添加老人并设置所在地。</div>
+                        <ol class="small text-muted mt-3 mb-0 ps-3">
+                            <li>添加家人</li>
+                            <li>核对所在地</li>
+                            <li>查看风险并发送提醒</li>
+                        </ol>
                     {% endif %}
                 </div>
             </div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -178,7 +178,7 @@
                         </div>
                         <div class="mb-3">
                             <label for="confirm_password" class="form-label">确认新密码</label>
-                            <input type="password" class="form-control" id="confirm_password">
+                            <input type="password" class="form-control" id="confirm_password" name="confirm_password" autocomplete="new-password">
                         </div>
                         <button type="submit" class="btn btn-warning">修改密码</button>
                     </form>
@@ -193,12 +193,13 @@
                 </div>
                 <div class="card-body">
                     <p class="text-muted small mb-2">
-                        使用独立的跨端账号页保存手机号，并在复验当前密码后生成 8 位一次性绑定码。
+                        在跨端账号页复验当前密码后生成 8 位一次性绑定码。绑定不需要手机号。
                     </p>
                     <a class="btn btn-primary w-100" href="{{ url_for('public.account_link') }}">
                         <i class="bi bi-link-45deg"></i> 打开跨端账号页
                     </a>
 
+                    {% if current_user.role == 'admin' %}
                     <details class="mt-3">
                         <summary class="small text-muted">旧版 API Token 兼容入口</summary>
                         {% if last_api_token_plain %}
@@ -218,6 +219,7 @@
                             <button type="submit" class="btn btn-outline-secondary btn-sm w-100">生成旧版 Token</button>
                         </form>
                     </details>
+                    {% endif %}
                 </div>
             </div>
 

--- a/templates/register.html
+++ b/templates/register.html
@@ -19,8 +19,19 @@
 
                 <div class="card auth-form-card">
                     <div class="card-body p-4 p-md-5">
-                        <form method="POST" action="{{ url_for('public.register') }}">
+                        <form method="POST" action="{{ url_for('public.register') }}" novalidate>
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+                            {% if form_errors.get('account') %}
+                            <div class="alert alert-danger" role="alert">
+                                {{ form_errors.get('account') }}
+                            </div>
+                            {% endif %}
+                            {% if form_errors %}
+                            <div class="alert alert-warning" role="status">
+                                请检查下方标出的内容。密码不会被保留，请重新输入。
+                            </div>
+                            {% endif %}
 
                             {# 基础 #}
                             <div class="mb-3" style="font-size:.8rem; color:var(--yl-muted); text-transform:uppercase; letter-spacing:.05em; font-weight:600;">
@@ -32,32 +43,30 @@
                                     <label for="username" class="form-label">
                                         <i class="bi bi-person me-1"></i>用户名 <span style="color:var(--yl-danger);">*</span>
                                     </label>
-                                    <input type="text" class="form-control" id="username" name="username" required>
+                                    <input type="text" class="form-control{% if form_errors.get('username') %} is-invalid{% endif %}" id="username" name="username" value="{{ form_data.get('username', '') }}" autocomplete="username" aria-describedby="usernameError" {% if form_errors.get('username') %}aria-invalid="true"{% endif %}>
+                                    <div class="invalid-feedback" id="usernameError">{{ form_errors.get('username', '') }}</div>
                                 </div>
                                 <div class="col-md-6">
                                     <label for="email" class="form-label">
                                         <i class="bi bi-envelope me-1"></i>邮箱
                                     </label>
-                                    <input type="email" class="form-control" id="email" name="email" placeholder="可选">
-                                </div>
-                                <div class="col-md-6">
-                                    <label for="phone" class="form-label">
-                                        <i class="bi bi-phone me-1"></i>手机号
-                                    </label>
-                                    <input type="tel" class="form-control" id="phone" name="phone" inputmode="tel" autocomplete="tel" placeholder="可选，例如 13800138000">
-                                    <small class="text-muted">当前不发送短信验证码，仅保存为待验证标识，不能用于登录。</small>
+                                    <input type="email" class="form-control{% if form_errors.get('email') %} is-invalid{% endif %}" id="email" name="email" value="{{ form_data.get('email', '') }}" placeholder="可选" autocomplete="email" aria-describedby="emailError" {% if form_errors.get('email') %}aria-invalid="true"{% endif %}>
+                                    <div class="invalid-feedback" id="emailError">{{ form_errors.get('email', '') }}</div>
                                 </div>
                                 <div class="col-md-6">
                                     <label for="password" class="form-label">
                                         <i class="bi bi-lock me-1"></i>密码 <span style="color:var(--yl-danger);">*</span>
                                     </label>
-                                    <input type="password" class="form-control" id="password" name="password" required>
+                                    <input type="password" class="form-control{% if form_errors.get('password') %} is-invalid{% endif %}" id="password" name="password" autocomplete="new-password" aria-describedby="passwordHelp passwordError" {% if form_errors.get('password') %}aria-invalid="true"{% endif %}>
+                                    <div class="form-text" id="passwordHelp">至少 12 位；提交失败后需要重新输入。</div>
+                                    <div class="invalid-feedback" id="passwordError">{{ form_errors.get('password', '') }}</div>
                                 </div>
                                 <div class="col-md-6">
                                     <label for="confirm_password" class="form-label">
                                         <i class="bi bi-lock-fill me-1"></i>确认密码 <span style="color:var(--yl-danger);">*</span>
                                     </label>
-                                    <input type="password" class="form-control" id="confirm_password" name="confirm_password" required>
+                                    <input type="password" class="form-control{% if form_errors.get('confirm_password') %} is-invalid{% endif %}" id="confirm_password" name="confirm_password" autocomplete="new-password" aria-describedby="confirmPasswordError" {% if form_errors.get('confirm_password') %}aria-invalid="true"{% endif %}>
+                                    <div class="invalid-feedback" id="confirmPasswordError">{{ form_errors.get('confirm_password', '') }}</div>
                                 </div>
                             </div>
 
@@ -69,22 +78,24 @@
                             <div class="row g-3">
                                 <div class="col-md-4">
                                     <label for="age" class="form-label"><i class="bi bi-calendar me-1"></i>年龄</label>
-                                    <input type="number" class="form-control" id="age" name="age" min="1" max="120" placeholder="可选">
+                                    <input type="number" class="form-control{% if form_errors.get('age') %} is-invalid{% endif %}" id="age" name="age" value="{{ form_data.get('age', '') }}" min="1" max="150" placeholder="可选" aria-describedby="ageError" {% if form_errors.get('age') %}aria-invalid="true"{% endif %}>
+                                    <div class="invalid-feedback" id="ageError">{{ form_errors.get('age', '') }}</div>
                                 </div>
                                 <div class="col-md-4">
                                     <label for="gender" class="form-label"><i class="bi bi-gender-ambiguous me-1"></i>性别</label>
-                                    <select class="form-select" id="gender" name="gender">
+                                    <select class="form-select{% if form_errors.get('gender') %} is-invalid{% endif %}" id="gender" name="gender" aria-describedby="genderError" {% if form_errors.get('gender') %}aria-invalid="true"{% endif %}>
                                         <option value="">请选择</option>
-                                        <option value="男性">男性</option>
-                                        <option value="女性">女性</option>
+                                        <option value="男性" {% if form_data.get('gender') == '男性' %}selected{% endif %}>男性</option>
+                                        <option value="女性" {% if form_data.get('gender') == '女性' %}selected{% endif %}>女性</option>
                                     </select>
+                                    <div class="invalid-feedback" id="genderError">{{ form_errors.get('gender', '') }}</div>
                                 </div>
                                 <div class="col-md-4">
                                     <label for="community" class="form-label"><i class="bi bi-geo-alt me-1"></i>所属社区</label>
                                     <select class="form-select" id="community" name="community">
                                         <option value="">请选择</option>
                                         {% for comm in communities %}
-                                            <option value="{{ comm.name }}">{{ comm.name }}</option>
+                                            <option value="{{ comm.name }}" {% if form_data.get('community') == comm.name %}selected{% endif %}>{{ comm.name }}</option>
                                         {% endfor %}
                                     </select>
                                 </div>

--- a/tests/test_auth_onboarding.py
+++ b/tests/test_auth_onboarding.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+"""账号首登、表单重试和导航三态回归。"""
+
+
+def _set_csrf(client, token):
+    with client.session_transaction() as flask_session:
+        flask_session['_csrf_token'] = token
+
+
+def _create_user(db_session, username='auth-onboarding-user', role='user'):
+    from core.db_models import User
+
+    user = User(username=username, role=role, community='朝阳社区')
+    user.set_password('ExistingPassword1!')
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+def _login(client, username, csrf='auth-onboarding-login-csrf'):
+    _set_csrf(client, csrf)
+    return client.post(
+        '/login',
+        data={
+            'username': username,
+            'password': 'ExistingPassword1!',
+            'csrf_token': csrf,
+        },
+        follow_redirects=False,
+    )
+
+
+def test_register_aggregates_errors_and_preserves_only_safe_fields(
+    client,
+    db_session,
+):
+    _set_csrf(client, 'register-errors-csrf')
+    response = client.post(
+        '/register',
+        data={
+            'username': 'x',
+            'email': 'remember-me-invalid-email',
+            'password': 'short',
+            'confirm_password': 'secret-different',
+            'age': '999',
+            'gender': '任意值',
+            'community': '朝阳社区',
+            'csrf_token': 'register-errors-csrf',
+        },
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 422
+    assert '用户名长度需在3-25字符之间' in body
+    assert '密码长度至少12位' in body
+    assert '两次输入的密码不一致' in body
+    assert '邮箱格式不正确' in body
+    assert '年龄需在1-150之间' in body
+    assert '性别选择不正确' in body
+    assert 'value="x"' in body
+    assert 'remember-me-invalid-email' in body
+    assert 'value="short"' not in body
+    assert 'secret-different' not in body
+
+
+def test_register_clears_guest_identity_and_starts_non_persistent_session(
+    app,
+    client,
+    db_session,
+):
+    app.config['WECHAT_FORMAL_RUNTIME'] = False
+    app.config['WEB_PRIVATE_FEATURES_ENABLED'] = True
+    client.get('/guest', follow_redirects=False)
+    _set_csrf(client, 'register-success-csrf')
+
+    response = client.post(
+        '/register',
+        data={
+            'username': 'new_care_account',
+            'email': 'new-care@example.com',
+            'password': 'NewCarePassword1!',
+            'confirm_password': 'NewCarePassword1!',
+            'csrf_token': 'register-success-csrf',
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code in (302, 303)
+    assert response.headers['Location'].endswith('/pairs?welcome=1')
+    assert 'remember_token=' not in '\n'.join(
+        response.headers.getlist('Set-Cookie')
+    )
+    with client.session_transaction() as flask_session:
+        assert flask_session.get('_user_id')
+        assert 'guest_id' not in flask_session
+        assert 'guest_profile' not in flask_session
+
+    welcome = client.get('/pairs?welcome=1')
+    body = welcome.get_data(as_text=True)
+    assert welcome.status_code == 200
+    assert '账号已准备好，按这 3 步开始照护' in body
+    assert '添加需要关注的家人' in body
+
+
+def test_register_miniprogram_only_runtime_keeps_account_link_landing(
+    app,
+    client,
+    db_session,
+):
+    app.config['WECHAT_FORMAL_RUNTIME'] = True
+    app.config['WEB_PRIVATE_FEATURES_ENABLED'] = False
+    _set_csrf(client, 'register-mini-only-csrf')
+
+    response = client.post(
+        '/register',
+        data={
+            'username': 'mini_only_new_user',
+            'password': 'MiniOnlyPassword1!',
+            'confirm_password': 'MiniOnlyPassword1!',
+            'csrf_token': 'register-mini-only-csrf',
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code in (302, 303)
+    assert response.headers['Location'].endswith('/account-link')
+
+
+def test_login_retry_preserves_identifier_and_remember_without_password(
+    client,
+    db_session,
+):
+    _set_csrf(client, 'login-retry-csrf')
+    response = client.post(
+        '/login',
+        data={
+            'username': 'retry-name',
+            'password': 'NeverRenderThisPassword1!',
+            'remember': '1',
+            'csrf_token': 'login-retry-csrf',
+        },
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert 'value="retry-name"' in body
+    assert 'id="remember" name="remember" value="1" checked' in body
+    assert 'NeverRenderThisPassword1!' not in body
+    assert '用户名或密码错误' in body
+
+
+def test_register_and_login_copy_only_promises_username_login(client, db_session):
+    register_page = client.get('/register').get_data(as_text=True)
+    login_page = client.get('/login').get_data(as_text=True)
+
+    assert 'name="phone"' not in register_page
+    assert '>用户名<' in login_page
+    assert '用户名或已验证手机号' not in login_page
+
+
+def test_navigation_distinguishes_anonymous_guest_and_real_user(
+    client,
+    db_session,
+):
+    anonymous = client.get('/login').get_data(as_text=True)
+    assert '登录正式账号' not in anonymous
+    assert '结束游客体验' not in anonymous
+    assert '>退出<' not in anonymous
+
+    client.get('/guest', follow_redirects=False)
+    guest = client.get('/login').get_data(as_text=True)
+    assert '登录正式账号' in guest
+    assert '注册账号' in guest
+    assert '结束游客体验' in guest
+
+    logout_csrf = 'guest-finish-csrf'
+    _set_csrf(client, logout_csrf)
+    client.post(
+        '/logout',
+        data={'csrf_token': logout_csrf},
+        follow_redirects=False,
+    )
+    _create_user(db_session, username='real-nav-user')
+    _login(client, 'real-nav-user')
+    real = client.get('/login').get_data(as_text=True)
+    assert '>退出<' in real
+    assert '结束游客体验' not in real
+
+
+def test_account_link_says_phone_is_optional(client, db_session):
+    _create_user(db_session, username='link-copy-user')
+    _login(client, 'link-copy-user')
+
+    body = client.get('/account-link').get_data(as_text=True)
+    assert '不需要填写手机号' in body
+    assert '不影响小程序绑定' in body
+
+
+def test_ordinary_profile_hides_legacy_token_and_password_needs_confirmation(
+    client,
+    db_session,
+):
+    user = _create_user(db_session, username='profile-confirm-user')
+    _login(client, 'profile-confirm-user')
+    profile_page = client.get('/profile').get_data(as_text=True)
+    assert '旧版 API Token 兼容入口' not in profile_page
+
+    _set_csrf(client, 'password-confirm-csrf')
+    response = client.post(
+        '/profile',
+        data={
+            'form_id': 'password',
+            'old_password': 'ExistingPassword1!',
+            'new_password': 'ChangedPassword1!',
+            'confirm_password': 'DifferentPassword1!',
+            'csrf_token': 'password-confirm-csrf',
+        },
+        follow_redirects=True,
+    )
+    assert '两次输入的新密码不一致' in response.get_data(as_text=True)
+    db_session.refresh(user)
+    assert user.check_password('ExistingPassword1!')
+    assert not user.check_password('ChangedPassword1!')

--- a/tests/test_bugfix_batch1.py
+++ b/tests/test_bugfix_batch1.py
@@ -62,6 +62,7 @@ class TestPasswordChangeRequiresOldPassword:
                 'form_id': 'password',
                 'old_password': 'WrongOldPass!',
                 'new_password': 'NewPass456!x',
+                'confirm_password': 'NewPass456!x',
                 'csrf_token': csrf,
             }, follow_redirects=True)
 
@@ -81,6 +82,7 @@ class TestPasswordChangeRequiresOldPassword:
                 'form_id': 'password',
                 'old_password': 'OldPass123!',
                 'new_password': 'NewPass456!x',
+                'confirm_password': 'NewPass456!x',
                 'csrf_token': csrf,
             }, follow_redirects=True)
 
@@ -101,6 +103,7 @@ class TestPasswordChangeRequiresOldPassword:
                 'form_id': 'password',
                 'old_password': '',
                 'new_password': 'NewPass456!',
+                'confirm_password': 'NewPass456!',
                 'csrf_token': csrf,
             }, follow_redirects=True)
 
@@ -133,6 +136,7 @@ class TestPasswordChangeRequiresOldPassword:
                 'form_id': 'password',
                 'old_password': 'OldPass123!',
                 'new_password': 'ShortPass1!',
+                'confirm_password': 'ShortPass1!',
                 'csrf_token': csrf,
             }, follow_redirects=False)
             assert short_response.status_code in (301, 302)
@@ -145,6 +149,7 @@ class TestPasswordChangeRequiresOldPassword:
                 'form_id': 'password',
                 'old_password': 'OldPass123!',
                 'new_password': 'LongNewPass1!',
+                'confirm_password': 'LongNewPass1!',
                 'csrf_token': csrf,
             }, follow_redirects=False)
 

--- a/tests/test_cross_platform_identity.py
+++ b/tests/test_cross_platform_identity.py
@@ -816,6 +816,7 @@ def test_password_change_revokes_existing_link_code(
             "form_id": "password",
             "old_password": "long-web-password",
             "new_password": "new-long-web-password",
+            "confirm_password": "new-long-web-password",
         },
         follow_redirects=False,
     )
@@ -881,6 +882,7 @@ def test_password_change_detaches_wechat_until_fresh_relink(
             "form_id": "password",
             "old_password": "long-web-password",
             "new_password": "new-long-web-password",
+            "confirm_password": "new-long-web-password",
         },
         follow_redirects=False,
     )
@@ -977,6 +979,7 @@ def test_password_change_allows_different_wechat_to_replace_stale_identity(
             "form_id": "password",
             "old_password": "long-web-password",
             "new_password": "new-long-web-password",
+            "confirm_password": "new-long-web-password",
         },
         follow_redirects=False,
     )
@@ -1103,12 +1106,14 @@ def test_registration_rejects_phone_shaped_username(app, client, db_session):
         data={
             "username": "13800138000",
             "password": "long-registration-password",
+            "confirm_password": "long-registration-password",
             "csrf_token": csrf,
         },
         follow_redirects=False,
     )
 
-    assert response.status_code in (301, 302, 303)
+    assert response.status_code == 422
+    assert "用户名不能使用手机号格式" in response.get_data(as_text=True)
     assert User.query.filter_by(username="13800138000").first() is None
 
 
@@ -1130,103 +1135,37 @@ def test_registration_rejects_internal_username_namespaces(
             data={
                 "username": username,
                 "password": "long-registration-password",
+                "confirm_password": "long-registration-password",
                 "csrf_token": csrf,
             },
             follow_redirects=False,
         )
-        assert response.status_code in (301, 302, 303)
+        assert response.status_code == 422
         assert User.query.filter_by(username=username).first() is None
 
 
-def test_registration_hides_phone_occupancy_in_response(
-    app,
-    db_session,
-):
+def test_registration_ignores_legacy_phone_field(app, db_session):
     from core.db_models import User
 
-    occupied = User(
-        username="occupied_phone_owner",
-        phone_normalized="+8613900000001",
-    )
-    occupied.set_password("existing-password-long")
-    db_session.add(occupied)
-    db_session.commit()
-
-    def submit(username, phone):
-        test_client = app.test_client()
-        csrf = f"csrf-{username}"
-        with test_client.session_transaction() as flask_session:
-            flask_session["_csrf_token"] = csrf
-        response = test_client.post(
-            "/register",
-            data={
-                "username": username,
-                "password": "registration-password-long",
-                "phone": phone,
-                "csrf_token": csrf,
-            },
-            follow_redirects=False,
-        )
-        with test_client.session_transaction() as flask_session:
-            flashes = list(flask_session.get("_flashes") or [])
-        return response, flashes
-
-    occupied_response, occupied_flashes = submit(
-        "phone_probe_occupied",
-        "13900000001",
-    )
-    available_response, available_flashes = submit(
-        "phone_probe_available",
-        "13900000002",
+    test_client = app.test_client()
+    csrf = "legacy-register-phone-csrf"
+    with test_client.session_transaction() as flask_session:
+        flask_session["_csrf_token"] = csrf
+    response = test_client.post(
+        "/register",
+        data={
+            "username": "legacy_phone_field",
+            "password": "registration-password-long",
+            "confirm_password": "registration-password-long",
+            "phone": "13900000001",
+            "csrf_token": csrf,
+        },
+        follow_redirects=False,
     )
 
-    assert occupied_response.status_code == available_response.status_code
-    assert occupied_response.headers["Location"] == available_response.headers["Location"]
-    assert occupied_flashes == available_flashes
-    assert "手机号" not in occupied_flashes[0][1]
-    duplicate_user = User.query.filter_by(username="phone_probe_occupied").one()
-    assert duplicate_user.phone_normalized == "+8613900000001"
-    assert duplicate_user.phone_verified_at is None
-    assert User.query.filter_by(username="phone_probe_available").one()
-    assert User.query.filter_by(
-        phone_normalized="+8613900000001",
-    ).count() == 2
-
-    def attempt_pending_phone_login(phone, password):
-        test_client = app.test_client()
-        csrf = f"csrf-{phone}-{password}"
-        with test_client.session_transaction() as flask_session:
-            flask_session["_csrf_token"] = csrf
-        response = test_client.post(
-            "/login",
-            data={
-                "username": phone,
-                "password": password,
-                "csrf_token": csrf,
-            },
-            follow_redirects=False,
-        )
-        with test_client.session_transaction() as flask_session:
-            flashes = list(flask_session.get("_flashes") or [])
-            logged_in = "_user_id" in flask_session
-        return response.status_code, flashes, logged_in
-
-    occupied_phone_result = attempt_pending_phone_login(
-        "13900000001",
-        "registration-password-long",
-    )
-    available_phone_result = attempt_pending_phone_login(
-        "13900000002",
-        "registration-password-long",
-    )
-    existing_owner_result = attempt_pending_phone_login(
-        "13900000001",
-        "existing-password-long",
-    )
-    assert occupied_phone_result == available_phone_result
-    assert occupied_phone_result == existing_owner_result
-    assert occupied_phone_result[0] == 200
-    assert occupied_phone_result[2] is False
+    assert response.status_code in (301, 302, 303)
+    created = User.query.filter_by(username="legacy_phone_field").one()
+    assert created.phone_normalized is None
 
 
 def test_registration_post_has_dedicated_rate_limit(app, db_session):
@@ -1240,8 +1179,9 @@ def test_registration_post_has_dedicated_rate_limit(app, db_session):
         test_client.post(
             "/register",
             data={
-                "username": f"rate_limited_registration_{index}",
+                "username": f"rate_register_{index}",
                 "password": "registration-password-long",
+                "confirm_password": "registration-password-long",
                 "csrf_token": csrf,
             },
             follow_redirects=False,

--- a/tests/test_formal_web_gate.py
+++ b/tests/test_formal_web_gate.py
@@ -142,7 +142,7 @@ def test_formal_web_registration_keeps_minimal_account_creation(
     client,
     db_session,
 ):
-    """正式态保留待验证手机号保存，并继续执行 CSRF 与输入校验。"""
+    """小程序独占正式态注册后建立会话并落到账号绑定页。"""
     from core.db_models import User
 
     app.config["WECHAT_FORMAL_RUNTIME"] = True
@@ -156,6 +156,7 @@ def test_formal_web_registration_keeps_minimal_account_creation(
         data={
             "username": "formal_link_user",
             "password": "formal-test-password",
+            "confirm_password": "formal-test-password",
             "phone": "13800138000",
             "csrf_token": csrf,
         },
@@ -163,10 +164,12 @@ def test_formal_web_registration_keeps_minimal_account_creation(
     )
 
     assert response.status_code in (301, 302, 303)
-    assert "/login" in response.headers["Location"]
+    assert response.headers["Location"].endswith("/account-link")
     user = User.query.filter_by(username="formal_link_user").one()
-    assert user.phone_normalized == "+8613800138000"
+    assert user.phone_normalized is None
     assert user.phone_verified_at is None
+    with client.session_transaction() as flask_session:
+        assert flask_session.get("_user_id")
 
 
 def test_formal_web_gate_preserves_public_aggregate_and_admin_inventory(app):

--- a/tests/test_http_errors.py
+++ b/tests/test_http_errors.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+"""中文错误页、限流响应和可信代理客户端键回归。"""
+from flask import abort
+
+
+def _set_csrf(client, token):
+    with client.session_transaction() as flask_session:
+        flask_session['_csrf_token'] = token
+
+
+def _register_payload(index, csrf):
+    return {
+        'username': f'error_rate_{index}',
+        'password': 'RegistrationPassword1!',
+        'confirm_password': 'RegistrationPassword1!',
+        'csrf_token': csrf,
+    }
+
+
+def test_html_rate_limit_is_branded_and_has_retry_contract(
+    app,
+    client,
+    db_session,
+):
+    app.config['RATE_LIMIT_REGISTER'] = '2 per hour'
+    csrf = 'html-rate-limit-csrf'
+    _set_csrf(client, csrf)
+    responses = [
+        client.post(
+            '/register',
+            data=_register_payload(index, csrf),
+            environ_base={'REMOTE_ADDR': '198.51.100.70'},
+            follow_redirects=False,
+        )
+        for index in range(3)
+    ]
+
+    response = responses[-1]
+    body = response.get_data(as_text=True)
+    assert [item.status_code for item in responses[:2]] == [302, 302]
+    assert response.status_code == 429
+    assert '操作太频繁' in body
+    assert '5 per 5 minute' not in body
+    assert 'data-retry-seconds=' in body
+    assert int(response.headers['Retry-After']) >= 1
+    assert response.headers['Cache-Control'] == 'no-store, private, max-age=0'
+    assert response.headers['X-Request-ID']
+    assert response.headers['X-Request-ID'] in body
+
+
+def test_json_rate_limit_keeps_structured_api_contract(
+    app,
+    client,
+    db_session,
+):
+    app.config['RATE_LIMIT_REGISTER'] = '1 per hour'
+    csrf = 'json-rate-limit-csrf'
+    _set_csrf(client, csrf)
+    first = client.post(
+        '/register',
+        data=_register_payload(20, csrf),
+        headers={'Accept': 'application/json'},
+        environ_base={'REMOTE_ADDR': '198.51.100.71'},
+        follow_redirects=False,
+    )
+    limited = client.post(
+        '/register',
+        data=_register_payload(21, csrf),
+        headers={'Accept': 'application/json'},
+        environ_base={'REMOTE_ADDR': '198.51.100.71'},
+        follow_redirects=False,
+    )
+
+    payload = limited.get_json()
+    assert first.status_code == 302
+    assert limited.status_code == 429
+    assert payload['success'] is False
+    assert payload['error'] == 'rate_limit_exceeded'
+    assert payload['retry_after_seconds'] == int(limited.headers['Retry-After'])
+    assert payload['request_id'] == limited.headers['X-Request-ID']
+
+
+def test_successful_logins_do_not_consume_failed_login_limit(
+    app,
+    client,
+    db_session,
+):
+    from core.db_models import User
+
+    app.config['RATE_LIMIT_LOGIN'] = '2 per 5 minutes'
+    user = User(username='deduct-login-user', role='user')
+    user.set_password('CorrectLoginPassword1!')
+    db_session.add(user)
+    db_session.commit()
+    csrf = 'deduct-login-csrf'
+    _set_csrf(client, csrf)
+    remote = {'REMOTE_ADDR': '198.51.100.72'}
+
+    for _index in range(3):
+        success = client.post(
+            '/login',
+            data={
+                'username': user.username,
+                'password': 'CorrectLoginPassword1!',
+                'csrf_token': csrf,
+            },
+            environ_base=remote,
+            follow_redirects=False,
+        )
+        assert success.status_code == 302
+        client.post(
+            '/logout',
+            data={'csrf_token': csrf},
+            environ_base=remote,
+            follow_redirects=False,
+        )
+
+    failures = [
+        client.post(
+            '/login',
+            data={
+                'username': user.username,
+                'password': 'WrongLoginPassword1!',
+                'csrf_token': csrf,
+            },
+            environ_base=remote,
+            follow_redirects=False,
+        )
+        for _index in range(3)
+    ]
+    assert [item.status_code for item in failures] == [200, 200, 429]
+
+
+def test_client_rate_limit_key_obeys_trusted_proxy_boundary(app):
+    from core.security import client_rate_limit_key
+
+    app.config['TRUSTED_PROXY_CIDRS'] = '127.0.0.1/32,::1/128'
+    with app.test_request_context(
+        '/',
+        headers={'X-Forwarded-For': '8.8.8.8'},
+        environ_base={'REMOTE_ADDR': '203.0.113.10'},
+    ):
+        untrusted_a = client_rate_limit_key()
+    with app.test_request_context(
+        '/',
+        headers={'X-Forwarded-For': '9.9.9.9'},
+        environ_base={'REMOTE_ADDR': '203.0.113.10'},
+    ):
+        untrusted_b = client_rate_limit_key()
+    with app.test_request_context(
+        '/',
+        headers={'X-Forwarded-For': '8.8.8.8'},
+        environ_base={'REMOTE_ADDR': '127.0.0.1'},
+    ):
+        trusted_a = client_rate_limit_key()
+    with app.test_request_context(
+        '/',
+        headers={'X-Forwarded-For': '9.9.9.9'},
+        environ_base={'REMOTE_ADDR': '127.0.0.1'},
+    ):
+        trusted_b = client_rate_limit_key()
+
+    assert untrusted_a == untrusted_b
+    assert trusted_a != trusted_b
+    assert all(
+        key.startswith('client:')
+        and '8.8.8.8' not in key
+        and '203.0.113.10' not in key
+        for key in (untrusted_a, trusted_a, trusted_b)
+    )
+
+
+def test_html_and_api_not_found_are_content_negotiated(client, db_session):
+    html_response = client.get('/settings')
+    api_response = client.get('/api/does-not-exist')
+
+    html_body = html_response.get_data(as_text=True)
+    assert html_response.status_code == 404
+    assert '页面没有找到' in html_body
+    assert 'Not Found' not in html_body
+    assert api_response.status_code == 404
+    assert api_response.get_json()['error'] == 'not_found'
+    assert api_response.get_json()['request_id']
+
+
+def test_forbidden_and_internal_errors_use_station_pages(app, client, db_session):
+    app.config['PROPAGATE_EXCEPTIONS'] = False
+
+    @app.get('/_test/forbidden')
+    def _test_forbidden():
+        abort(403)
+
+    @app.get('/_test/server-error')
+    def _test_server_error():
+        raise RuntimeError('raw-private-error-text')
+
+    forbidden = client.get('/_test/forbidden')
+    failed = client.get('/_test/server-error')
+    assert forbidden.status_code == 403
+    assert '没有访问权限' in forbidden.get_data(as_text=True)
+    assert failed.status_code == 500
+    assert '页面暂时不可用' in failed.get_data(as_text=True)
+    assert 'raw-private-error-text' not in failed.get_data(as_text=True)
+
+
+def test_community_permission_message_names_required_role(
+    client,
+    db_session,
+):
+    from core.db_models import User
+
+    user = User(username='ordinary-community-visitor', role='user')
+    user.set_password('CommunityVisitor1!')
+    db_session.add(user)
+    db_session.commit()
+    csrf = 'community-role-csrf'
+    _set_csrf(client, csrf)
+    client.post(
+        '/login',
+        data={
+            'username': user.username,
+            'password': 'CommunityVisitor1!',
+            'csrf_token': csrf,
+        },
+        follow_redirects=False,
+    )
+
+    response = client.get('/community', follow_redirects=False)
+    assert response.status_code == 302
+    with client.session_transaction() as flask_session:
+        messages = [message for _kind, message in flask_session.get('_flashes', [])]
+    assert '该页面仅限社区工作人员或管理员使用，请切换对应账号。' in messages
+
+
+def test_base_template_has_no_full_screen_page_loader(client, db_session):
+    body = client.get('/login').get_data(as_text=True)
+    assert 'id="pageLoader"' not in body
+    assert 'function hideLoader' not in body
+    assert '处理中…' in body

--- a/tests/test_session_revocation.py
+++ b/tests/test_session_revocation.py
@@ -130,6 +130,7 @@ def test_password_change_revokes_all_other_sessions_and_refreshes_current_browse
             'form_id': 'password',
             'old_password': 'OldPassword1!',
             'new_password': 'NewPassword2!',
+            'confirm_password': 'NewPassword2!',
             'csrf_token': current_csrf,
         },
         follow_redirects=False,

--- a/tests/test_web_owner_write_guard.py
+++ b/tests/test_web_owner_write_guard.py
@@ -209,6 +209,7 @@ def test_account_delete_finishes_before_web_write_and_blocks_all_private_rows(
                 "form_id": "password",
                 "old_password": "web-owner-write-test-password",
                 "new_password": "NewConcurrentPassword!",
+                "confirm_password": "NewConcurrentPassword!",
             },
         ),
         ("/location", {"location": "都昌县"}),


### PR DESCRIPTION
## 1. 这次改了什么

修正注册首登、游客导航、密码确认和账号绑定文案，并加入中文 403/404/429/500 页面、可信代理限流键及失败登录计数。

## 2. 为什么要改

Grok 真人流程发现注册成功提示含糊、首登错误落到账号绑定、游客误显示退出、登录 429 暴露英文纯文本、错误页缺少站内返回路径，同时注册失败会清空输入且只显示第一条错误。

## 3. 怎么测试

- 基线相关测试：19 passed
- 完整账号与错误边界回归：238 passed
- 编译检查：core、services、blueprints 与新增测试均通过
- 浏览器桌面回归：注册错误聚合并保留非敏感字段，密码清空；成功后进入 /pairs?welcome=1；游客导航三态正确；404 和 429 为中文站内页；控制台无错误或告警
- 浏览器 390 x 844：429 页面无横向溢出，倒计时、返回按钮和请求编号可见

## 4. 文件与迁移

- 文件均保留在主仓库
- 无数据库迁移
- 未修改生产配置、服务器文件或微信小程序包

## 5. 脚本检查

未修改 .sh 或 .githooks，无需运行 bash -n。

## 6. Notion

当前未访问 Notion，发布记录待集成完成后回填。