### PR TITLE
fix: 统一天气快照与页面新鲜度

### DIFF
--- a/miniprogram/pages/actions/index.js
+++ b/miniprogram/pages/actions/index.js
@@ -116,7 +116,8 @@ Page({
 
   renderActions(result) {
     const snapshot = normalizeBootstrap(result.data);
-    const freshness = freshnessView(result.meta, snapshot);
+    const freshness = freshnessView(result.meta, snapshot, 'risk');
+    const warningsFreshness = freshnessView(result.meta, snapshot, 'warnings');
     const generalMode = freshness.stale || !snapshot.available || !snapshot.actions.length;
     const sourceActions = generalMode ? GENERAL_ACTIONS : snapshot.actions;
     const actions = this.mergeChecked(sourceActions);
@@ -128,7 +129,7 @@ Page({
       completedCount,
       progressPercent: actions.length ? Math.round(completedCount / actions.length * 100) : 0,
       generalMode,
-      familyReminder: freshness.stale ? null : snapshot.familyReminder,
+      familyReminder: freshness.stale || warningsFreshness.stale ? null : snapshot.familyReminder,
       locationName: snapshot.location.name,
       freshness,
     });

--- a/miniprogram/pages/alerts/index.js
+++ b/miniprogram/pages/alerts/index.js
@@ -73,7 +73,8 @@ Page({
 
   renderWarnings(result) {
     const snapshot = normalizeBootstrap(result.data);
-    const freshness = freshnessView(result.meta, snapshot);
+    const freshness = freshnessView(result.meta, snapshot, 'warnings');
+    const currentFreshness = freshnessView(result.meta, snapshot, 'current');
     this.setData({
       loading: false,
       error: result.meta && result.meta.networkError
@@ -82,7 +83,7 @@ Page({
       // 较早缓存中的预警可能已经失效，刷新前不继续标成有效预警。
       warnings: freshness.stale ? [] : snapshot.warnings,
       warningsSourceAvailable: freshness.stale ? false : snapshot.warningsSourceAvailable,
-      current: snapshot.current,
+      current: Object.assign({}, snapshot.current, { stale: currentFreshness.stale }),
       locationName: snapshot.location.name,
       freshness,
     });

--- a/miniprogram/pages/alerts/index.wxml
+++ b/miniprogram/pages/alerts/index.wxml
@@ -11,7 +11,7 @@
   <block wx:if="{{current}}">
     <freshness-bar updated-text="{{freshness.updatedText}}" stale="{{freshness.stale}}" source="{{freshness.source}}" refresh-deferred="{{freshness.refreshDeferred}}" refresh-started="{{freshness.refreshStarted}}" />
     <view class="card weather-strip">
-      <view><view class="small muted">{{freshness.stale ? '较早观测' : '当前'}}</view><view class="strip-value">{{current.temperatureText}}</view></view>
+      <view><view class="small muted">{{current.stale ? '较早观测' : '当前'}}</view><view class="strip-value">{{current.temperatureText}}</view></view>
       <view><view class="small muted">最高</view><view class="strip-value">{{current.highText}}</view></view>
       <view><view class="small muted">最低</view><view class="strip-value">{{current.lowText}}</view></view>
     </view>

--- a/miniprogram/pages/forecast/index.js
+++ b/miniprogram/pages/forecast/index.js
@@ -82,7 +82,7 @@ Page({
 
   renderForecast(result) {
     const snapshot = normalizeBootstrap(result.data);
-    const freshness = freshnessView(result.meta, snapshot);
+    const freshness = freshnessView(result.meta, snapshot, 'forecast');
     const forecast = freshness.stale
       ? staleForecast(snapshot.forecast)
       : snapshot.forecast;

--- a/miniprogram/pages/home/index.js
+++ b/miniprogram/pages/home/index.js
@@ -17,16 +17,16 @@ const {
   sourceFromShareEvent,
 } = require('../../utils/share');
 
-function homeSnapshotView(snapshot) {
+function homeSnapshotView(snapshot, warningsStale) {
   const source = snapshot || {};
   // 首页只跨逻辑层与视图层传递实际渲染字段，避免复制预报、来源等整份快照。
   return {
     available: source.available,
     location: source.location,
     current: source.current,
-    warnings: Array.isArray(source.warnings) ? source.warnings : [],
-    warningsSourceAvailable: source.warningsSourceAvailable === true,
-    warningsStatusText: source.warningsStatusText,
+    warnings: warningsStale ? [] : (Array.isArray(source.warnings) ? source.warnings : []),
+    warningsSourceAvailable: warningsStale ? false : source.warningsSourceAvailable === true,
+    warningsStatusText: warningsStale ? '官方预警待刷新' : source.warningsStatusText,
     risk: source.risk,
   };
 }
@@ -145,7 +145,8 @@ Page({
 
   renderSnapshot(result) {
     const snapshot = normalizeBootstrap(result.data);
-    const freshness = freshnessView(result.meta, snapshot);
+    const freshness = freshnessView(result.meta, snapshot, 'risk');
+    const warningsFreshness = freshnessView(result.meta, snapshot, 'warnings');
     // 较早天气可以继续展示观测值，风险分数和定制行动必须等刷新后再启用。
     const displaySnapshot = freshness.stale ? staleHomeSnapshot(snapshot) : snapshot;
     this.setData({
@@ -153,7 +154,7 @@ Page({
       error: result.meta && result.meta.networkError
         ? '天气更新失败，正在显示较早观测；风险、预警和定制行动已暂停。稍后会自动重试。'
         : '',
-      snapshot: homeSnapshotView(displaySnapshot),
+      snapshot: homeSnapshotView(displaySnapshot, warningsFreshness.stale),
       topActions: freshness.stale ? [] : snapshot.actions.slice(0, 3),
       freshness,
     });

--- a/miniprogram/tests/format.test.js
+++ b/miniprogram/tests/format.test.js
@@ -79,6 +79,53 @@ test('更新时间优先采用服务端真实抓取时间', () => {
   assert.match(view.updatedText, /08:00/);
 });
 
+test('页面只按自身依赖来源判断快照新鲜度', () => {
+  const now = Date.parse('2026-07-17T08:00:00Z');
+  const snapshot = normalizeBootstrap({
+    stale: true,
+    current_stale: false,
+    forecast_stale: true,
+    warnings_stale: false,
+    risk_stale: false,
+    current: { temperature: 35 },
+    risk: { available: true, score: 28, level: '低风险' },
+    source_status: {
+      current: { available: true, stale: false, expires_at: '2026-07-17T08:30:00Z' },
+      forecast: { available: true, stale: true, expires_at: '2026-07-17T07:59:00Z' },
+      warnings: { available: true, stale: false, expires_at: '2026-07-17T08:30:00Z' },
+      risk: { available: true, stale: false, expires_at: '2026-07-17T08:30:00Z' },
+    },
+  });
+
+  assert.equal(freshnessView({ stale: true }, snapshot, 'risk', now).stale, false);
+  assert.equal(freshnessView({ stale: true }, snapshot, 'forecast', now).stale, true);
+  assert.equal(freshnessView({ stale: true }, snapshot, 'warnings', now).stale, false);
+  assert.equal(
+    freshnessView({ stale: true }, snapshot, 'risk', Date.parse('2026-07-17T08:31:00Z')).stale,
+    true,
+  );
+  assert.equal(snapshot.current.available, true);
+  assert.equal(snapshot.risk.available, true);
+
+  const warningsExpired = normalizeBootstrap({
+    warnings_stale: true,
+    warnings: [{ title: '旧高温预警' }],
+    source_status: {
+      warnings: { available: true, stale: true },
+    },
+  });
+  assert.deepEqual(warningsExpired.warnings, []);
+  assert.equal(warningsExpired.warningsSourceAvailable, false);
+  assert.equal(warningsExpired.warningsStatusText, '来源暂不可用');
+
+  const legacyWithoutExpiry = normalizeBootstrap({
+    risk_stale: false,
+    risk: { available: true, score: 28, level: '低风险' },
+    source_status: { risk: { available: true, stale: false } },
+  });
+  assert.equal(freshnessView({ stale: true }, legacyWithoutExpiry, 'risk', now).stale, true);
+});
+
 test('都昌县时间展示不受运行环境时区影响', () => {
   assert.equal(formatDateTime('2026-07-17T00:00:00Z'), '07月17日 08:00');
   assert.equal(formatDateTime('2026-07-17 08:00:00'), '07月17日 08:00');

--- a/miniprogram/tests/format.test.js
+++ b/miniprogram/tests/format.test.js
@@ -101,7 +101,7 @@ test('页面只按自身依赖来源判断快照新鲜度', () => {
   assert.equal(freshnessView({ stale: true }, snapshot, 'forecast', now).stale, true);
   assert.equal(freshnessView({ stale: true }, snapshot, 'warnings', now).stale, false);
   assert.equal(
-    freshnessView({ stale: true }, snapshot, 'risk', Date.parse('2026-07-17T08:31:00Z')).stale,
+    freshnessView({ stale: true }, snapshot, 'risk', Date.parse('2026-07-17T08:30:00Z')).stale,
     true,
   );
   assert.equal(snapshot.current.available, true);
@@ -117,6 +117,21 @@ test('页面只按自身依赖来源判断快照新鲜度', () => {
   assert.deepEqual(warningsExpired.warnings, []);
   assert.equal(warningsExpired.warningsSourceAvailable, false);
   assert.equal(warningsExpired.warningsStatusText, '来源暂不可用');
+
+  const warningsUnavailable = normalizeBootstrap({
+    warnings_stale: false,
+    warnings: [{ title: '来源失败前的旧高温预警' }],
+    source_status: {
+      warnings: {
+        available: false,
+        stale: false,
+        expires_at: '2026-07-17T08:30:00Z',
+      },
+    },
+  });
+  assert.deepEqual(warningsUnavailable.warnings, []);
+  assert.equal(warningsUnavailable.warningsSourceAvailable, false);
+  assert.equal(freshnessView({}, warningsUnavailable, 'warnings', now).stale, true);
 
   const legacyWithoutExpiry = normalizeBootstrap({
     risk_stale: false,
@@ -179,6 +194,7 @@ test('预警列表为空时区分暂无预警与来源不可用', () => {
 
 test('预警保留发布单位、发布时间和生效时间', () => {
   const result = normalizeBootstrap({
+    source_status: { warnings: { available: true, stale: false } },
     warnings: [{
       title: '高温黄色预警',
       start_time: '2026-07-17T08:30:00+08:00',
@@ -199,11 +215,13 @@ test('预警保留发布单位、发布时间和生效时间', () => {
   assert.match(warning.effectiveText, /08:30/);
 
   const objectSender = normalizeBootstrap({
+    source_status: { warnings: { available: true, stale: false } },
     warnings: [{ raw: { sender: { name: '九江市气象台' } } }],
   });
   assert.equal(objectSender.warnings[0].issuer, '九江市气象台');
 
   const publishedOnly = normalizeBootstrap({
+    source_status: { warnings: { available: true, stale: false } },
     warnings: [{
       start_time: '2026-07-17T08:00:00+08:00',
       raw: { pubTime: '2026-07-17T08:00:00+08:00' },

--- a/miniprogram/utils/format.js
+++ b/miniprogram/utils/format.js
@@ -286,7 +286,11 @@ function normalizeBootstrap(payload) {
   const riskScore = finiteNumber(firstDefined(riskSource, ['score', 'risk_score', 'value', 'index'], null));
   const currentStale = Boolean(data.current_stale === true || currentState.stale === true);
   const forecastStale = Boolean(data.forecast_stale === true || forecastState.stale === true);
-  const warningsStale = Boolean(data.warnings_stale === true || warningsState.stale === true);
+  const warningsStale = Boolean(
+    data.warnings_stale === true
+    || warningsState.stale === true
+    || warningsState.available !== true
+  );
   const riskStale = Boolean(data.risk_stale === true || riskState.stale === true);
   const componentFreshness = (state, stale, explicitKey) => {
     const expiresValue = state && (state.expires_at || state.expiresAt);
@@ -468,7 +472,7 @@ function freshnessView(resultMeta, snapshot, component, nowMs) {
   const stale = componentState && componentState.known
     ? Boolean(
       componentState.stale
-      || (Number.isFinite(componentState.expiresAt) && currentTime > componentState.expiresAt)
+      || (Number.isFinite(componentState.expiresAt) && currentTime >= componentState.expiresAt)
     )
     : Boolean(meta.stale || data.stale);
   return {

--- a/miniprogram/utils/format.js
+++ b/miniprogram/utils/format.js
@@ -271,13 +271,38 @@ function warningStatusText(warnings, sourceAvailable) {
 
 function normalizeBootstrap(payload) {
   const data = payload && typeof payload === 'object' ? payload : {};
+  const sourceStatus = data.source_status && typeof data.source_status === 'object'
+    ? data.source_status
+    : {};
+  const currentState = sourceStatus.current || sourceStatus.weather || {};
+  const forecastState = sourceStatus.forecast || {};
+  const warningsState = sourceStatus.warnings || {};
+  const riskState = sourceStatus.risk || {};
   const currentSource = data.current && typeof data.current === 'object' ? data.current : {};
   const riskSource = data.risk && typeof data.risk === 'object' ? data.risk : {};
   const temperature = finiteNumber(firstDefined(currentSource, ['temperature', 'temp', 'temp_now', 'temperature_current'], null));
   const high = finiteNumber(firstDefined(currentSource, ['temperature_max', 'temp_max', 'tempMax', 'high'], null));
   const low = finiteNumber(firstDefined(currentSource, ['temperature_min', 'temp_min', 'tempMin', 'low'], null));
   const riskScore = finiteNumber(firstDefined(riskSource, ['score', 'risk_score', 'value', 'index'], null));
-  const riskAvailable = data.available !== false && riskSource.available !== false && (riskScore !== null || Boolean(riskSource.level || riskSource.label));
+  const currentStale = Boolean(data.current_stale === true || currentState.stale === true);
+  const forecastStale = Boolean(data.forecast_stale === true || forecastState.stale === true);
+  const warningsStale = Boolean(data.warnings_stale === true || warningsState.stale === true);
+  const riskStale = Boolean(data.risk_stale === true || riskState.stale === true);
+  const componentFreshness = (state, stale, explicitKey) => {
+    const expiresValue = state && (state.expires_at || state.expiresAt);
+    const expiresAt = expiresValue ? Date.parse(String(expiresValue)) : NaN;
+    return {
+      stale,
+      // 只有服务端已判定过期，或有可验证的过期时间时，组件状态才能覆盖旧全局合同。
+      known: stale || Number.isFinite(expiresAt),
+      expiresAt: Number.isFinite(expiresAt) ? expiresAt : null,
+      explicit: explicitKey in data,
+    };
+  };
+  const riskAvailable = data.available !== false
+    && riskSource.available !== false
+    && !riskStale
+    && (riskScore !== null || Boolean(riskSource.level || riskSource.label));
   const riskLevelValue = firstDefined(riskSource, ['label', 'level', 'risk_level'], '');
   const forecastRaw = Array.isArray(data.forecast)
     ? data.forecast
@@ -288,8 +313,9 @@ function normalizeBootstrap(payload) {
   const actionsRaw = Array.isArray(data.actions)
     ? data.actions
     : (Array.isArray(data.actions && data.actions.items) ? data.actions.items : []);
-  const warnings = warningsRaw.map(normalizeWarning);
-  const warningsSourceAvailable = warningSourceAvailable(data.source_status);
+  // 过期预警不能继续以“当前有效”展示，首页与预警页共用这个安全结果。
+  const warnings = warningsStale ? [] : warningsRaw.map(normalizeWarning);
+  const warningsSourceAvailable = !warningsStale && warningSourceAvailable(data.source_status);
   return {
     snapshotId: String(data.snapshot_id || ''),
     location: {
@@ -302,8 +328,19 @@ function normalizeBootstrap(payload) {
     ttlSeconds: finiteNumber(data.ttl_seconds) || 1800,
     available: data.available !== false,
     stale: Boolean(data.stale),
+    currentStale,
+    forecastStale,
+    warningsStale,
+    riskStale,
+    freshness: {
+      current: componentFreshness(currentState, currentStale, 'current_stale'),
+      forecast: componentFreshness(forecastState, forecastStale, 'forecast_stale'),
+      warnings: componentFreshness(warningsState, warningsStale, 'warnings_stale'),
+      risk: componentFreshness(riskState, riskStale, 'risk_stale'),
+    },
     current: {
-      available: data.available !== false && currentSource.available !== false && temperature !== null,
+      available: data.available !== false && currentSource.available !== false && !currentStale && temperature !== null,
+      stale: currentStale,
       temperature,
       temperatureText: formatTemperature(temperature),
       high,
@@ -320,6 +357,7 @@ function normalizeBootstrap(payload) {
     warningsStatusText: warningStatusText(warnings, warningsSourceAvailable),
     risk: {
       available: riskAvailable,
+      stale: riskStale,
       score: riskScore,
       scoreText: riskScore === null ? '待计算' : String(Math.round(riskScore)),
       level: String(riskLevelValue),
@@ -421,13 +459,21 @@ function normalizeCommunity(payload) {
   };
 }
 
-function freshnessView(resultMeta, snapshot) {
+function freshnessView(resultMeta, snapshot, component, nowMs) {
   const meta = resultMeta || {};
   const data = snapshot || {};
   const storedAt = data.fetchedAt || data.generatedAt || meta.storedAt;
+  const componentState = component && data.freshness && data.freshness[component];
+  const currentTime = Number.isFinite(Number(nowMs)) ? Number(nowMs) : Date.now();
+  const stale = componentState && componentState.known
+    ? Boolean(
+      componentState.stale
+      || (Number.isFinite(componentState.expiresAt) && currentTime > componentState.expiresAt)
+    )
+    : Boolean(meta.stale || data.stale);
   return {
     updatedText: formatDateTime(storedAt),
-    stale: Boolean(meta.stale || data.stale),
+    stale,
     source: meta.source || 'unknown',
     refreshDeferred: Boolean(meta.refreshDeferred),
     refreshStarted: Boolean(meta.refreshStarted),

--- a/services/miniprogram_service.py
+++ b/services/miniprogram_service.py
@@ -231,7 +231,7 @@ def _component_state(
             break
     expires_at = _source_datetime(raw.get("expires_at")) or fallback_expires_at
     fetched_at = _source_datetime(raw.get("fetched_at"))
-    stale = expires_at is None or now > expires_at
+    stale = expires_at is None or now >= expires_at
     available = bool(raw.get("available", fallback_available))
     state = {
         **raw,
@@ -268,7 +268,8 @@ def _payload_source_status(record, current, forecast, warnings, *, now, expires_
         "warnings",
         now=now,
         fallback_expires_at=expires_at,
-        fallback_available=isinstance(warnings, list),
+        # 未知预警来源不能因为 payload 恰好是列表就被视为核验成功。
+        fallback_available=False,
     )
     risk_stale = current_state["stale"] or not current_state["available"]
     risk_state = {
@@ -553,7 +554,7 @@ def snapshot_payload(record=None, *, now=None) -> dict:
     current = safe_json_loads(record.current_json, {})
     forecast = safe_json_loads(record.forecast_json, [])
     warnings = safe_json_loads(record.warnings_json, [])
-    stale = current_time > expires_at
+    stale = current_time >= expires_at
     source_status = _payload_source_status(
         record,
         current,
@@ -570,7 +571,7 @@ def snapshot_payload(record=None, *, now=None) -> dict:
         record,
         current,
         # 过期预警不能继续参与家庭提醒话术，当前天气风险仍可独立使用。
-        [] if warnings_stale else warnings,
+        [] if warnings_stale or not source_status["warnings"]["available"] else warnings,
         available=bool(record.available) and not risk_stale,
         date_value=current_time,
     )

--- a/services/miniprogram_service.py
+++ b/services/miniprogram_service.py
@@ -24,7 +24,13 @@ from core.db_models import (
     WeatherCache,
 )
 from core.extensions import db
-from core.time_utils import ensure_utc_aware, today_local, utc_to_local_date, utcnow
+from core.time_utils import (
+    ensure_utc_aware,
+    today_local,
+    utc_to_local_date,
+    utc_to_local_datetime,
+    utcnow,
+)
 from core.weather import get_consecutive_hot_days, get_qweather_forecast_with_cache
 from services.qweather_auth import is_qweather_configured
 from services.miniprogram_auth import current_privacy_version
@@ -196,6 +202,91 @@ def _source_datetime(value):
         return ensure_utc_aware(datetime.fromisoformat(str(value)))
     except (TypeError, ValueError, OverflowError):
         return None
+
+
+def snapshot_display_time(value):
+    """把快照 UTC 时间转换为都昌页面使用的本地时间文字。"""
+    parsed = _source_datetime(value)
+    if parsed is None:
+        return None
+    return utc_to_local_datetime(parsed).strftime("%Y-%m-%d %H:%M")
+
+
+def _component_state(
+    source_status,
+    name,
+    *,
+    now,
+    fallback_expires_at,
+    fallback_available,
+):
+    """在读取时计算单个来源的新鲜度，旧快照继续回退到总过期时间。"""
+    source = source_status if isinstance(source_status, dict) else {}
+    aliases = {"current": ("current", "weather")}
+    raw = {}
+    for key in aliases.get(name, (name,)):
+        candidate = source.get(key)
+        if isinstance(candidate, dict):
+            raw = dict(candidate)
+            break
+    expires_at = _source_datetime(raw.get("expires_at")) or fallback_expires_at
+    fetched_at = _source_datetime(raw.get("fetched_at"))
+    stale = expires_at is None or now > expires_at
+    available = bool(raw.get("available", fallback_available))
+    state = {
+        **raw,
+        "available": available,
+        "stale": stale,
+    }
+    if fetched_at is not None:
+        state["fetched_at"] = fetched_at.isoformat()
+    if expires_at is not None:
+        state["expires_at"] = expires_at.isoformat()
+    return state
+
+
+def _payload_source_status(record, current, forecast, warnings, *, now, expires_at):
+    """补齐各来源状态；总 stale 保留兼容，页面按组件状态决定是否展示。"""
+    stored = safe_json_loads(record.source_status_json, {})
+    stored = dict(stored) if isinstance(stored, dict) else {}
+    current_state = _component_state(
+        stored,
+        "current",
+        now=now,
+        fallback_expires_at=expires_at,
+        fallback_available=bool(record.available) and _weather_available(current),
+    )
+    forecast_state = _component_state(
+        stored,
+        "forecast",
+        now=now,
+        fallback_expires_at=expires_at,
+        fallback_available=bool(forecast),
+    )
+    warnings_state = _component_state(
+        stored,
+        "warnings",
+        now=now,
+        fallback_expires_at=expires_at,
+        fallback_available=isinstance(warnings, list),
+    )
+    risk_stale = current_state["stale"] or not current_state["available"]
+    risk_state = {
+        "available": not risk_stale and public_risk_weather_is_ready(current),
+        "stale": risk_stale,
+        "depends_on": ["current"],
+        "fetched_at": current_state.get("fetched_at"),
+        "expires_at": current_state.get("expires_at"),
+    }
+    # weather 是旧客户端使用的键，current 是新合同的直观别名。
+    stored.update({
+        "weather": dict(current_state),
+        "current": dict(current_state),
+        "forecast": forecast_state,
+        "warnings": warnings_state,
+        "risk": risk_state,
+    })
+    return stored
 
 
 def _normalize_source_timing(
@@ -431,6 +522,10 @@ def snapshot_payload(record=None, *, now=None) -> dict:
             "ttl_seconds": SNAPSHOT_TTL_SECONDS,
             "available": False,
             "stale": True,
+            "current_stale": True,
+            "forecast_stale": True,
+            "warnings_stale": True,
+            "risk_stale": True,
             "current": {"is_mock": True},
             "forecast": [],
             "warnings": [],
@@ -442,18 +537,41 @@ def snapshot_payload(record=None, *, now=None) -> dict:
                 "status": "missing",
                 "refresh_interval_seconds": SNAPSHOT_TTL_SECONDS,
                 "canonical_location_only": True,
+                "current": {"available": False, "stale": True},
+                "weather": {"available": False, "stale": True},
+                "forecast": {"available": False, "stale": True},
+                "warnings": {"available": False, "stale": True},
+                "risk": {
+                    "available": False,
+                    "stale": True,
+                    "depends_on": ["current"],
+                },
             },
             "required_privacy_consent_version": current_privacy_version(),
         }
     expires_at = ensure_utc_aware(record.expires_at)
     current = safe_json_loads(record.current_json, {})
+    forecast = safe_json_loads(record.forecast_json, [])
     warnings = safe_json_loads(record.warnings_json, [])
     stale = current_time > expires_at
+    source_status = _payload_source_status(
+        record,
+        current,
+        forecast,
+        warnings,
+        now=current_time,
+        expires_at=expires_at,
+    )
+    current_stale = bool(source_status["current"]["stale"])
+    forecast_stale = bool(source_status["forecast"]["stale"])
+    warnings_stale = bool(source_status["warnings"]["stale"])
+    risk_stale = bool(source_status["risk"]["stale"])
     public_context = _persisted_public_context(
         record,
         current,
-        warnings,
-        available=bool(record.available) and not stale,
+        # 过期预警不能继续参与家庭提醒话术，当前天气风险仍可独立使用。
+        [] if warnings_stale else warnings,
+        available=bool(record.available) and not risk_stale,
         date_value=current_time,
     )
     return {
@@ -468,13 +586,17 @@ def snapshot_payload(record=None, *, now=None) -> dict:
         "ttl_seconds": SNAPSHOT_TTL_SECONDS,
         "available": bool(record.available),
         "stale": stale,
+        "current_stale": current_stale,
+        "forecast_stale": forecast_stale,
+        "warnings_stale": warnings_stale,
+        "risk_stale": risk_stale,
         "current": current,
-        "forecast": safe_json_loads(record.forecast_json, []),
+        "forecast": forecast,
         "warnings": warnings,
         "risk": public_context["risk"],
         "actions": public_context["actions"],
         "family_reminder": public_context["family_reminder"],
-        "source_status": safe_json_loads(record.source_status_json, {}),
+        "source_status": source_status,
         "required_privacy_consent_version": current_privacy_version(),
     }
 

--- a/services/miniprogram_service.py
+++ b/services/miniprogram_service.py
@@ -567,11 +567,16 @@ def snapshot_payload(record=None, *, now=None) -> dict:
     forecast_stale = bool(source_status["forecast"]["stale"])
     warnings_stale = bool(source_status["warnings"]["stale"])
     risk_stale = bool(source_status["risk"]["stale"])
+    warnings_usable = (
+        not warnings_stale
+        and source_status["warnings"]["available"] is True
+    )
+    public_warnings = warnings if warnings_usable else []
     public_context = _persisted_public_context(
         record,
         current,
         # 过期预警不能继续参与家庭提醒话术，当前天气风险仍可独立使用。
-        [] if warnings_stale or not source_status["warnings"]["available"] else warnings,
+        public_warnings,
         available=bool(record.available) and not risk_stale,
         date_value=current_time,
     )
@@ -593,7 +598,7 @@ def snapshot_payload(record=None, *, now=None) -> dict:
         "risk_stale": risk_stale,
         "current": current,
         "forecast": forecast,
-        "warnings": warnings,
+        "warnings": public_warnings,
         "risk": public_context["risk"],
         "actions": public_context["actions"],
         "family_reminder": public_context["family_reminder"],

--- a/services/public_service.py
+++ b/services/public_service.py
@@ -58,7 +58,7 @@ from services.community_daily_service import (
     refresh_community_daily_best_effort as _refresh_community_daily_best_effort,
 )
 from services.heat_action_service import HeatActionService
-from services.miniprogram_service import get_bootstrap_payload
+from services.miniprogram_service import get_bootstrap_payload, snapshot_display_time
 from services.cross_platform_identity import (
     AccountLinkError,
     create_account_link_challenge,
@@ -1750,6 +1750,12 @@ def render_public_risk_page(location):
         actions=snapshot.get('actions') or [],
         risk_reasons=risk_reasons,
         family_reminder=snapshot.get('family_reminder'),
+        weather_snapshot_id=snapshot.get('snapshot_id'),
+        weather_snapshot_fetched_at=snapshot.get('fetched_at'),
+        weather_snapshot_display_time=snapshot_display_time(snapshot.get('fetched_at')),
+        weather_snapshot_expires_at=snapshot.get('expires_at'),
+        weather_risk_stale=snapshot.get('risk_stale', True),
+        weather_source_status=snapshot.get('source_status') or {},
     )
 
 

--- a/services/user/dashboard_service.py
+++ b/services/user/dashboard_service.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import math
-from datetime import timedelta
 from types import SimpleNamespace
 
 from flask import current_app, has_app_context, render_template, request
@@ -25,7 +24,6 @@ from core.db_models import (
     HealthRiskAssessment,
     MedicationReminder,
     Notification,
-    WeatherAlert,
 )
 from services.forecast_cards import build_forecast_cards
 from utils.parsers import safe_json_loads
@@ -139,6 +137,31 @@ def _dashboard_alert_card(alert):
         'alert_date_local': local_date.strftime('%Y-%m-%d') if local_date else '日期未标注',
         'location': location,
         'description': alert.description,
+        'is_high': is_high,
+    }
+
+
+def _dashboard_snapshot_alert_card(warning, location):
+    """将同一县级快照中的官方预警转换成首页卡片。"""
+    row = warning if isinstance(warning, dict) else {}
+    level_text = str(row.get('level') or row.get('severity') or '未分级').strip()
+    normalized_level = level_text.lower()
+    is_high = normalized_level in {'high', 'extreme', 'severe', 'moderate', 'red'} or any(
+        marker in level_text for marker in ('高', '严重', '红', '橙')
+    )
+    published_at = str(
+        row.get('start_time')
+        or row.get('issued_at')
+        or row.get('published_at')
+        or ''
+    ).strip()
+    date_text = published_at[:10] if len(published_at) >= 10 else '日期未标注'
+    return {
+        'alert_type': str(row.get('title') or row.get('type') or '天气预警').strip(),
+        'alert_level': level_text,
+        'alert_date_local': date_text,
+        'location': location or '都昌县',
+        'description': str(row.get('text') or row.get('instruction') or '').strip(),
         'is_high': is_high,
     }
 
@@ -295,7 +318,6 @@ def user_dashboard(force_elder=False):
     # 首页和公开风险、小程序共用同一份只读快照；缺少快照时统一安全降级。
     today = today_local()
     user_location = ensure_user_location_valid()
-    alert_locations = _dashboard_alert_locations(user_location)
     snapshot = get_bootstrap_payload()
     snapshot_id = snapshot.get('snapshot_id')
     snapshot_mode = bool(snapshot_id)
@@ -362,11 +384,17 @@ def user_dashboard(force_elder=False):
     if latest_assessment and getattr(latest_assessment, 'explain', None):
         assessment_explain = safe_json_loads(latest_assessment.explain, {})
 
-    # 获取天气预警（最近24小时）
-    alerts = WeatherAlert.query.filter(
-        WeatherAlert.alert_date >= utcnow() - timedelta(days=1),
-        WeatherAlert.location.in_(alert_locations)
-    ).order_by(WeatherAlert.alert_date.desc()).limit(5).all()
+    # 预警与温度、风险共用同一快照；来源未知、不可用或过期时不展示旧预警。
+    warning_state = (snapshot.get('source_status') or {}).get('warnings') or {}
+    warnings_ready = (
+        snapshot_mode
+        and not snapshot.get('warnings_stale')
+        and warning_state.get('available') is True
+    )
+    alerts = [
+        _dashboard_snapshot_alert_card(item, weather_source_city)
+        for item in (snapshot.get('warnings') or [])[:5]
+    ] if warnings_ready else []
 
     # 用药提醒（根据天气触发）
     reminders = []
@@ -451,7 +479,7 @@ def user_dashboard(force_elder=False):
             weather_source_status=snapshot.get('source_status') or {},
         )
 
-    alert_cards = [_dashboard_alert_card(alert) for alert in alerts]
+    alert_cards = alerts
 
     return render_template('user_dashboard.html',
                          weather=weather if weather_available else None,

--- a/services/user/dashboard_service.py
+++ b/services/user/dashboard_service.py
@@ -15,9 +15,6 @@ from core.health_profiles import reminder_triggered
 from core.time_utils import today_local, utc_to_local_date, utcnow
 from core.weather import (
     ensure_user_location_valid,
-    get_consecutive_hot_days,
-    get_qweather_forecast_with_cache,
-    get_weather_with_cache,
     is_demo_mode,
     is_qweather_online_weather,
     resolve_weather_city_label
@@ -29,14 +26,9 @@ from core.db_models import (
     MedicationReminder,
     Notification,
     WeatherAlert,
-    WeatherData
 )
-from services.heat_action_service import HeatActionService
 from services.forecast_cards import build_forecast_cards
-from services.forecast_service import get_forecast_service
 from utils.parsers import safe_json_loads
-
-from ._common import HEAT_RISK_LABELS, _action_plan
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +38,20 @@ _REQUIRED_DASHBOARD_WEATHER_FIELDS = (
     'temperature_min',
     'humidity',
 )
+
+
+def get_bootstrap_payload(*args, **kwargs):
+    """延迟导入快照服务，避免 services.user 包初始化时形成循环依赖。"""
+    from services.miniprogram_service import get_bootstrap_payload as load_payload
+
+    return load_payload(*args, **kwargs)
+
+
+def snapshot_display_time(value):
+    """延迟导入快照时间格式化函数。"""
+    from services.miniprogram_service import snapshot_display_time as format_time
+
+    return format_time(value)
 
 
 def _clamp(value, lower=0.0, upper=1.0):
@@ -169,18 +175,6 @@ def _dashboard_weather_available(weather_data):
     return True
 
 
-def _forecast_weather_context(weather_data):
-    """提取真实和风实况中的有限空气质量值，供未来日代理链使用。"""
-    if not is_qweather_online_weather(weather_data):
-        return {}
-    context = {}
-    for field in ('pm25', 'aqi'):
-        value = _parse_float((weather_data or {}).get(field))
-        if value is not None and math.isfinite(value):
-            context[field] = value
-    return context
-
-
 def _parse_systolic(value):
     """从画像指标里提取收缩压，支持 138/82 或单个数字。"""
     if isinstance(value, str) and '/' in value:
@@ -253,28 +247,41 @@ def _dashboard_metric_cards(user_id):
     return [cards[key] for key in ('sbp', 'heart_rate', 'blood_sugar') if key in cards]
 
 
-def _dashboard_forecast_days(location, start_date, current_weather=None):
-    """首页 7 日预测只使用和风实时预报，失败时不展示演示风险。"""
-    qweather_days, _, meta = get_qweather_forecast_with_cache(location, days=7)
-    if len(qweather_days or []) < 7:
-        logger.warning(
-            "首页和风7日预报不可用: location=%s meta=%s count=%s",
-            location,
-            meta,
-            len(qweather_days or []),
-        )
+def _dashboard_snapshot_forecast_days(snapshot, start_date):
+    """把已落库的逐日天气风险直接转换成首页卡片。"""
+    if snapshot.get('forecast_stale'):
         return []
-
-    health_forecasts = []
-    try:
-        health_forecasts, _ = get_forecast_service().generate_7day_forecast(
-            qweather_days,
-            start_date=start_date,
-            context=_forecast_weather_context(current_weather),
+    forecast = snapshot.get('forecast')
+    if not isinstance(forecast, list):
+        return []
+    cards = build_forecast_cards(forecast, [], start_date)
+    source_by_date = {
+        str(item.get('date') or item.get('forecast_date')): item
+        for item in forecast
+        if isinstance(item, dict) and (item.get('date') or item.get('forecast_date'))
+    }
+    for card in cards:
+        item = source_by_date.get(card.get('full_date')) or {}
+        score = _parse_float(item.get('risk_score'))
+        available = (
+            item.get('risk_available') is True
+            and score is not None
+            and math.isfinite(score)
         )
-    except Exception as exc:
-        logger.warning("首页7日健康预测生成失败，仅展示和风天气: %s", exc)
-    return build_forecast_cards(qweather_days, health_forecasts, start_date)
+        if not available:
+            continue
+        label = str(item.get('risk_level') or '待计算')
+        card.update({
+            'risk_available': True,
+            'risk_score': max(0, min(100, int(round(score)))),
+            'risk_label': label,
+            'risk_level': (
+                'high' if '高' in label or '极' in label
+                else 'mid' if '中' in label
+                else 'low'
+            ),
+        })
+    return cards
 
 
 def user_dashboard(force_elder=False):
@@ -285,12 +292,21 @@ def user_dashboard(force_elder=False):
     )
     is_guest = is_guest_user(current_user)
     demo_mode = is_demo_mode()
-    # 获取当前天气
+    # 首页和公开风险、小程序共用同一份只读快照；缺少快照时统一安全降级。
     today = today_local()
     user_location = ensure_user_location_valid()
     alert_locations = _dashboard_alert_locations(user_location)
-    weather_source_city = resolve_weather_city_label(user_location)
-    weather_data, used_cache = get_weather_with_cache(user_location)
+    snapshot = get_bootstrap_payload()
+    snapshot_id = snapshot.get('snapshot_id')
+    snapshot_mode = bool(snapshot_id)
+    snapshot_location = snapshot.get('location') or {}
+    weather_source_city = str(
+        snapshot_location.get('name')
+        or resolve_weather_city_label(user_location)
+    )
+    weather_data = snapshot.get('current') or {}
+    if not snapshot_mode or snapshot.get('current_stale'):
+        weather_data = {}
     weather_is_mock = bool(weather_data.get('is_mock'))
     weather_available = _dashboard_weather_available(weather_data)
 
@@ -305,75 +321,34 @@ def user_dashboard(force_elder=False):
             logger.warning("极端天气识别失败，已跳过: %s", exc)
             extreme_result = {'is_extreme': False, 'conditions': []}
 
-    weather = WeatherData.query.filter_by(
-        date=today,
-        location=user_location
-    ).order_by(WeatherData.id.desc()).first()
-
-    if weather_available and (not weather or not used_cache):
-        if not weather:
-            weather = WeatherData(date=today, location=user_location)
-            db.session.add(weather)
-        weather.temperature = weather_data.get('temperature')
-        weather.temperature_max = weather_data.get('temperature_max')
-        weather.temperature_min = weather_data.get('temperature_min')
-        weather.humidity = weather_data.get('humidity')
-        weather.pressure = weather_data.get('pressure')
-        weather.weather_condition = weather_data.get('weather_condition')
-        weather.wind_speed = weather_data.get('wind_speed')
-        weather.pm25 = weather_data.get('pm25')
-        weather.aqi = weather_data.get('aqi')
-        weather.is_extreme = extreme_result['is_extreme']
-        weather.extreme_type = '、'.join([c['type'] for c in extreme_result['conditions']]) if extreme_result['is_extreme'] else None
-        db.session.commit()
-
-    if weather_available and not weather:
+    weather = None
+    if weather_available:
         weather = SimpleNamespace(**weather_data)
         weather.is_extreme = extreme_result['is_extreme']
         weather.extreme_type = '、'.join([c['type'] for c in extreme_result['conditions']]) if extreme_result['is_extreme'] else None
 
-    heat_service = HeatActionService()
-    if not weather_available:
+    risk = snapshot.get('risk') or {} if snapshot_mode else {}
+    calculation = risk.get('calculation') if isinstance(risk, dict) else {}
+    stored_heat_result = calculation.get('heat_result') if isinstance(calculation, dict) else None
+    snapshot_risk_ready = (
+        snapshot_mode
+        and not snapshot.get('risk_stale')
+        and risk.get('available') is True
+        and isinstance(stored_heat_result, dict)
+    )
+    if snapshot_risk_ready:
+        heat_result = dict(stored_heat_result)
+        heat_risk_label = risk.get('level') or '暂不可用'
+        heat_actions = snapshot.get('actions') or []
+    else:
         heat_result = None
         heat_risk_label = '暂不可用'
         heat_actions = []
-    else:
-        consecutive_hot_days = get_consecutive_hot_days(
-            user_location,
-            today_max=weather_data.get('temperature_max')
-        )
-        heat_result = heat_service.calculate_heat_risk(
-            weather_data,
-            consecutive_hot_days=consecutive_hot_days
-        )
-        heat_risk_label = HEAT_RISK_LABELS.get(heat_result['risk_level'], '低风险')
-        heat_actions = _action_plan(heat_risk_label)
     dashboard_hero_theme = _dashboard_hero_theme(
         getattr(weather, 'temperature', None) if weather_available else None
     )
     dashboard_metric_cards = [] if is_guest else _dashboard_metric_cards(current_user.id)
-    forecast_days = _dashboard_forecast_days(user_location, today, weather_data)
-
-    # 如果是极端天气，生成预警（避免重复）
-    if weather_available and extreme_result['is_extreme'] and not used_cache:
-        recent_alert = WeatherAlert.query.filter(
-            WeatherAlert.location.in_(alert_locations),
-            WeatherAlert.alert_date >= utcnow() - timedelta(hours=6)
-        ).first()
-        if not recent_alert:
-            alert = weather_service.generate_weather_alert(user_location, weather_data)
-            if alert:
-                weather_alert = WeatherAlert(
-                    alert_date=utcnow(),
-                    location=alert['location'],
-                    alert_type=alert['alert_type'],
-                    alert_level=alert['alert_level'],
-                    description=alert['description'],
-                    affected_communities=json.dumps([user_location]),
-                    disease_correlation=json.dumps({})
-                )
-                db.session.add(weather_alert)
-                db.session.commit()
+    forecast_days = _dashboard_snapshot_forecast_days(snapshot, today) if snapshot_mode else []
 
     # 获取最新风险评估
     if is_guest:
@@ -392,38 +367,6 @@ def user_dashboard(force_elder=False):
         WeatherAlert.alert_date >= utcnow() - timedelta(days=1),
         WeatherAlert.location.in_(alert_locations)
     ).order_by(WeatherAlert.alert_date.desc()).limit(5).all()
-
-    # 如果没有预警但有极端天气，创建预警
-    if weather_available and not alerts and weather and weather.is_extreme:
-        from services.weather_service import WeatherService
-        weather_service = WeatherService()
-        weather_data = {
-            'temperature': weather.temperature,
-            'temperature_max': weather.temperature_max,
-            'temperature_min': weather.temperature_min,
-            'humidity': weather.humidity,
-            'aqi': weather.aqi,
-            'wind_speed': weather.wind_speed,
-        }
-        recent_alert = WeatherAlert.query.filter(
-            WeatherAlert.location.in_(alert_locations),
-            WeatherAlert.alert_date >= utcnow() - timedelta(hours=6)
-        ).first()
-        if not recent_alert:
-            alert = weather_service.generate_weather_alert(user_location, weather_data)
-            if alert:
-                weather_alert = WeatherAlert(
-                    alert_date=utcnow(),
-                    location=alert['location'],
-                    alert_type=alert['alert_type'],
-                    alert_level=alert['alert_level'],
-                    description=alert['description'],
-                    affected_communities=json.dumps([user_location]),
-                    disease_correlation=json.dumps({})
-                )
-                db.session.add(weather_alert)
-                db.session.commit()
-                alerts = [weather_alert]
 
     # 用药提醒（根据天气触发）
     reminders = []
@@ -501,7 +444,11 @@ def user_dashboard(force_elder=False):
             heat_result=heat_result,
             heat_risk_label=heat_risk_label,
             heat_actions=heat_actions,
-            is_guest=is_guest
+            is_guest=is_guest,
+            weather_snapshot_id=snapshot_id,
+            weather_snapshot_fetched_at=snapshot.get('fetched_at'),
+            weather_snapshot_display_time=snapshot_display_time(snapshot.get('fetched_at')),
+            weather_source_status=snapshot.get('source_status') or {},
         )
 
     alert_cards = [_dashboard_alert_card(alert) for alert in alerts]
@@ -523,7 +470,11 @@ def user_dashboard(force_elder=False):
                          alerts=alert_cards,
                          reminders=reminders,
                          notifications=notifications,
-                         is_guest=is_guest)
+                         is_guest=is_guest,
+                         weather_snapshot_id=snapshot_id,
+                         weather_snapshot_fetched_at=snapshot.get('fetched_at'),
+                         weather_snapshot_display_time=snapshot_display_time(snapshot.get('fetched_at')),
+                         weather_source_status=snapshot.get('source_status') or {})
 
 
 def elder_dashboard():

--- a/templates/risk.html
+++ b/templates/risk.html
@@ -10,6 +10,15 @@
         <div class="col-12">
             <h1 class="h2"><i class="bi bi-thermometer-sun"></i> 都昌高温风险与老人防护行动</h1>
             <p class="text-muted mb-0">基于都昌县当前天气的通用行动提示（不提供医疗诊断或治疗建议）。</p>
+            <p class="small text-muted mt-2 mb-0"
+               {% if weather_snapshot_id %}data-weather-snapshot-id="{{ weather_snapshot_id }}"{% endif %}>
+                {% if weather_snapshot_id %}
+                    数据更新时间：<time datetime="{{ weather_snapshot_fetched_at }}">{{ weather_snapshot_display_time }}</time>
+                    · 数据编号 {{ weather_snapshot_id[:8] }}
+                {% else %}
+                    暂无可用的公开天气快照
+                {% endif %}
+            </p>
         </div>
     </div>
 
@@ -38,13 +47,13 @@
                     <div class="mb-3" id="heatRiskAdjust" data-heat-risk-score="{{ heat_result.risk_score if heat_result and heat_result.risk_score is not none else 0 }}">
                         <div class="d-flex flex-wrap align-items-center gap-2">
                             <span class="text-muted small">个人阈值 {{ metric_info('personal_threshold') }}</span>
-                            <div class="btn-group btn-group-sm" role="group" aria-label="Heat threshold adjust">
+                            <div class="btn-group" role="group" aria-label="调整个人高温阈值">
                                 <input type="radio" class="btn-check" name="heatAdjustRisk" id="heatAdjustRiskLow" value="-0.1" data-heat-adjust>
-                                <label class="btn btn-outline-secondary" for="heatAdjustRiskLow">-0.1</label>
+                                <label class="btn btn-outline-secondary px-3 py-2" for="heatAdjustRiskLow">-0.1</label>
                                 <input type="radio" class="btn-check" name="heatAdjustRisk" id="heatAdjustRiskMid" value="0" data-heat-adjust>
-                                <label class="btn btn-outline-secondary" for="heatAdjustRiskMid">0</label>
+                                <label class="btn btn-outline-secondary px-3 py-2" for="heatAdjustRiskMid">0</label>
                                 <input type="radio" class="btn-check" name="heatAdjustRisk" id="heatAdjustRiskHigh" value="0.1" data-heat-adjust>
-                                <label class="btn btn-outline-secondary" for="heatAdjustRiskHigh">+0.1</label>
+                                <label class="btn btn-outline-secondary px-3 py-2" for="heatAdjustRiskHigh">+0.1</label>
                             </div>
                             <span class="badge bg-secondary" id="heatAdjustedBadge">--</span>
                             <span class="text-muted small">仅保存在本机</span>
@@ -77,11 +86,12 @@
             {% else %}
             <div class="card shadow-sm border-warning">
                 <div class="card-header bg-warning-subtle text-warning-emphasis">
-                    <h5 class="mb-0"><i class="bi bi-cloud-slash"></i> 天气更新中</h5>
+                    <h5 class="mb-0"><i class="bi bi-cloud-slash"></i> 公开天气快照暂未就绪，天气更新中</h5>
                 </div>
                 <div class="card-body">
                     <div class="mb-2 text-muted">地区：{{ location }}</div>
-                    <p class="mb-0">风险等级暂不显示。你可以先查看通用防护和附近避暑资源。</p>
+                    <p class="mb-2">风险等级暂不显示。此页为公开数据，登录不会改变当前快照状态。</p>
+                    <p class="mb-0 text-muted small">系统完成下一次县级天气同步后会自动恢复；现在可先查看通用防护和附近避暑资源。</p>
                 </div>
             </div>
             {% endif %}
@@ -123,10 +133,10 @@
             {% endif %}
             <div class="card shadow-sm mb-3">
                 <div class="card-body">
-                    <h6 class="mb-2"><i class="bi bi-clipboard-check"></i> 去行动打卡</h6>
-                    <p class="text-muted small">使用短码完成今日确认或求助。</p>
+                    <h6 class="mb-2"><i class="bi bi-clipboard-check"></i> 去宜老平安小程序打卡</h6>
+                    <p class="text-muted small">网页会先说明交接方式；实际确认和求助在微信小程序完成。</p>
                     <a class="btn btn-primary w-100" href="{{ url_for('public.elder_entry') }}">
-                        进入行动入口
+                        查看小程序交接方式
                     </a>
                 </div>
             </div>

--- a/templates/user_dashboard.html
+++ b/templates/user_dashboard.html
@@ -60,6 +60,11 @@
                     <span>家庭照护今日页</span>
                     <span>{{ today_date or '今天' }}</span>
                     <span><i class="bi bi-geo-alt"></i> {{ current_location or '未设置' }}</span>
+                    {% if weather_snapshot_id %}
+                    <span data-weather-snapshot-id="{{ weather_snapshot_id }}">
+                        数据 {{ weather_snapshot_id[:8] }} · {{ weather_snapshot_display_time }}
+                    </span>
+                    {% endif %}
                 </div>
                 <h1>
                     {% if risk_level in ['high', 'extreme'] %}
@@ -82,7 +87,7 @@
                 </p>
 
                 <div class="yl-academic-actions">
-                    <a class="btn btn-primary" href="{{ url_for('public.action_check') }}">记录今天是否做到</a>
+                    <a class="btn btn-primary" href="{{ url_for('public.elder_entry') }}">去宜老平安小程序打卡</a>
                     <a class="btn btn-outline-secondary" href="{{ url_for('tools.forecast_7day') }}">看 7 天趋势</a>
                 </div>
 
@@ -113,7 +118,7 @@
                     <span>当前温度</span>
                     <strong>
                     {% if weather_available and weather.temperature is not none %}
-                        <span class="yl-count" data-target="{{ weather.temperature }}" data-decimals="0">{{ weather.temperature }}</span>
+                        <span>{{ weather.temperature }}</span>
                     {% else %}
                         --
                     {% endif %}<small>°C</small>
@@ -135,7 +140,7 @@
                         <span>健康风险 {{ metric_info('heat_risk_score', heat_context) }}</span>
                         <strong class="{{ risk_score_class }}">
                             {% if risk_score is not none %}
-                                <span class="yl-count" data-target="{{ risk_score }}" data-decimals="0">{{ risk_score }}</span>
+                                <span>{{ risk_score }}</span>
                             {% else %}
                                 --
                             {% endif %}
@@ -177,7 +182,7 @@
             <strong>{{ heat_actions[0].title }}</strong>
             <p>{{ heat_actions[0].detail }}</p>
         </div>
-        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('public.action_check') }}">去打卡 <i class="bi bi-arrow-right"></i></a>
+        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('public.elder_entry') }}">查看小程序交接方式 <i class="bi bi-arrow-right"></i></a>
     </section>
     {% endif %}
 

--- a/templates/user_dashboard.html
+++ b/templates/user_dashboard.html
@@ -224,7 +224,7 @@
                         <img src="{{ url_for('static', filename='illustrations/dashboard/today-actions.png') }}" alt="" width="1254" height="1254" loading="lazy" decoding="async">
                     </div>
                 </div>
-                <a class="btn btn-sm btn-outline-primary" href="{{ url_for('public.action_check') }}">打卡 <i class="bi bi-arrow-right"></i></a>
+                <a class="btn btn-sm btn-outline-primary" href="{{ url_for('public.elder_entry') }}">去宜老平安小程序打卡 <i class="bi bi-arrow-right"></i></a>
             </div>
             <div class="yl-action-list mt-3">
                 {% if not weather_available %}

--- a/tests/test_dashboard_temperature_theme.py
+++ b/tests/test_dashboard_temperature_theme.py
@@ -56,31 +56,39 @@ def test_dashboard_renders_weather_alert_real_fields_with_local_date(
     db_session,
     monkeypatch,
 ):
-    from core.db_models import User, WeatherAlert
+    from core.db_models import User
 
     fixed_now = datetime(2026, 1, 1, 20, 0, tzinfo=timezone.utc)
     user = User.query.filter_by(username='testuser').one()
     user.community = '都昌'
     app.config['QWEATHER_CANONICAL_LOCATION'] = '116.20,29.27'
-    db_session.add(WeatherAlert(
-        alert_date=datetime(2026, 1, 1, 18, 0, tzinfo=timezone.utc),
-        location='116.20,29.27',
-        alert_type='高温预警',
-        alert_level='红色',
-        description='测试预警详情',
-    ))
     db_session.commit()
 
     monkeypatch.setattr('services.user.dashboard_service.utcnow', lambda: fixed_now)
     monkeypatch.setattr(
-        'services.user.dashboard_service.get_weather_with_cache',
-        lambda _location: ({'data_source': 'Demo', 'is_mock': True}, False),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        'services.user.dashboard_service.get_qweather_forecast_with_cache',
-        lambda _location, days=7: ([], False, {'error': 'qweather_unavailable'}),
-        raising=False,
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: {
+            'snapshot_id': 'dashboard-warning-snapshot',
+            'fetched_at': '2026-01-02T02:00:00+08:00',
+            'current_stale': True,
+            'forecast_stale': True,
+            'warnings_stale': False,
+            'risk_stale': True,
+            'location': {'name': '都昌县', 'code': '116.20,29.27'},
+            'current': {'is_mock': True},
+            'forecast': [],
+            'warnings': [{
+                'title': '高温预警',
+                'level': '红色',
+                'text': '测试预警详情',
+                'start_time': '2026-01-02T02:00:00+08:00',
+            }],
+            'risk': {'available': False},
+            'actions': [],
+            'source_status': {
+                'warnings': {'available': True, 'stale': False},
+            },
+        },
     )
 
     response = authenticated_client.get('/dashboard')

--- a/tests/test_dashboard_temperature_theme.py
+++ b/tests/test_dashboard_temperature_theme.py
@@ -75,10 +75,12 @@ def test_dashboard_renders_weather_alert_real_fields_with_local_date(
     monkeypatch.setattr(
         'services.user.dashboard_service.get_weather_with_cache',
         lambda _location: ({'data_source': 'Demo', 'is_mock': True}, False),
+        raising=False,
     )
     monkeypatch.setattr(
         'services.user.dashboard_service.get_qweather_forecast_with_cache',
         lambda _location, days=7: ([], False, {'error': 'qweather_unavailable'}),
+        raising=False,
     )
 
     response = authenticated_client.get('/dashboard')

--- a/tests/test_miniprogram_runtime.py
+++ b/tests/test_miniprogram_runtime.py
@@ -157,10 +157,13 @@ def test_snapshot_fresh_at_2959_and_stale_at_3001(app, db_session):
 
         record = MiniProgramSnapshot.query.filter_by(snapshot_id=snapshot_id).one()
         fresh = snapshot_payload(record, now=fetched_at + timedelta(minutes=29, seconds=59))
+        exact_expiry = snapshot_payload(record, now=fetched_at + timedelta(minutes=30))
         stale = snapshot_payload(record, now=fetched_at + timedelta(minutes=30, seconds=1))
 
     assert fresh["ttl_seconds"] == 1800
     assert fresh["stale"] is False
+    assert exact_expiry["stale"] is True
+    assert exact_expiry["current_stale"] is True
     assert stale["stale"] is True
     assert fresh["snapshot_id"] == stale["snapshot_id"]
     assert fresh["family_reminder"]["date"]

--- a/tests/test_motion_widgets.py
+++ b/tests/test_motion_widgets.py
@@ -39,6 +39,53 @@ def _login_as(client, user_id, csrf_token='test-csrf-token'):
         session['_csrf_token'] = csrf_token
 
 
+def _dashboard_snapshot(current=None, forecast=None, *, risk_available=True):
+    """构造 dashboard 契约使用的县级持久化快照。"""
+    weather = current or {
+        'temperature': 27.5,
+        'temperature_max': 30,
+        'temperature_min': 22,
+        'humidity': 64,
+        'pressure': 1008,
+        'weather_condition': '多云',
+        'wind_speed': 2.5,
+        'aqi': 42,
+        'is_mock': False,
+        'data_source': 'QWeather',
+    }
+    risk = {
+        'available': risk_available,
+        'level': '低风险' if risk_available else '未知',
+        'score': 28 if risk_available else None,
+        'calculation': {
+            'heat_result': {
+                'risk_level': 'low',
+                'risk_score': 28,
+                'heat_index': 28,
+                'night_min': weather.get('temperature_min'),
+                'consecutive_hot_days': 0,
+            },
+        } if risk_available else {},
+    }
+    return {
+        'snapshot_id': '87654321-1234-5678-1234-567812345678',
+        'fetched_at': '2026-08-12T01:02:03+00:00',
+        'expires_at': '2026-08-12T01:32:03+00:00',
+        'available': True,
+        'stale': False,
+        'current_stale': False,
+        'forecast_stale': False,
+        'warnings_stale': False,
+        'risk_stale': not risk_available,
+        'location': {'name': '都昌县', 'code': '116.20,29.27'},
+        'current': weather,
+        'forecast': forecast or [],
+        'risk': risk,
+        'actions': [{'title': '日常补水', 'detail': '少量多次喝水'}] if risk_available else [],
+        'source_status': {},
+    }
+
+
 def test_dashboard_renders_temperature_and_registered_metric_widgets(client, db_session, monkeypatch):
     from core.db_models import FamilyMember, FamilyMemberProfile, User
 
@@ -61,25 +108,8 @@ def test_dashboard_renders_temperature_and_registered_metric_widgets(client, db_
     db_session.commit()
     _login_as(client, user.id)
     monkeypatch.setattr(
-        'services.user.dashboard_service.get_weather_with_cache',
-        lambda location: ({
-            'temperature': 27.5,
-            'temperature_max': 30,
-            'temperature_min': 22,
-            'humidity': 64,
-            'pressure': 1008,
-            'weather_condition': '多云',
-            'wind_speed': 2.5,
-            'aqi': 42,
-            'is_mock': False,
-            'data_source': 'QWeather',
-        }, False),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        'services.user.dashboard_service.get_qweather_forecast_with_cache',
-        lambda location, days=7: ([], False, {'error': 'qweather_unavailable'}),
-        raising=False,
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: _dashboard_snapshot(),
     )
 
     response = client.get('/dashboard')
@@ -93,7 +123,126 @@ def test_dashboard_renders_temperature_and_registered_metric_widgets(client, db_
     assert '橙线 = 当前登记值定位' in body
 
 
-def test_dashboard_forecast_uses_qweather_cards(client, db_session, monkeypatch):
+def test_dashboard_uses_one_persisted_snapshot_without_cache_or_weather_write(
+    client,
+    db_session,
+    monkeypatch,
+):
+    """正式快照存在时，天气、风险和页面编号必须来自同一份只读记录。"""
+    from core.db_models import User, WeatherData
+
+    user = User(username='dashboard_snapshot_user', role='user', community='都昌')
+    user.set_password('testpass')
+    db_session.add(user)
+    db_session.commit()
+    _login_as(client, user.id)
+    snapshot = {
+        'snapshot_id': '12345678-1234-5678-1234-567812345678',
+        'fetched_at': '2026-08-12T01:02:03+00:00',
+        'expires_at': '2026-08-12T01:32:03+00:00',
+        'available': True,
+        'stale': False,
+        'current_stale': False,
+        'forecast_stale': False,
+        'warnings_stale': False,
+        'risk_stale': False,
+        'location': {'name': '都昌县', 'code': '116.20,29.27'},
+        'current': {
+            'temperature': 31.25,
+            'temperature_max': 35,
+            'temperature_min': 25,
+            'humidity': 66,
+            'pressure': 1005,
+            'weather_condition': '晴',
+            'wind_speed': 2,
+            'aqi': 40,
+            'data_source': 'QWeather',
+            'is_mock': False,
+        },
+        'forecast': [],
+        'risk': {
+            'available': True,
+            'level': '中风险',
+            'score': 66,
+            'calculation': {
+                'heat_result': {
+                    'risk_level': 'medium',
+                    'risk_score': 66,
+                    'heat_index': 35,
+                    'night_min': 25,
+                    'consecutive_hot_days': 1,
+                },
+            },
+        },
+        'actions': [{'title': '及时补水', 'detail': '少量多次喝水'}],
+        'source_status': {'current': {'available': True, 'stale': False}},
+    }
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: snapshot,
+    )
+    from services.user import dashboard_service
+    assert not hasattr(dashboard_service, 'get_weather_with_cache')
+    assert not hasattr(dashboard_service, 'get_qweather_forecast_with_cache')
+
+    response = client.get('/dashboard')
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert 'data-weather-snapshot-id="12345678-1234-5678-1234-567812345678"' in body
+    assert '2026-08-12 09:02' in body
+    assert '<span>31.25</span>' in body
+    assert '<span>66</span>' in body
+    assert 'data-target="31.25"' not in body
+    assert 'data-target="66"' not in body
+    assert '中风险' in body
+    assert WeatherData.query.count() == 0
+
+
+def test_dashboard_without_snapshot_fails_closed_without_weather_cache(
+    client,
+    db_session,
+    monkeypatch,
+):
+    """快照缺失或读取失败时，登录页不能私自切换到另一套天气来源。"""
+    from core.db_models import User, WeatherData
+
+    user = User(username='dashboard_missing_snapshot', role='user', community='都昌')
+    user.set_password('testpass')
+    db_session.add(user)
+    db_session.commit()
+    _login_as(client, user.id)
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: {
+            'snapshot_id': None,
+            'current_stale': True,
+            'risk_stale': True,
+            'forecast_stale': True,
+            'current': {'is_mock': True},
+            'risk': {'available': False},
+            'forecast': [],
+            'source_status': {'status': 'missing'},
+        },
+    )
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_weather_with_cache',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError('无快照时也不得切换到另一份天气缓存')
+        ),
+        raising=False,
+    )
+
+    response = client.get('/dashboard')
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert '天气正在更新，风险等级暂不显示' in body
+    assert 'data-weather-snapshot-id=' not in body
+    assert WeatherData.query.count() == 0
+
+
+def test_dashboard_forecast_uses_persisted_snapshot_cards(client, db_session, monkeypatch):
     from core.db_models import User
 
     user = User(username='dashboard_qweather_user', role='user', community='都昌')
@@ -118,62 +267,26 @@ def test_dashboard_forecast_uses_qweather_cards(client, db_session, monkeypatch)
         })
     qweather_days[1]['temperature_max'] = 26
     qweather_days[1]['temperature_min'] = 18
+    qweather_days[1]['risk_level'] = '中风险'
+    qweather_days[1]['risk_score'] = 43
 
-    captured = {}
-
-    def fake_qweather(location, days=7):
-        captured['location'] = location
-        captured['days'] = days
-        return qweather_days, False, {'source': 'QWeather'}
-
-    class FakeForecastService:
-        def generate_7day_forecast(self, forecast_temps, start_date=None, context=None):
-            captured['start_date'] = start_date
-            captured['context'] = context
-            forecasts = []
-            for idx, _entry in enumerate(forecast_temps):
-                day = start + timedelta(days=idx)
-                forecasts.append({
-                    'date': day.strftime('%Y-%m-%d'),
-                    'probability_high_visits': 10 + idx,
-                    'composite_exposure': {'score': 18 + idx, 'level': '低'},
-                })
-            return forecasts, {'recommendations': []}
-
+    for idx, item in enumerate(qweather_days):
+        item.setdefault('risk_score', 18 + idx)
+        item.setdefault('risk_level', '低风险')
+        item['risk_available'] = True
     monkeypatch.setattr(
-        'services.user.dashboard_service.get_qweather_forecast_with_cache',
-        fake_qweather,
-        raising=False,
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: _dashboard_snapshot(forecast=qweather_days),
     )
-    monkeypatch.setattr(
-        'services.user.dashboard_service.get_weather_with_cache',
-        lambda _location: ({
-            'temperature': 27,
-            'temperature_max': 30,
-            'temperature_min': 22,
-            'humidity': 64,
-            'pm25': 18,
-            'aqi': 42,
-            'data_source': 'QWeather',
-            'is_mock': False,
-        }, False),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        'services.user.dashboard_service.get_forecast_service',
-        lambda: FakeForecastService(),
-        raising=False,
-    )
+    from services.user import dashboard_service
+    assert not hasattr(dashboard_service, 'get_qweather_forecast_with_cache')
 
     response = client.get('/dashboard')
 
     assert response.status_code == 200
     body = response.get_data(as_text=True)
-    assert captured['location'] == '都昌'
-    assert captured['days'] == 7
-    assert captured['start_date'] == start
-    assert captured['context'] == {'pm25': 18.0, 'aqi': 42.0}
     assert '26° / 18°' in body
+    assert '中风险' in body
     assert '演示风险' not in body
     assert '34°/26°' not in body
 
@@ -202,7 +315,7 @@ def test_dashboard_forecast_failure_does_not_render_demo_heat(client, db_session
     assert '34°/26°' not in body
 
 
-def test_dashboard_forecast_generation_failure_marks_risk_unknown(client, db_session, monkeypatch):
+def test_dashboard_forecast_snapshot_marks_unavailable_risk_unknown(client, db_session, monkeypatch):
     from core.db_models import User
 
     user = User(username='dashboard_forecast_unknown_user', role='user', community='都昌')
@@ -226,19 +339,11 @@ def test_dashboard_forecast_generation_failure_marks_risk_unknown(client, db_ses
             'is_mock': False,
         })
 
-    class FailingForecastService:
-        def generate_7day_forecast(self, forecast_temps, start_date=None, context=None):
-            raise RuntimeError('forecast unavailable')
-
+    for item in qweather_days:
+        item.update(risk_available=False, risk_score=None, risk_level='未知')
     monkeypatch.setattr(
-        'services.user.dashboard_service.get_qweather_forecast_with_cache',
-        lambda location, days=7: (qweather_days, False, {'source': 'QWeather'}),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        'services.user.dashboard_service.get_forecast_service',
-        lambda: FailingForecastService(),
-        raising=False,
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: _dashboard_snapshot(forecast=qweather_days),
     )
 
     response = client.get('/dashboard')

--- a/tests/test_weather_cache_sync.py
+++ b/tests/test_weather_cache_sync.py
@@ -798,4 +798,5 @@ def test_unavailable_warnings_do_not_feed_family_reminder(app, db_session, monke
 
     assert payload["warnings_stale"] is False
     assert payload["source_status"]["warnings"]["available"] is False
+    assert payload["warnings"] == []
     assert captured["warnings"] == []

--- a/tests/test_weather_cache_sync.py
+++ b/tests/test_weather_cache_sync.py
@@ -644,3 +644,112 @@ def test_snapshot_expiry_uses_earliest_required_source(app, db_session):
     assert payload["expires_at"] == (forecast_time + timedelta(minutes=30)).isoformat()
     assert payload["source_status"]["forecast"]["fetched_at"] == forecast_time.isoformat()
     assert payload["source_status"]["budget_guard"] == "enabled"
+
+
+def test_stale_forecast_does_not_hide_fresh_current_risk(app, db_session):
+    """总快照过期时，各页面仍应按自己依赖的来源判断可用性。"""
+    from core.time_utils import utcnow
+    from services.miniprogram_service import persist_snapshot, snapshot_payload
+
+    cycle_time = utcnow().replace(microsecond=0)
+    forecast_time = cycle_time - timedelta(minutes=31)
+    current = {
+        "temperature": 35,
+        "temperature_max": 38,
+        "temperature_min": 27,
+        "humidity": 70,
+        "data_source": "QWeather",
+        "is_mock": False,
+    }
+    forecast = [{
+        "date": cycle_time.date().isoformat(),
+        "temperature_max": 38,
+        "temperature_min": 27,
+        "temperature_mean": 32.5,
+        "humidity": 70,
+        "data_source": "QWeather",
+        "is_mock": False,
+    }]
+    with app.app_context():
+        record = persist_snapshot(
+            current,
+            forecast,
+            [],
+            fetched_at=cycle_time,
+            forecast_meta={"source": "QWeather"},
+            warning_status={"available": True, "status": "ok"},
+            source_timing={
+                "current": {
+                    "fetched_at": cycle_time,
+                    "expires_at": cycle_time + timedelta(minutes=30),
+                },
+                "forecast": {
+                    "fetched_at": forecast_time,
+                    "expires_at": forecast_time + timedelta(minutes=30),
+                },
+                "warnings": {
+                    "fetched_at": cycle_time,
+                    "expires_at": cycle_time + timedelta(minutes=30),
+                },
+            },
+        )
+        payload = snapshot_payload(record, now=cycle_time)
+
+    assert payload["stale"] is True
+    assert payload["forecast_stale"] is True
+    assert payload["current_stale"] is False
+    assert payload["warnings_stale"] is False
+    assert payload["risk_stale"] is False
+    assert payload["risk"]["available"] is True
+    assert payload["source_status"]["forecast"]["stale"] is True
+    assert payload["source_status"]["risk"]["stale"] is False
+
+
+def test_stale_warnings_do_not_feed_family_reminder(app, db_session, monkeypatch):
+    """预警来源过期时，提醒只能继续使用新鲜的当前天气。"""
+    from core.time_utils import utcnow
+    from services import miniprogram_service
+
+    cycle_time = utcnow().replace(microsecond=0)
+    captured = {}
+
+    def fake_reminder(current, warnings, **_kwargs):
+        captured["warnings"] = warnings
+        return {"date": cycle_time.date().isoformat(), "message": "安全提醒"}
+
+    monkeypatch.setattr(
+        miniprogram_service,
+        "build_public_family_reminder",
+        fake_reminder,
+    )
+    with app.app_context():
+        record = miniprogram_service.persist_snapshot(
+            {
+                "temperature": 35,
+                "temperature_max": 38,
+                "temperature_min": 27,
+                "humidity": 70,
+                "data_source": "QWeather",
+                "is_mock": False,
+            },
+            [],
+            [{"title": "旧高温预警"}],
+            fetched_at=cycle_time,
+            warning_status={"available": True, "status": "ok"},
+            source_timing={
+                "current": {
+                    "fetched_at": cycle_time,
+                    "expires_at": cycle_time + timedelta(minutes=30),
+                },
+                "warnings": {
+                    "fetched_at": cycle_time - timedelta(minutes=31),
+                    "expires_at": cycle_time - timedelta(minutes=1),
+                },
+            },
+        )
+        captured.clear()
+        payload = miniprogram_service.snapshot_payload(record, now=cycle_time)
+
+    assert payload["warnings_stale"] is True
+    assert payload["risk_stale"] is False
+    assert captured["warnings"] == []

--- a/tests/test_weather_cache_sync.py
+++ b/tests/test_weather_cache_sync.py
@@ -753,3 +753,49 @@ def test_stale_warnings_do_not_feed_family_reminder(app, db_session, monkeypatch
     assert payload["warnings_stale"] is True
     assert payload["risk_stale"] is False
     assert captured["warnings"] == []
+
+
+def test_unavailable_warnings_do_not_feed_family_reminder(app, db_session, monkeypatch):
+    """来源失败但记录尚未总过期时，也不能把旧预警继续用于提醒。"""
+    from core.time_utils import utcnow
+    from services import miniprogram_service
+
+    cycle_time = utcnow().replace(microsecond=0)
+    captured = {}
+
+    def fake_reminder(current, warnings, **_kwargs):
+        captured["warnings"] = warnings
+        return {"date": cycle_time.date().isoformat(), "message": "安全提醒"}
+
+    monkeypatch.setattr(
+        miniprogram_service,
+        "build_public_family_reminder",
+        fake_reminder,
+    )
+    with app.app_context():
+        record = miniprogram_service.persist_snapshot(
+            {
+                "temperature": 35,
+                "temperature_max": 38,
+                "temperature_min": 27,
+                "humidity": 70,
+                "data_source": "QWeather",
+                "is_mock": False,
+            },
+            [],
+            [{"title": "来源失败前的旧预警"}],
+            fetched_at=cycle_time,
+            warning_status={"available": False, "status": "fetch_failed"},
+            source_timing={
+                "current": {
+                    "fetched_at": cycle_time,
+                    "expires_at": cycle_time + timedelta(minutes=30),
+                },
+            },
+        )
+        captured.clear()
+        payload = miniprogram_service.snapshot_payload(record, now=cycle_time)
+
+    assert payload["warnings_stale"] is False
+    assert payload["source_status"]["warnings"]["available"] is False
+    assert captured["warnings"] == []


### PR DESCRIPTION
1. 这次改了什么：统一 Web 与小程序的县级天气快照和分组件新鲜度，并让关键数值首帧直接显示最终值。\n\n2. 为什么要改：解决登录前后风险和温度来源不一致、预报过期牵连当前风险、离线缓存跨过期仍展示旧结论、dashboard GET 写天气记录等问题。\n\n3. 怎么测试：Python 专项 142 passed；小程序全部 Node 测试 311 passed；py_compile 与 git diff --check 通过。\n\n4. 文件去向：全部保留在主仓库，无文件迁移。\n\n5. 未修改 .sh 或 .githooks。\n\n6. 本 PR 不需要 Notion 回填。\n\n未部署，待集成分支联合浏览器与微信开发者工具回归。