### PR TITLE
修复输入边界与行动交接

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,9 @@ WX_MINIPROGRAM_SECRET=
 # 两项均使用独立的 32 字节以上随机值。
 WX_MINIPROGRAM_OPENID_PEPPER=
 WX_MINIPROGRAM_SESSION_SECRET=
+# 可选：官方永久小程序码图片。填写 static 下相对文件名（如 images/action-code.png）
+# 或 HTTPS 图片 URL；缺失或文件无效时网页不会显示占位码或假二维码。
+WX_MINIPROGRAM_ACTION_CODE_IMAGE=
 # 网页与微信一次性绑定码专用 pepper，必须与上面两项及 SECRET_KEY 分开生成。
 ACCOUNT_LINK_CODE_PEPPER=
 # 更新隐私指引内容时同步递增版本，旧会话会要求重新同意。

--- a/blueprints/tools.py
+++ b/blueprints/tools.py
@@ -1,20 +1,22 @@
 # -*- coding: utf-8 -*-
 """Tooling and prediction pages."""
 from datetime import datetime
+from decimal import Decimal, InvalidOperation
 import math
+import re
 
 from flask import Blueprint, current_app, flash, render_template, request
 from flask_login import current_user, login_required
 
-from core.db_models import FamilyMember
+from core.guest import is_guest_user
+from core.location_resolution import get_user_location_options, resolve_user_location
+from core.db_models import Community, FamilyMember
 from core.time_utils import today_local
 from core.weather import (
     ensure_user_location_valid,
-    get_location_options,
     get_qweather_forecast_with_cache,
     get_weather_with_cache,
     is_qweather_online_weather,
-    normalize_location_name,
 )
 from services.chronic_risk_service import get_chronic_service
 from services.forecast_cards import build_forecast_cards
@@ -55,12 +57,31 @@ def _selected_member(member_id):
     return FamilyMember.query.filter_by(id=parsed_id, user_id=current_user.id).first()
 
 
-def _normalized_location(raw_location):
-    """清洗并标准化地点输入。"""
-    location = sanitize_input(raw_location, max_length=100)
-    if location:
-        return normalize_location_name(location)
-    return ensure_user_location_valid()
+def _tool_location_options():
+    """合并静态县内别名与管理员维护的社区表。"""
+    dynamic_names = []
+    try:
+        communities = Community.query.with_entities(
+            Community.name,
+        ).all()
+    except Exception as exc:
+        current_app.logger.warning('读取工具页社区候选失败: %s', exc)
+        communities = []
+    for (name,) in communities:
+        clean_name = str(name or '').strip()
+        if clean_name:
+            dynamic_names.append(clean_name)
+    return get_user_location_options(extra_names=dynamic_names)
+
+
+def _resolve_tool_location(raw_location, *, location_options=None):
+    """解析工具页地点，非法输入不得回退到默认县域。"""
+    raw = raw_location.strip() if isinstance(raw_location, str) else ''
+    candidate = raw or ensure_user_location_valid()
+    return resolve_user_location(
+        candidate,
+        extra_names=location_options or _tool_location_options(),
+    )
 
 
 def _coerce_age(raw_age, default_age):
@@ -215,16 +236,72 @@ def _build_chronic_breakdown(result, adherence, symptoms):
     return breakdown[:4]
 
 
+_PLAIN_DECIMAL_RE = re.compile(r'^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$')
+
+
+def _parse_optional_vital(raw_value, *, label, minimum, maximum):
+    """只接受短、有限且不使用指数写法的十进制生命体征。"""
+    if raw_value is None:
+        return None, None
+    raw = str(raw_value).strip()
+    if not raw:
+        return None, None
+    if len(raw) > 20:
+        return None, f'{label}输入过长，请重新填写。'
+    if not _PLAIN_DECIMAL_RE.fullmatch(raw):
+        return None, f'{label}格式不正确，请填写普通数字。'
+    try:
+        value = Decimal(raw)
+    except InvalidOperation:
+        return None, f'{label}格式不正确，请填写普通数字。'
+    if not value.is_finite():
+        return None, f'{label}格式不正确，请填写有限数字。'
+    if value < Decimal(str(minimum)) or value > Decimal(str(maximum)):
+        return None, f'{label}需在 {minimum} 到 {maximum} 之间。'
+    return float(value), None
+
+
 def _parse_chronic_vitals(form_state):
-    """解析慢病表单中的自测血压/血糖。"""
-    sbp = parse_float(form_state.get('sbp'))
-    fbg = parse_float(form_state.get('fbg'))
+    """严格解析慢病表单中的可选血压与血糖。"""
     vitals = {}
-    if sbp is not None and 60 <= sbp <= 260:
+    errors = {}
+    sbp, sbp_error = _parse_optional_vital(
+        form_state.get('sbp'),
+        label='最高收缩压',
+        minimum=60,
+        maximum=260,
+    )
+    fbg, fbg_error = _parse_optional_vital(
+        form_state.get('fbg'),
+        label='空腹血糖',
+        minimum=2,
+        maximum=30,
+    )
+    if sbp_error:
+        errors['sbp'] = sbp_error
+    elif sbp is not None:
         vitals['sbp'] = sbp
-    if fbg is not None and 2 <= fbg <= 30:
+    if fbg_error:
+        errors['fbg'] = fbg_error
+    elif fbg is not None:
         vitals['fbg'] = fbg
-    return vitals
+    return vitals, errors
+
+
+def _classified_ml_error(raw_error=None, *, code='model_unavailable'):
+    """把模型内部错误收敛为可安全展示的有限分类。"""
+    normalized = str(raw_error or '').strip().lower()
+    if code == 'auth_required':
+        message = '游客可以浏览说明；生成个人类别线索需要注册或登录正式账号。'
+    elif code == 'invalid_location':
+        message = str(raw_error)
+    elif code == 'weather_unavailable':
+        message = '健康关注线索暂时无法生成：官方天气快照正在更新，请稍后再试。'
+    elif any(marker in normalized for marker in ('model', '模型', 'load', '加载')):
+        message = '类别线索模型正在维护，请稍后再试。'
+    else:
+        message = '类别线索服务暂时不可用，请稍后再试。'
+    return {'code': code, 'message': message}
 
 
 def _normalize_chronic_suggestions(items):
@@ -245,6 +322,7 @@ def ml_prediction():
     """ML预测页面。"""
     family_members = _tool_family_members()
     current_location = ensure_user_location_valid()
+    location_options = _tool_location_options()
     form_state = {
         'member_id': '',
         'location': current_location,
@@ -253,48 +331,72 @@ def ml_prediction():
     prediction = None
     factors = None
     prediction_error = None
+    response_status = 200
 
     if request.method == 'POST':
         selected_member = _selected_member(request.form.get('member_id'))
         default_age = selected_member.age if selected_member and selected_member.age else current_user.age or 65
         default_gender = selected_member.gender if selected_member and selected_member.gender else current_user.gender or '男'
+        raw_location = request.form.get('location')
+        location_resolution = _resolve_tool_location(
+            raw_location,
+            location_options=location_options,
+        )
         form_state = {
             'member_id': str(selected_member.id) if selected_member else '',
-            'location': _normalized_location(request.form.get('location')),
+            'location': (
+                location_resolution.raw
+                if not location_resolution.valid
+                else location_resolution.value
+            ),
             'age': _coerce_age(request.form.get('age'), default_age),
         }
 
-        weather_info, _ = get_weather_with_cache(form_state['location'])
-        if not is_qweather_online_weather(weather_info):
-            prediction_error = '天气正在更新，类别线索暂不显示。请稍后再试。'
+        if is_guest_user(current_user):
+            prediction_error = _classified_ml_error(code='auth_required')
+            response_status = 403
+        elif not location_resolution.valid:
+            prediction_error = _classified_ml_error(
+                location_resolution.error,
+                code='invalid_location',
+            )
+            response_status = 422
         else:
-            user_info = {
-                'age': form_state['age'],
-                'gender': default_gender,
-            }
-            result = get_ml_service().predict_disease_risk(user_info, weather_info)
-            if result.get('success'):
-                prediction = []
-                for rank, item in enumerate((result.get('predictions') or [])[:3], start=1):
-                    adjusted_probability = float(item.get('probability') or 0.0)
-                    original_probability = float(
-                        item.get('original_probability')
-                        if item.get('original_probability') is not None
-                        else adjusted_probability
-                    )
-                    multiplier = item.get('weather_multiplier')
-                    if multiplier is None:
-                        multiplier = adjusted_probability / original_probability if original_probability > 0 else 1.0
-                    prediction.append({
-                        'disease': item.get('disease', '未知风险'),
-                        'score': round(adjusted_probability * 100.0, 1),
-                        'original_score': round(original_probability * 100.0, 1),
-                        'weather_multiplier': round(float(multiplier), 3),
-                        'label': f'关注排序第 {rank}',
-                    })
-                factors = _build_ml_factor_cards(result, form_state['age'], weather_info)
+            weather_info, _ = get_weather_with_cache(form_state['location'])
+            if not is_qweather_online_weather(weather_info):
+                prediction_error = _classified_ml_error(code='weather_unavailable')
             else:
-                prediction_error = result.get('error') or '预测暂时不可用，请稍后再试。'
+                user_info = {
+                    'age': form_state['age'],
+                    'gender': default_gender,
+                }
+                try:
+                    result = get_ml_service().predict_disease_risk(user_info, weather_info)
+                except Exception:
+                    current_app.logger.exception('ML 类别线索服务调用失败')
+                    result = {'success': False, 'error': 'service_exception'}
+                if result.get('success'):
+                    prediction = []
+                    for rank, item in enumerate((result.get('predictions') or [])[:3], start=1):
+                        adjusted_probability = float(item.get('probability') or 0.0)
+                        original_probability = float(
+                            item.get('original_probability')
+                            if item.get('original_probability') is not None
+                            else adjusted_probability
+                        )
+                        multiplier = item.get('weather_multiplier')
+                        if multiplier is None:
+                            multiplier = adjusted_probability / original_probability if original_probability > 0 else 1.0
+                        prediction.append({
+                            'disease': item.get('disease', '未知风险'),
+                            'score': round(adjusted_probability * 100.0, 1),
+                            'original_score': round(original_probability * 100.0, 1),
+                            'weather_multiplier': round(float(multiplier), 3),
+                            'label': f'关注排序第 {rank}',
+                        })
+                    factors = _build_ml_factor_cards(result, form_state['age'], weather_info)
+                else:
+                    prediction_error = _classified_ml_error(result.get('error'))
 
     return render_template(
         'ml_prediction.html',
@@ -303,7 +405,9 @@ def ml_prediction():
         prediction=prediction,
         factors=factors,
         prediction_error=prediction_error,
-    )
+        is_guest=is_guest_user(current_user),
+        location_options=location_options,
+    ), response_status
 
 
 @bp.route('/ai-qa', endpoint='ai_qa')
@@ -318,12 +422,37 @@ def ai_qa():
 @login_required
 def forecast_7day():
     """7天健康预测页面"""
-    current_location = _normalized_location(request.args.get('location'))
+    location_options = _tool_location_options()
+    location_resolution = _resolve_tool_location(
+        request.args.get('location'),
+        location_options=location_options,
+    )
+    current_location = (
+        location_resolution.value
+        if location_resolution.valid
+        else location_resolution.raw
+    )
     start_date = today_local()
     forecast_days = []
     weekly_tips = None
     forecast_error = None
+    location_error = None
     forecast_meta = {'source': 'QWeather'}
+    if not location_resolution.valid:
+        location_error = location_resolution.error
+        return render_template(
+            'forecast_7day.html',
+            family_members=_tool_family_members(),
+            current_location=current_location,
+            location_input=location_resolution.raw,
+            location_options=location_options,
+            location_error=location_error,
+            forecast_days=[],
+            forecast_error=None,
+            forecast_meta=forecast_meta,
+            weekly_tips=None,
+        ), 422
+
     qweather_days, from_cache, forecast_meta = get_qweather_forecast_with_cache(current_location, days=7)
     forecast_meta = dict(forecast_meta or {})
     forecast_meta['source_label'] = '和风天气'
@@ -363,7 +492,9 @@ def forecast_7day():
         'forecast_7day.html',
         family_members=_tool_family_members(),
         current_location=current_location,
-        location_options=get_location_options(),
+        location_input=current_location,
+        location_options=location_options,
+        location_error=location_error,
         forecast_days=forecast_days,
         forecast_error=forecast_error,
         forecast_meta=forecast_meta,
@@ -387,46 +518,55 @@ def chronic_risk():
     breakdown = None
     suggestions = None
     risk_error = None
+    vital_errors = {}
+    response_status = 200
 
     if request.method == 'POST':
         disease_key = sanitize_input(request.form.get('disease'), max_length=32) or 'hypertension'
         disease_key = disease_key if disease_key in CHRONIC_FORM_LABELS else 'hypertension'
         form_state = {
             'disease': disease_key,
-            'sbp': sanitize_input(request.form.get('sbp'), max_length=10) or '',
-            'fbg': sanitize_input(request.form.get('fbg'), max_length=10) or '',
+            'sbp': sanitize_input(request.form.get('sbp'), max_length=32) or '',
+            'fbg': sanitize_input(request.form.get('fbg'), max_length=32) or '',
             'adherence': sanitize_input(request.form.get('adherence'), max_length=20) or 'strict',
             'symptoms': sanitize_input(request.form.get('symptoms'), max_length=100) or '',
         }
 
-        weather_data, _ = get_weather_with_cache(ensure_user_location_valid())
-        if not is_qweather_online_weather(weather_data):
-            risk_error = '天气正在更新，慢病风险提示暂不显示。请稍后再试。'
+        vitals, vital_errors = _parse_chronic_vitals({
+            'sbp': request.form.get('sbp'),
+            'fbg': request.form.get('fbg'),
+        })
+        if vital_errors:
+            risk_error = '请先修正生命体征输入，再生成慢病风险提示。'
+            response_status = 422
         else:
-            vitals = _parse_chronic_vitals(form_state)
-            result = get_chronic_service().predict_individual_risk(
-                {
-                    'age': current_user.age or 65,
-                    'gender': current_user.gender or '未知',
-                    'chronic_diseases': [CHRONIC_FORM_LABELS[disease_key]],
-                    'vitals': vitals,
-                    'sbp': vitals.get('sbp'),
-                    'fbg': vitals.get('fbg'),
-                },
-                weather_data,
-            )
+            weather_data, _ = get_weather_with_cache(ensure_user_location_valid())
+            if not is_qweather_online_weather(weather_data):
+                risk_error = '天气正在更新，本次提醒暂未生成。请稍后再试。'
+            else:
+                result = get_chronic_service().predict_individual_risk(
+                    {
+                        'age': current_user.age or 65,
+                        'gender': current_user.gender or '未知',
+                        'chronic_diseases': [CHRONIC_FORM_LABELS[disease_key]],
+                        'vitals': vitals,
+                        'sbp': vitals.get('sbp'),
+                        'fbg': vitals.get('fbg'),
+                    },
+                    weather_data,
+                )
 
-            overall = result.get('overall_risk') or {}
-            risk_score = int(round(overall.get('score', 0) or 0))
-            risk_level = overall.get('level') or _score_level(risk_score)
-            risk_comment = (
-                f"当前以{CHRONIC_FORM_LABELS[disease_key]}为重点观察对象，结合天气条件判定为{risk_level}。"
-            )
-            vital_factors = ((result.get('vital_adjustment') or {}).get('factors') or [])
-            if vital_factors:
-                risk_comment = f"{risk_comment} 已参考{'；'.join(vital_factors[:2])}。"
-            breakdown = _build_chronic_breakdown(result, form_state['adherence'], form_state['symptoms'])
-            suggestions = _normalize_chronic_suggestions(result.get('recommendations'))[:5]
+                overall = result.get('overall_risk') or {}
+                risk_score = int(round(overall.get('score', 0) or 0))
+                risk_level = overall.get('level') or _score_level(risk_score)
+                risk_comment = (
+                    f"当前以{CHRONIC_FORM_LABELS[disease_key]}为重点观察对象，结合天气条件判定为{risk_level}。"
+                )
+                vital_factors = ((result.get('vital_adjustment') or {}).get('factors') or [])
+                if vital_factors:
+                    risk_comment = f"{risk_comment} 已参考{'；'.join(vital_factors[:2])}。"
+                breakdown = _build_chronic_breakdown(result, form_state['adherence'], form_state['symptoms'])
+                suggestions = _normalize_chronic_suggestions(result.get('recommendations'))[:5]
 
     return render_template(
         'chronic_risk.html',
@@ -436,4 +576,5 @@ def chronic_risk():
         breakdown=breakdown,
         suggestions=suggestions,
         risk_error=risk_error,
-    )
+        vital_errors=vital_errors,
+    ), response_status

--- a/core/config.py
+++ b/core/config.py
@@ -443,6 +443,38 @@ def _normalized_env_value(key, default=None):
     return value if value else default
 
 
+def _validated_miniprogram_code_image(value, static_folder):
+    """只接受 HTTPS 图片或已存在的 static 相对图片。"""
+    normalized = (value or '').strip()
+    if not normalized:
+        return ''
+    allowed_suffixes = {'.png', '.jpg', '.jpeg', '.webp'}
+    try:
+        parsed = urlparse(normalized)
+    except ValueError:
+        return ''
+    if parsed.scheme or parsed.netloc:
+        if (
+            parsed.scheme == 'https'
+            and parsed.hostname
+            and not parsed.username
+            and not parsed.password
+            and Path(parsed.path).suffix.lower() in allowed_suffixes
+        ):
+            return parsed.geturl()
+        return ''
+    if normalized.startswith(('/', '\\')) or '\\' in normalized:
+        return ''
+    relative_path = Path(normalized)
+    if '..' in relative_path.parts or relative_path.suffix.lower() not in allowed_suffixes:
+        return ''
+    static_root = Path(static_folder).resolve()
+    candidate = (static_root / relative_path).resolve()
+    if static_root not in candidate.parents or not candidate.is_file():
+        return ''
+    return relative_path.as_posix()
+
+
 def configure_app(app, logger):
     """Load configuration into the Flask app."""
     secret_key_is_generated = False
@@ -516,6 +548,10 @@ def configure_app(app, logger):
     wx_miniprogram_secret = _normalized_env_value('WX_MINIPROGRAM_SECRET', '')
     wx_miniprogram_openid_pepper = _normalized_env_value('WX_MINIPROGRAM_OPENID_PEPPER', '')
     wx_miniprogram_session_secret = _normalized_env_value('WX_MINIPROGRAM_SESSION_SECRET', '')
+    wx_miniprogram_action_code_image = _validated_miniprogram_code_image(
+        _normalized_env_value('WX_MINIPROGRAM_ACTION_CODE_IMAGE', ''),
+        app.static_folder,
+    )
     account_link_code_pepper = _normalized_env_value('ACCOUNT_LINK_CODE_PEPPER', '')
     wechat_formal_runtime_raw = _normalized_env_value('WECHAT_FORMAL_RUNTIME', '')
     web_private_features_enabled = parse_bool(
@@ -612,6 +648,9 @@ def configure_app(app, logger):
     app.config['WX_MINIPROGRAM_SECRET'] = wx_miniprogram_secret
     app.config['WX_MINIPROGRAM_OPENID_PEPPER'] = wx_miniprogram_openid_pepper
     app.config['WX_MINIPROGRAM_SESSION_SECRET'] = wx_miniprogram_session_secret
+    app.config['WX_MINIPROGRAM_ACTION_CODE_IMAGE'] = wx_miniprogram_action_code_image
+    app.config['WX_MINIPROGRAM_ACTION_PATH'] = 'pages/actions/index'
+    app.config['WX_MINIPROGRAM_NAME'] = '宜老平安'
     app.config['ACCOUNT_LINK_CODE_PEPPER'] = account_link_code_pepper or secret_key
     app.config['WX_MINIPROGRAM_PRIVACY_VERSION'] = wx_miniprogram_privacy_version
     app.config['ANALYTICS_TEST_USER_IDS'] = analytics_test_user_ids

--- a/core/location_resolution.py
+++ b/core/location_resolution.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""面向网页用户输入的严格地点解析。
+
+后台同步仍可继续使用 ``normalize_location_name`` 的历史回退语义。网页表单必须
+显式识别地点，避免把拼错或县外地点悄悄替换成都昌县。
+"""
+from dataclasses import dataclass
+
+from flask import current_app
+
+from core.constants import DEFAULT_CITY_LABEL
+
+
+@dataclass(frozen=True)
+class UserLocationResolution:
+    """严格地点解析结果。"""
+
+    raw: str
+    value: str | None
+    valid: bool
+    error: str | None = None
+
+
+def _clean_name(value):
+    if not isinstance(value, str):
+        return ''
+    return value.strip()
+
+
+def _configured_aliases(extra_names=()):
+    """构造县内可接受名称，排除旧配置里的县外城市和原始坐标。"""
+    default_city = _clean_name(current_app.config.get('DEFAULT_CITY'))
+    default_location = _clean_name(current_app.config.get('DEFAULT_LOCATION'))
+    community_names = {
+        _clean_name(name)
+        for name in (current_app.config.get('COMMUNITY_COORDS_GCJ') or {})
+        if _clean_name(name)
+    }
+    accepted = {
+        DEFAULT_CITY_LABEL,
+        '都昌',
+        '都昌县',
+        *community_names,
+        *(_clean_name(name) for name in extra_names),
+    }
+    accepted.discard('')
+
+    city_map = current_app.config.get('CITY_LOCATION_MAP') or {}
+    for name, mapped_value in city_map.items():
+        clean_name = _clean_name(name)
+        clean_value = _clean_name(mapped_value)
+        if clean_name in community_names or (
+            clean_value and default_location and clean_value == default_location
+        ):
+            accepted.add(clean_name)
+
+    aliases = {name: name for name in accepted}
+    for name in ('都昌', '都昌县', default_city):
+        if name and name in accepted:
+            aliases[name] = name
+
+    configured_aliases = current_app.config.get('USER_LOCATION_ALIASES') or {}
+    for alias, target in configured_aliases.items():
+        clean_alias = _clean_name(alias)
+        clean_target = _clean_name(target)
+        if clean_alias and clean_target in accepted:
+            aliases[clean_alias] = aliases.get(clean_target, clean_target)
+
+    # 支持“都昌县 + 已配置村/社区名”的常见完整写法。
+    for name in tuple(accepted):
+        if name not in {'都昌', '都昌县'} and not name.startswith('都昌县'):
+            aliases[f'都昌县{name}'] = aliases.get(name, name)
+    return aliases
+
+
+def get_user_location_options(*, extra_names=()):
+    """返回与严格解析器一致的地点候选，避免表单提示县外旧别名。"""
+    aliases = _configured_aliases(extra_names)
+    preferred = ['都昌', '都昌县']
+    options = [name for name in preferred if name in aliases]
+    options.extend(sorted(name for name in aliases if name not in options))
+    return options
+
+
+def resolve_user_location(raw_location, *, extra_names=(), default_if_blank=True):
+    """严格解析网页地点。
+
+    空值可按调用方要求回到默认县域；非空且未识别的值一律返回错误，不接受
+    QWeather ID、经纬度或旧配置中的县外城市。
+    """
+    raw = _clean_name(raw_location)
+    if not raw:
+        if default_if_blank:
+            return UserLocationResolution('', DEFAULT_CITY_LABEL, True)
+        return UserLocationResolution('', None, True)
+
+    if len(raw) > 100:
+        return UserLocationResolution(
+            raw[:100],
+            None,
+            False,
+            '地点名称过长，请从都昌县或已配置的乡镇、社区中选择。',
+        )
+
+    aliases = _configured_aliases(extra_names)
+    resolved = aliases.get(raw)
+    if resolved:
+        return UserLocationResolution(raw, resolved, True)
+    return UserLocationResolution(
+        raw,
+        None,
+        False,
+        '未找到这个地点。目前仅支持都昌县及已配置的乡镇、社区，请从提示中选择。',
+    )

--- a/services/public_service.py
+++ b/services/public_service.py
@@ -19,7 +19,7 @@ from flask import (
     url_for,
 )
 from flask_login import current_user, login_user, logout_user
-from sqlalchemy import or_
+from sqlalchemy import false, or_
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from werkzeug.exceptions import MethodNotAllowed, NotFound
 from werkzeug.routing import RequestRedirect
@@ -27,6 +27,7 @@ from werkzeug.security import check_password_hash, generate_password_hash
 
 from core.constants import GUEST_ID_PREFIX
 from core.extensions import db
+from core.location_resolution import get_user_location_options, resolve_user_location
 from core.security import hash_identifier, hash_pair_token, hash_short_code, rate_limit_key, verify_pair_token
 from core.time_utils import today_local, utcnow, ensure_utc_aware
 from core.weather import (
@@ -1632,20 +1633,62 @@ def render_cooling_resources_page(
 ):
     open_only_flag = parse_bool(open_only, default=False)
     location_query = sanitize_input(request.args.get('location'), max_length=100)
-    weather_location = normalize_location_name(community or location_query or None)
+    raw_location = community or location_query or ''
+    all_resources = CoolingResource.query.filter_by(is_active=True).all()
+    communities = sorted({item.community_code for item in all_resources if item.community_code})
+    resource_types = sorted({item.resource_type for item in all_resources if item.resource_type})
+    location_resolution = resolve_user_location(
+        raw_location,
+        extra_names=communities,
+    )
+    location_error = location_resolution.error if not location_resolution.valid else None
+    weather_location = (
+        location_resolution.value
+        if location_resolution.valid
+        else location_resolution.raw
+    )
     cooling_weather = {}
-    try:
-        cooling_weather, _ = get_weather_with_cache(weather_location)
-    except Exception as exc:
-        logger.warning("避暑资源页天气读取失败，已隐藏室外温度计: %s", exc)
-        cooling_weather = {}
+    snapshot_meta = {}
+    if not location_error:
+        snapshot = get_bootstrap_payload()
+        snapshot_id = snapshot.get('snapshot_id')
+        if snapshot_id:
+            current_stale = snapshot.get('current_stale', snapshot.get('stale', True))
+            risk_stale = snapshot.get('risk_stale', snapshot.get('stale', True))
+            current_snapshot = snapshot.get('current')
+            if (
+                current_stale is False
+                and risk_stale is False
+                and is_qweather_online_weather(current_snapshot)
+            ):
+                cooling_weather = current_snapshot
+            snapshot_location = snapshot.get('location') or {}
+            if isinstance(snapshot_location, dict) and snapshot_location.get('name'):
+                weather_location = str(snapshot_location['name'])
+            snapshot_meta = {
+                'id_short': str(snapshot_id)[:8],
+                'fetched_at': snapshot.get('fetched_at'),
+            }
+        else:
+            # 本地测试和首次启动尚无持久快照时兼容旧缓存；线上已有快照后不混读。
+            try:
+                cooling_weather, _ = get_weather_with_cache(weather_location)
+            except Exception as exc:
+                logger.warning("避暑资源页天气读取失败，已隐藏室外温度计: %s", exc)
+                cooling_weather = {}
     outdoor_temp = None
-    if cooling_weather and not cooling_weather.get('is_mock'):
-        outdoor_temp = cooling_weather.get('temperature')
+    if is_qweather_online_weather(cooling_weather):
+        parsed_temperature = parse_float(cooling_weather.get('temperature'))
+        if parsed_temperature is not None and math.isfinite(parsed_temperature):
+            outdoor_temp = parsed_temperature
 
     query = CoolingResource.query.filter_by(is_active=True)
-    if community:
-        query = query.filter(CoolingResource.community_code == community)
+    if location_error:
+        query = query.filter(false())
+    elif raw_location and location_resolution.value not in {'都昌', '都昌县'}:
+        query = query.filter(
+            CoolingResource.community_code == location_resolution.value
+        )
     if resource_type:
         query = query.filter(CoolingResource.resource_type == resource_type)
     if has_ac_raw not in (None, ''):
@@ -1670,14 +1713,21 @@ def render_cooling_resources_page(
         CoolingResource.community_code,
         CoolingResource.name
     ).all()
-    all_resources = CoolingResource.query.filter_by(is_active=True).all()
+    location_filter_active = bool(
+        raw_location and location_resolution.value not in {'都昌', '都昌县'}
+    )
+    filters_active = bool(
+        location_filter_active
+        or resource_type
+        or has_ac_raw not in (None, '')
+        or is_accessible_raw not in (None, '')
+        or open_only_flag
+    )
     candidate_preview = (
         list(cooling_candidates or [])
-        if not all_resources
+        if not all_resources and not filters_active and not location_error
         else []
     )
-    communities = sorted({item.community_code for item in all_resources if item.community_code})
-    resource_types = sorted({item.resource_type for item in all_resources if item.resource_type})
     grouped = {}
     map_points = []
     for item in resources:
@@ -1694,7 +1744,7 @@ def render_cooling_resources_page(
         total=len(resources),
         communities=communities,
         resource_types=resource_types,
-        selected_community=community or '',
+        selected_community=location_resolution.raw if raw_location else '',
         selected_resource_type=resource_type or '',
         selected_has_ac=has_ac_raw if has_ac_raw is not None else '',
         selected_is_accessible=is_accessible_raw if is_accessible_raw is not None else '',
@@ -1707,7 +1757,12 @@ def render_cooling_resources_page(
         cooling_weather_location=weather_location,
         outdoor_temp=outdoor_temp,
         cooling_candidates=candidate_preview,
+        cooling_location_error=location_error,
+        cooling_location_options=get_user_location_options(extra_names=communities),
+        cooling_snapshot_meta=snapshot_meta,
     ))
+    if location_error:
+        response.status_code = 422
     if not map_points:
         # 没有可计算距离的正式点位时，浏览器不应提供定位能力。
         response.headers['Permissions-Policy'] = (

--- a/services/user/profile_service.py
+++ b/services/user/profile_service.py
@@ -57,6 +57,14 @@ _ACADEMIC_MAPPING_FIELDS = (
     'rr_breakdown',
 )
 
+_HEALTH_SCREENING_OPTIONS = {
+    'outdoor_exposure': {'low', 'medium', 'high'},
+    'symptom_level': {'none', 'mild', 'moderate', 'severe'},
+    'hydration': {'good', 'normal', 'poor'},
+    'medication_adherence': {'good', 'partial', 'poor'},
+    'sleep_quality': {'good', 'fair', 'poor'},
+}
+
 
 def _normalize_academic_profile(raw_profile):
     """把历史评估中的不可信 JSON 形状收敛到模板可安全读取的结构。"""
@@ -112,24 +120,66 @@ def _safe_referrer_or_dashboard():
     return referrer
 
 
+def _render_health_assessment_page(*, form_state=None, form_errors=None, status=200):
+    """渲染健康评估页，并在校验失败时保留已完成选项。"""
+    normalized_form_errors = form_errors or {}
+    first_form_error = next(
+        (name for name in _HEALTH_SCREENING_OPTIONS if name in normalized_form_errors),
+        None,
+    )
+    latest_assessment = None
+    if is_guest_user(current_user):
+        latest_assessment = get_guest_assessment()
+    else:
+        latest_assessment = HealthRiskAssessment.query.filter_by(
+            user_id=current_user.id
+        ).order_by(HealthRiskAssessment.assessment_date.desc()).first()
+    explain_data = {}
+    disease_risks_data = {}
+    if latest_assessment and getattr(latest_assessment, 'explain', None):
+        explain_data = safe_json_loads(latest_assessment.explain, {})
+    if latest_assessment and getattr(latest_assessment, 'disease_risks', None):
+        disease_risks_data = safe_json_loads(latest_assessment.disease_risks, {})
+    if not isinstance(explain_data, dict):
+        explain_data = {}
+    academic_profile = _normalize_academic_profile(
+        explain_data.get('academic_profile')
+    )
+    explain_data = dict(explain_data)
+    explain_data['academic_profile'] = academic_profile
+    if not isinstance(disease_risks_data, dict):
+        disease_risks_data = {}
+
+    return render_template(
+        'health_assessment.html',
+        assessment=latest_assessment,
+        assessment_explain=explain_data,
+        assessment_disease_risks=disease_risks_data,
+        assessment_academic=academic_profile,
+        form_state=form_state or {},
+        form_errors=normalized_form_errors,
+        first_form_error=first_form_error,
+    ), status
+
+
 def health_assessment():
     """健康风险评估"""
     if request.method == 'POST':
-        screening_options = {
-            'outdoor_exposure': {'low', 'medium', 'high'},
-            'symptom_level': {'none', 'mild', 'moderate', 'severe'},
-            'hydration': {'good', 'normal', 'poor'},
-            'medication_adherence': {'good', 'partial', 'poor'},
-            'sleep_quality': {'good', 'fair', 'poor'},
-        }
         screening = {}
-        for name, allowed in screening_options.items():
+        form_errors = {}
+        for name, allowed in _HEALTH_SCREENING_OPTIONS.items():
             value = sanitize_input(request.form.get(name), max_length=20)
             value = value.strip().lower() if isinstance(value, str) else ''
             if value not in allowed:
-                flash('请完整选择全部 5 项健康筛查后再提交。', 'error')
-                return redirect(url_for('user.health_assessment'))
-            screening[name] = value
+                form_errors[name] = '请选择这一项后再提交。'
+            else:
+                screening[name] = value
+        if form_errors:
+            return _render_health_assessment_page(
+                form_state=screening,
+                form_errors=form_errors,
+                status=422,
+            )
 
         try:
             # 执行风险评估（多路径融合版）
@@ -245,37 +295,7 @@ def health_assessment():
 
         return redirect(url_for('user.health_assessment'))
 
-    latest_assessment = None
-    if is_guest_user(current_user):
-        latest_assessment = get_guest_assessment()
-    else:
-        latest_assessment = HealthRiskAssessment.query.filter_by(
-            user_id=current_user.id
-        ).order_by(HealthRiskAssessment.assessment_date.desc()).first()
-    explain_data = {}
-    disease_risks_data = {}
-    academic_profile = {}
-    if latest_assessment and getattr(latest_assessment, 'explain', None):
-        explain_data = safe_json_loads(latest_assessment.explain, {})
-    if latest_assessment and getattr(latest_assessment, 'disease_risks', None):
-        disease_risks_data = safe_json_loads(latest_assessment.disease_risks, {})
-    if not isinstance(explain_data, dict):
-        explain_data = {}
-    academic_profile = _normalize_academic_profile(
-        explain_data.get('academic_profile')
-    )
-    explain_data = dict(explain_data)
-    explain_data['academic_profile'] = academic_profile
-    if not isinstance(disease_risks_data, dict):
-        disease_risks_data = {}
-
-    return render_template(
-        'health_assessment.html',
-        assessment=latest_assessment,
-        assessment_explain=explain_data,
-        assessment_disease_risks=disease_risks_data,
-        assessment_academic=academic_profile
-    )
+    return _render_health_assessment_page()
 
 
 def profile():

--- a/static/js/cooling-map.js
+++ b/static/js/cooling-map.js
@@ -72,7 +72,7 @@
             [point.type, point.community].filter(Boolean).join(' · ') || '避暑资源'
         ));
         content.appendChild(textRow(point.address || '地址未标注'));
-        content.appendChild(textRow(point.open_hours || '开放时间未标注'));
+        content.appendChild(textRow(point.open_hours || '开放时间未核验，请出发前确认'));
         return content;
     }
 

--- a/static/js/yilao-data-fx-extra.js
+++ b/static/js/yilao-data-fx-extra.js
@@ -403,7 +403,10 @@
             }
         }
         if (bulb) bulb.dataset.zone = zone;
-        if (valEl) animateNumber(valEl, 0, t, { duration: 1500, decimals: 1 });
+        // 服务端首帧已给出正式数值时，只动画水银柱，避免数字先跳回 0。
+        if (valEl && el.dataset.staticValue !== '1') {
+            animateNumber(valEl, 0, t, { duration: 1500, decimals: 1 });
+        }
 
         if (zone === 'danger') el.classList.add('danger-active');
         else el.classList.remove('danger-active');

--- a/templates/action_checkin.html
+++ b/templates/action_checkin.html
@@ -2,8 +2,11 @@
 {% from "partials/metric_info.html" import metric_info with context %}
 {% set needs_chartjs = true %}
 {% set web_actions_read_only = web_actions_read_only|default(config.get('WECHAT_FORMAL_RUNTIME', false)) %}
+{% set mini_program_name = config.get('WX_MINIPROGRAM_NAME', '宜老平安') %}
+{% set mini_program_action_path = config.get('WX_MINIPROGRAM_ACTION_PATH', 'pages/actions/index') %}
+{% set mini_program_code_image = config.get('WX_MINIPROGRAM_ACTION_CODE_IMAGE', '') %}
 
-{% block title %}行动打卡 - 天气健康风险预测系统{% endblock %}
+{% block title %}今日行动入口 · 宜老天气通{% endblock %}
 
 {% block content %}
 <div class="container my-4">
@@ -11,8 +14,8 @@
         <div class="col-12">
             <h2><i class="bi bi-clipboard-check"></i> 行动型热健康预警</h2>
             {% if web_actions_read_only %}
-                <p class="text-muted mb-0">当前网页仅显示家庭行动入口的停用说明（不含医疗诊断/治疗建议）。</p>
-                <p class="text-muted small mt-2 mb-0">微信正式版不会在网页读取短码或家庭安全链接。确认、求助和复盘请在微信小程序中登录并完成健康资料单独同意后操作。</p>
+                <p class="text-muted mb-0">网页提供今日公共行动清单，并把家庭确认安全地交接到“{{ mini_program_name }}”小程序。</p>
+                <p class="text-muted small mt-2 mb-0">网页不会读取短码、兑换安全链接或写入家庭记录。家庭确认、求助和复盘请在小程序中登录后完成。</p>
             {% else %}
                 <p class="text-muted mb-0">输入短码即可完成今日确认或求助（不含医疗诊断/治疗建议）。</p>
                 <p class="text-muted small mt-2 mb-0">未登录者可使用照护人提供的有效短码或有时效家庭行动安全链接。只有主动提交时，行动确认、求助需求或复盘才会写入对应照护账号；该入口不等于登录，不能查看账号内其他资料。</p>
@@ -25,13 +28,52 @@
             <div class="col-lg-6">
                 <div class="card shadow-sm">
                     <div class="card-header bg-light">
+                        {% if web_actions_read_only %}
+                        <h5 class="mb-0"><i class="bi bi-wechat"></i> 去“{{ mini_program_name }}”完成家庭打卡</h5>
+                        {% else %}
                         <h5 class="mb-0"><i class="bi bi-key"></i> 短码确认</h5>
+                        {% endif %}
                     </div>
                     <div class="card-body">
                         {% if web_actions_read_only %}
-                        <div class="alert alert-info mb-0" role="status" data-testid="web-actions-read-only">
-                            <strong>当前网页仅供查看停用说明。</strong>
-                            为保护家庭资料，首发不会读取短码、兑换安全链接或写入家庭记录。请打开微信小程序并登录后操作。
+                        <div data-testid="miniprogram-action-handoff"
+                             data-miniprogram-path="{{ mini_program_action_path }}">
+                            {% if mini_program_code_image %}
+                            <div class="text-center mb-3">
+                                <img src="{% if mini_program_code_image.startswith('https://') %}{{ mini_program_code_image }}{% else %}{{ url_for('static', filename=mini_program_code_image) }}{% endif %}"
+                                     alt="{{ mini_program_name }}官方小程序码，进入今日行动页"
+                                     width="220"
+                                     height="220"
+                                     loading="eager"
+                                     referrerpolicy="no-referrer"
+                                     class="img-fluid rounded border">
+                                <div class="text-muted small mt-2">微信扫码后进入“今日行动”页。</div>
+                            </div>
+                            {% else %}
+                            <div class="alert alert-info" role="status" data-testid="miniprogram-code-fallback">
+                                <strong>当前没有可展示的官方小程序码。</strong>
+                                请打开微信，搜索小程序“{{ mini_program_name }}”，进入后点“今日行动”。页面不会显示占位码或未经核验的二维码。
+                            </div>
+                            {% endif %}
+
+                            <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+                                <span>小程序名称：<strong id="miniProgramName">{{ mini_program_name }}</strong></span>
+                                <button type="button" class="btn btn-sm btn-outline-primary" id="copyMiniProgramName" data-copy-value="{{ mini_program_name }}">
+                                    <i class="bi bi-copy me-1" aria-hidden="true"></i>复制名称
+                                </button>
+                                <span class="small text-success" id="copyMiniProgramFeedback" role="status" aria-live="polite"></span>
+                            </div>
+
+                            <ol class="small ps-3 mb-3">
+                                <li class="mb-1">打开“{{ mini_program_name }}”，进入“今日行动”。</li>
+                                <li class="mb-1">公共行动可直接在本机勾选，无需先选择家人。</li>
+                                <li>需要保存家庭确认、求助或复盘时，从“照护”选择对应家人。</li>
+                            </ol>
+
+                            <div class="d-flex flex-wrap gap-2">
+                                <a class="btn btn-primary" href="{{ url_for('public.public_risk') }}"><i class="bi bi-shield-check me-1"></i>返回今日风险</a>
+                                <a class="btn btn-outline-secondary" href="{{ url_for('public.index') }}"><i class="bi bi-house me-1"></i>返回首页</a>
+                            </div>
                         </div>
                         {% else %}
                         <form method="POST" action="{{ entry_action or url_for('public.action_check') }}">
@@ -52,10 +94,23 @@
             <div class="col-lg-6 mt-4 mt-lg-0">
                 <div class="card shadow-sm">
                     <div class="card-header bg-light">
+                        {% if web_actions_read_only %}
+                        <h5 class="mb-0"><i class="bi bi-list-check"></i> 今天先做这 3 件事</h5>
+                        {% else %}
                         <h5 class="mb-0"><i class="bi bi-shield-check"></i> 统一免责声明</h5>
+                        {% endif %}
                     </div>
                     <div class="card-body">
+                        {% if web_actions_read_only %}
+                        <div class="d-grid gap-3" data-testid="public-action-fallback-list">
+                            <div><strong>1. 少量多次补水</strong><div class="text-muted small">根据自身饮水限制安排，别等明显口渴才喝。</div></div>
+                            <div><strong>2. 避开午后高温</strong><div class="text-muted small">尽量在室内休息，外出优先安排在上午或傍晚。</div></div>
+                            <div><strong>3. 主动联系家人</strong><div class="text-muted small">身体不适或需要帮助时直接电话、微信联系；紧急情况拨打 120。</div></div>
+                            <a class="btn btn-outline-primary" href="{{ url_for('public.cooling_resources') }}"><i class="bi bi-snow2 me-1"></i>查看已核验避暑资源</a>
+                        </div>
+                        {% else %}
                         {% include "partials/disclaimer_block.html" %}
+                        {% endif %}
                     </div>
                 </div>
             </div>
@@ -379,6 +434,20 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function () {
+    const copyMiniProgramButton = document.getElementById('copyMiniProgramName');
+    const copyMiniProgramFeedback = document.getElementById('copyMiniProgramFeedback');
+    if (copyMiniProgramButton && copyMiniProgramFeedback) {
+        copyMiniProgramButton.addEventListener('click', async function () {
+            const value = copyMiniProgramButton.dataset.copyValue || '';
+            try {
+                await navigator.clipboard.writeText(value);
+                copyMiniProgramFeedback.textContent = '已复制';
+            } catch (_error) {
+                copyMiniProgramFeedback.textContent = '复制失败，请长按名称复制';
+            }
+        });
+    }
+
     const nameInput = document.getElementById('localContactName');
     const phoneInput = document.getElementById('localContactPhone');
     const saveBtn = document.getElementById('saveLocalContact');

--- a/templates/chronic_risk.html
+++ b/templates/chronic_risk.html
@@ -10,7 +10,7 @@
         <p>填写近 7 天血压、血糖和当前状态，结合天气查看今天需要留意的事项。结果只用于日常照护参考。</p>
     </section>
 
-    <form method="POST" action="{{ url_for('tools.chronic_risk') }}" class="yl-section mb-4 yl-fade-up yl-fade-up-d1">
+    <form method="POST" action="{{ url_for('tools.chronic_risk') }}" class="yl-section mb-4 yl-fade-up yl-fade-up-d1" novalidate>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
         <div class="row g-3">
@@ -25,11 +25,15 @@
             </div>
             <div class="col-md-4">
                 <label class="form-label">近 7 天最高血压(mmHg)</label>
-                <input type="number" class="form-control" name="sbp" value="{{ form_state.sbp if form_state else '' }}" placeholder="例:142">
+                <input type="text" inputmode="decimal" class="form-control{% if vital_errors and vital_errors.sbp %} is-invalid{% endif %}" name="sbp" value="{{ form_state.sbp if form_state else '' }}" placeholder="例:142" maxlength="20" aria-describedby="sbpHelp{% if vital_errors and vital_errors.sbp %} sbpError{% endif %}">
+                <div class="form-text" id="sbpHelp">可不填；填写时接受 60 至 260 mmHg。</div>
+                {% if vital_errors and vital_errors.sbp %}<div class="invalid-feedback" id="sbpError">{{ vital_errors.sbp }}</div>{% endif %}
             </div>
             <div class="col-md-4">
                 <label class="form-label">近 7 天空腹血糖(mmol/L)</label>
-                <input type="number" step="0.1" class="form-control" name="fbg" value="{{ form_state.fbg if form_state else '' }}" placeholder="例:7.8">
+                <input type="text" inputmode="decimal" class="form-control{% if vital_errors and vital_errors.fbg %} is-invalid{% endif %}" name="fbg" value="{{ form_state.fbg if form_state else '' }}" placeholder="例:7.8" maxlength="20" aria-describedby="fbgHelp{% if vital_errors and vital_errors.fbg %} fbgError{% endif %}">
+                <div class="form-text" id="fbgHelp">可不填；填写时接受 2 至 30 mmol/L。</div>
+                {% if vital_errors and vital_errors.fbg %}<div class="invalid-feedback" id="fbgError">{{ vital_errors.fbg }}</div>{% endif %}
             </div>
             <div class="col-md-4">
                 <label class="form-label">用药依从</label>
@@ -50,8 +54,8 @@
     </form>
 
     {% if risk_error %}
-    <div class="alert alert-warning yl-fade-up yl-fade-up-d2" role="status">
-        <i class="bi bi-cloud-slash me-1"></i>天气正在更新，本次提醒暂未生成。请稍后再试。
+    <div class="alert alert-warning yl-fade-up yl-fade-up-d2" role="alert">
+        <i class="bi bi-exclamation-triangle me-1"></i>{{ risk_error }}
     </div>
     {% endif %}
 

--- a/templates/cooling.html
+++ b/templates/cooling.html
@@ -18,14 +18,17 @@
         <div class="row g-4 align-items-center">
             <div class="col-md-auto">
                 <div class="fx-thermometer" data-fx="thermometer"
-                     data-temp="{{ outdoor_temp }}" data-min="-5" data-max="45">
+                     data-temp="{{ outdoor_temp }}" data-min="-5" data-max="45" data-static-value="1">
                     <div class="fx-thermometer-tube">
                         <div class="fx-thermometer-mercury"></div>
                         <div class="fx-thermometer-bulb"></div>
                     </div>
                     <div class="fx-thermometer-info">
-                        <div class="v"><span class="num">0</span><span class="unit">°C</span></div>
+                        <div class="v"><span class="num">{{ outdoor_temp }}</span><span class="unit">°C</span></div>
                         <div class="k">{{ cooling_weather_location or current_location or '当前位置' }} · 当前室外</div>
+                        {% if cooling_snapshot_meta and cooling_snapshot_meta.id_short %}
+                        <div class="text-muted small mt-1">天气快照 {{ cooling_snapshot_meta.id_short }}{% if cooling_snapshot_meta.fetched_at %} · {{ cooling_snapshot_meta.fetched_at[:16]|replace('T', ' ') }}{% endif %}</div>
+                        {% endif %}
                     </div>
                 </div>
             </div>
@@ -52,8 +55,10 @@
         <div class="row g-3 align-items-end">
             <div class="col-md-5">
                 <label class="form-label">所在地</label>
-                <input type="text" class="form-control" name="community" value="{{ selected_community or current_location or '' }}" list="locOpts">
-                <datalist id="locOpts">{% for loc in (communities or location_options or []) %}<option value="{{ loc }}"></option>{% endfor %}</datalist>
+                <input type="text" class="form-control{% if cooling_location_error %} is-invalid{% endif %}" name="community" value="{{ selected_community or '' }}" list="locOpts" aria-describedby="coolingLocationHelp{% if cooling_location_error %} coolingLocationError{% endif %}">
+                <datalist id="locOpts">{% for loc in (cooling_location_options or []) %}<option value="{{ loc }}"></option>{% endfor %}</datalist>
+                <div class="form-text" id="coolingLocationHelp">目前仅支持都昌县及列表中的乡镇、社区。</div>
+                {% if cooling_location_error %}<div class="invalid-feedback" id="coolingLocationError">{{ cooling_location_error }}</div>{% endif %}
             </div>
             <div class="col-md-4">
                 <label class="form-label">类型</label>
@@ -70,6 +75,12 @@
         </div>
     </form>
 
+    {% if cooling_location_error %}
+    <div class="alert alert-warning mb-4 yl-fade-up yl-fade-up-d2" role="alert" data-error-code="invalid_location">
+        <i class="bi bi-geo-alt me-1"></i>{{ cooling_location_error }} 原输入已保留，请修改后重新查找。
+    </div>
+    {% endif %}
+
     <section class="yl-section mb-4 yl-fade-up yl-fade-up-d2 cooling-map-panel"
              id="coolingMapPanel"
              data-has-map-key="{{ '1' if amap_key else '0' }}">
@@ -78,13 +89,21 @@
                 <h2 class="cooling-map-title">地图查看避暑资源</h2>
                 <p class="cooling-map-copy mb-0">地图只接收已核验的公开资源点。只有你点击按钮后，浏览器才会申请一次位置权限；精确位置仅在本页内存计算距离，不上传至本项目服务器或保存，也不会用于地图打点。</p>
             </div>
-            <button type="button"
-                    class="btn btn-outline-primary cooling-locate-button"
-                    id="coolingLocateButton"
-                    {% if not map_points or not amap_key %}disabled{% endif %}>
-                <i class="bi bi-crosshair me-1" aria-hidden="true"></i>
-                按当前位置找附近
-            </button>
+            <div class="text-lg-end">
+                <button type="button"
+                        class="btn btn-outline-primary cooling-locate-button"
+                        id="coolingLocateButton"
+                    {% if not map_points or not amap_key %}disabled
+                        aria-describedby="coolingLocateAvailability"{% endif %}>
+                    <i class="bi bi-crosshair me-1" aria-hidden="true"></i>
+                    按当前位置找附近
+                </button>
+                {% if not map_points %}
+                <div class="text-muted small mt-1" id="coolingLocateAvailability">当前没有已核验地图点位，暂不能按位置查找。</div>
+                {% elif not amap_key %}
+                <div class="text-muted small mt-1" id="coolingLocateAvailability">地图服务尚未配置，暂不能读取位置。</div>
+                {% endif %}
+            </div>
         </div>
         <div class="cooling-map-canvas" id="coolingMap" role="region" aria-label="都昌县避暑资源地图">
             <div class="cooling-map-fallback">
@@ -127,7 +146,7 @@
                     <div class="text-muted" style="font-size:.85rem;">{{ r.resource_type or '避暑资源' }} · {{ community }}</div>
 
                     <div class="mt-3" style="font-size:.88rem; color:var(--yl-ink-soft);">
-                        <div class="mb-1"><i class="bi bi-clock me-1 text-muted"></i>{{ r.open_hours or '开放时间未标注' }}</div>
+                        <div class="mb-1"><i class="bi bi-clock me-1 text-muted"></i>{{ r.open_hours or '开放时间未核验，请出发前确认' }}</div>
                         <div><i class="bi bi-geo-alt me-1 text-muted"></i>{{ r.address_hint or '地址未标注' }}</div>
                         {% if r.is_accessible %}
                         <div class="mt-1"><i class="bi bi-universal-access me-1 text-muted"></i>适合行动不便老人</div>
@@ -176,7 +195,7 @@
             <div>
                 <span class="section-kicker">预览资料</span>
                 <h2 class="h4 mb-1" id="coolingCandidateTitle">待核验场所预览</h2>
-                <p class="text-muted mb-0">这些信息来自高德公开 POI，仅帮助后续人工核验和联系确认。</p>
+                <p class="text-muted mb-0">这些信息来自高德公开 POI，仅帮助后续人工核验和联系确认。候选资料不参与上方地点、类型或开放条件筛选。</p>
             </div>
             <span class="badge bg-warning-subtle text-warning-emphasis align-self-start">全部待人工核验</span>
         </div>

--- a/templates/forecast_7day.html
+++ b/templates/forecast_7day.html
@@ -15,8 +15,10 @@
         <div class="row g-3 align-items-end">
             <div class="col-md-8">
                 <label class="form-label">所在地</label>
-                <input type="text" class="form-control" name="location" value="{{ request.args.get('location', current_location) }}" list="locOpts">
+                <input type="text" class="form-control{% if location_error %} is-invalid{% endif %}" name="location" value="{{ location_input if location_input is defined else current_location }}" list="locOpts" aria-describedby="forecastLocationHelp{% if location_error %} forecastLocationError{% endif %}">
                 <datalist id="locOpts">{% for loc in (location_options or []) %}<option value="{{ loc }}"></option>{% endfor %}</datalist>
+                <div class="form-text" id="forecastLocationHelp">目前仅支持都昌县及列表中的乡镇、社区。</div>
+                {% if location_error %}<div class="invalid-feedback" id="forecastLocationError">{{ location_error }}</div>{% endif %}
             </div>
             <div class="col-md-4 d-grid">
                 <button class="btn btn-primary" type="submit"><i class="bi bi-graph-up me-1"></i>生成预测</button>
@@ -24,6 +26,7 @@
         </div>
     </form>
 
+    {% if not location_error %}
     <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3 yl-fade-up yl-fade-up-d2">
         <div class="text-muted" style="font-size:.9rem;">
             来源：{{ forecast_meta.source_label or '和风天气' }}
@@ -31,6 +34,11 @@
             {% if forecast_meta.from_cache %} · 最近一次有效数据{% endif %}
         </div>
     </div>
+    {% else %}
+    <div class="alert alert-warning yl-fade-up yl-fade-up-d2" role="alert" data-error-code="invalid_location">
+        <i class="bi bi-geo-alt me-1"></i>{{ location_error }}
+    </div>
+    {% endif %}
 
     {% if forecast_error %}
     <div class="alert alert-warning yl-fade-up yl-fade-up-d2" role="alert">
@@ -114,7 +122,7 @@
         </div>
         {% endfor %}
     </div>
-    {% else %}
+    {% elif not location_error %}
     <section class="yl-section text-center yl-fade-up yl-fade-up-d2">
         <div style="font-size:2rem; color:var(--yl-orange-500);"><i class="bi bi-cloud-slash"></i></div>
         <h4 class="mt-2" style="font-size:1.05rem;">7 天预报正在更新</h4>
@@ -122,6 +130,7 @@
     </section>
     {% endif %}
 
+    {% if not location_error %}
     <div class="row g-4 mb-4">
         <div class="col-lg-8">
             <section class="yl-section yl-fade-up yl-fade-up-d3">
@@ -176,6 +185,7 @@
             {% endfor %}
         </div>
     </section>
+    {% endif %}
 </div>
 
 <script>

--- a/templates/health_assessment.html
+++ b/templates/health_assessment.html
@@ -1,6 +1,13 @@
 {% extends "base.html" %}
 {% from "partials/metric_info.html" import metric_info with context %}
 {% block title %}健康评估 · 宜老天气通{% endblock %}
+{% set questions = questions or [
+    {'id':'outdoor_exposure','text':'今日户外暴露情况','options':[('low','低,主要在室内'),('medium','中,约 1 到 3 小时'),('high','高,超过 3 小时')]},
+    {'id':'symptom_level','text':'当前不适症状','options':[('none','无明显不适'),('mild','轻微'),('moderate','中等'),('severe','明显或严重')]},
+    {'id':'hydration','text':'今天的饮水情况','options':[('good','充足'),('normal','一般'),('poor','不足')]},
+    {'id':'medication_adherence','text':'近期服药规律性','options':[('good','规律'),('partial','偶尔漏服'),('poor','经常漏服')]},
+    {'id':'sleep_quality','text':'最近睡眠质量','options':[('good','较好'),('fair','一般'),('poor','较差')]}
+] %}
 
 {% block content %}
 <div class="container" style="max-width:900px;">
@@ -19,7 +26,7 @@
         <div class="progress"><div class="progress-bar" id="progressBar" style="width:0%"></div></div>
     </div>
 
-    <form method="POST" action="{{ url_for('user.health_assessment') }}" id="assessForm" class="yl-fade-up yl-fade-up-d2">
+    <form method="POST" action="{{ url_for('user.health_assessment') }}" id="assessForm" class="yl-fade-up yl-fade-up-d2" novalidate>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
         <div class="alert alert-light border small" role="note">
@@ -36,6 +43,10 @@
                 border-color: var(--yl-orange-500);
                 color: #fff;
             }
+            .assessment-question.is-invalid {
+                border-color: var(--bs-danger);
+                box-shadow: 0 0 0 .15rem rgba(220, 53, 69, .12);
+            }
         </style>
 
         <div class="section-heading mb-3">
@@ -43,16 +54,22 @@
             <p>根据你今天的状态与近几天感受,快速完成这份筛查。</p>
         </div>
 
-        {% set questions = questions or [
-            {'id':'outdoor_exposure','text':'今日户外暴露情况','options':[('low','低,主要在室内'),('medium','中,约 1 到 3 小时'),('high','高,超过 3 小时')]},
-            {'id':'symptom_level','text':'当前不适症状','options':[('none','无明显不适'),('mild','轻微'),('moderate','中等'),('severe','明显或严重')]},
-            {'id':'hydration','text':'今天的饮水情况','options':[('good','充足'),('normal','一般'),('poor','不足')]},
-            {'id':'medication_adherence','text':'近期服药规律性','options':[('good','规律'),('partial','偶尔漏服'),('poor','经常漏服')]},
-            {'id':'sleep_quality','text':'最近睡眠质量','options':[('good','较好'),('fair','一般'),('poor','较差')]}
-        ] %}
+        <div class="alert alert-danger{% if not form_errors %} d-none{% endif %}"
+             id="assessmentErrorSummary"
+             role="alert"
+             tabindex="-1"
+             aria-live="assertive">
+            <strong>还差 <span id="assessmentMissingCount">{{ form_errors|length }}</span> 项。</strong>
+            请完成标红的问题后再提交，已选择的答案会保留。
+        </div>
 
         {% for q in questions %}
-        <div class="card mb-3">
+        <div class="card mb-3 assessment-question{% if form_errors.get(q.id) %} is-invalid{% endif %}"
+             id="assessmentQuestion-{{ q.id }}"
+             data-assessment-question="{{ q.id }}"
+             tabindex="-1"
+             {% if first_form_error == q.id %}autofocus{% endif %}
+             {% if form_errors.get(q.id) %}aria-invalid="true"{% endif %}>
             <div class="card-body">
                 <div class="d-flex gap-3">
                     <div class="fw-bold" style="color:var(--yl-orange-500); font-size:1.1rem;">{{ loop.index }}.</div>
@@ -61,10 +78,13 @@
                         <div class="d-flex flex-wrap gap-2">
                             {% for val, label in q.options %}
                             <label class="btn btn-outline-secondary assess-choice">
-                                <input type="radio" name="{{ q.id }}" value="{{ val }}" class="visually-hidden assess-opt" required>
+                                <input type="radio" name="{{ q.id }}" value="{{ val }}" class="visually-hidden assess-opt" {% if form_state.get(q.id) == val %}checked{% endif %}>
                                 {{ label }}
                             </label>
                             {% endfor %}
+                        </div>
+                        <div class="text-danger small mt-2{% if not form_errors.get(q.id) %} d-none{% endif %}" data-assessment-error="{{ q.id }}">
+                            {{ form_errors.get(q.id) or '请选择这一项后再提交。' }}
                         </div>
                     </div>
                 </div>
@@ -293,13 +313,63 @@
         document.getElementById('progressTxt').textContent = n + ' / ' + total;
         document.getElementById('progressBar').style.width = (n / total * 100) + '%';
     }
+    function setQuestionError(name, hasError) {
+        const card = document.querySelector(`[data-assessment-question="${name}"]`);
+        const message = document.querySelector(`[data-assessment-error="${name}"]`);
+        if (card) {
+            card.classList.toggle('is-invalid', hasError);
+            if (hasError) card.setAttribute('aria-invalid', 'true');
+            else card.removeAttribute('aria-invalid');
+        }
+        if (message) message.classList.toggle('d-none', !hasError);
+    }
+    function validateAssessment() {
+        return Array.from(document.querySelectorAll('[data-assessment-question]'))
+            .map(card => card.dataset.assessmentQuestion)
+            .filter(name => !document.querySelector(`.assess-opt[name="${name}"]:checked`));
+    }
     document.querySelectorAll('.assess-opt').forEach(input => {
         input.addEventListener('change', () => {
             syncGroup(input.name);
+            setQuestionError(input.name, false);
             update();
+            const missing = validateAssessment();
+            document.getElementById('assessmentMissingCount').textContent = String(missing.length);
+            summary.classList.toggle('d-none', missing.length === 0);
         });
         syncGroup(input.name);
     });
+    update();
+
+    const form = document.getElementById('assessForm');
+    const summary = document.getElementById('assessmentErrorSummary');
+    if (form && summary) {
+        form.addEventListener('submit', event => {
+            const missing = validateAssessment();
+            document.querySelectorAll('[data-assessment-question]').forEach(card => {
+                setQuestionError(card.dataset.assessmentQuestion, missing.includes(card.dataset.assessmentQuestion));
+            });
+            if (!missing.length) return;
+            event.preventDefault();
+            document.getElementById('assessmentMissingCount').textContent = String(missing.length);
+            summary.classList.remove('d-none');
+            summary.focus({ preventScroll: true });
+            const firstCard = document.querySelector(`[data-assessment-question="${missing[0]}"]`);
+            if (firstCard) {
+                firstCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                firstCard.focus({ preventScroll: true });
+            }
+        });
+    }
+
+    const serverMissing = validateAssessment().filter(name => {
+        const card = document.querySelector(`[data-assessment-question="${name}"]`);
+        return card && card.classList.contains('is-invalid');
+    });
+    if (serverMissing.length) {
+        const firstCard = document.querySelector(`[data-assessment-question="${serverMissing[0]}"]`);
+        if (firstCard) firstCard.focus();
+    }
 })();
 </script>
 {% endblock %}

--- a/templates/ml_prediction.html
+++ b/templates/ml_prediction.html
@@ -10,9 +10,16 @@
         <p>根据年龄、性别和当前天气，整理需要优先关注的健康类别。分数用于安排日常观察，不代表发病概率，也不能用于诊断。</p>
     </section>
 
+    {% if is_guest %}
+    <div class="alert alert-info yl-fade-up" role="status" data-testid="ml-guest-requirement">
+        <strong>游客可以先浏览这项功能说明。</strong>
+        生成个人类别线索需要<a href="{{ url_for('public.login', next=request.path) }}" class="alert-link">登录正式账号</a>或<a href="{{ url_for('public.register') }}" class="alert-link">注册账号</a>。
+    </div>
+    {% endif %}
+
     <div class="row g-4">
         <div class="col-lg-4">
-            <form method="POST" action="{{ url_for('tools.ml_prediction') }}" class="yl-section yl-fade-up yl-fade-up-d1">
+            <form method="POST" action="{{ url_for('tools.ml_prediction') }}" class="yl-section yl-fade-up yl-fade-up-d1" novalidate>
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <h4 style="font-size:1.05rem;">输入信息</h4>
 
@@ -27,8 +34,12 @@
                 </div>
                 <div class="mb-3">
                     <label class="form-label">所在地</label>
-                    <input type="text" class="form-control" name="location" value="{{ form_state.location if form_state else (current_location or '') }}" list="locOpts">
+                    <input type="text" class="form-control{% if prediction_error and prediction_error.code == 'invalid_location' %} is-invalid{% endif %}" name="location" value="{{ form_state.location if form_state else (current_location or '') }}" list="locOpts" aria-describedby="mlLocationHelp{% if prediction_error and prediction_error.code == 'invalid_location' %} mlLocationError{% endif %}">
                     <datalist id="locOpts">{% for loc in (location_options or []) %}<option value="{{ loc }}"></option>{% endfor %}</datalist>
+                    <div class="form-text" id="mlLocationHelp">目前仅支持都昌县及列表中的乡镇、社区。</div>
+                    {% if prediction_error and prediction_error.code == 'invalid_location' %}
+                    <div class="invalid-feedback" id="mlLocationError">{{ prediction_error.message }}</div>
+                    {% endif %}
                 </div>
                 <div class="mb-3">
                     <label class="form-label">年龄</label>
@@ -37,14 +48,18 @@
                 <div class="alert alert-light border small" role="note">
                     慢病档案不会参与这项类别排序。需要查看慢病与天气的关系，请使用“慢病风险评估”。
                 </div>
+                {% if is_guest %}
+                <a class="btn btn-primary w-100" href="{{ url_for('public.login', next=request.path) }}"><i class="bi bi-box-arrow-in-right me-1"></i>登录后生成</a>
+                {% else %}
                 <button type="submit" class="btn btn-primary w-100"><i class="bi bi-magic me-1"></i>生成类别线索</button>
+                {% endif %}
             </form>
         </div>
 
         <div class="col-lg-8">
             {% if prediction_error %}
             <section class="yl-section yl-fade-up yl-fade-up-d2 mb-3">
-                <div class="alert alert-warning mb-0">健康关注线索暂时无法生成，请稍后再试。</div>
+                <div class="alert alert-warning mb-0" role="alert" data-error-code="{{ prediction_error.code }}">{{ prediction_error.message }}</div>
             </section>
             {% endif %}
             {% if prediction %}

--- a/tests/test_input_integrity_and_handoff.py
+++ b/tests/test_input_integrity_and_handoff.py
@@ -1,0 +1,553 @@
+# -*- coding: utf-8 -*-
+"""输入完整性、地点边界与小程序行动交接回归。"""
+from pathlib import Path
+
+import pytest
+
+
+def _login_as(client, user_id, csrf_token='test-csrf-token'):
+    with client.session_transaction() as session:
+        session['_user_id'] = f'{user_id}:1'
+        session['_fresh'] = True
+        session['_csrf_token'] = csrf_token
+
+
+def _create_user(db_session, username='input-integrity-user'):
+    from core.db_models import User
+
+    user = User(username=username, role='user', age=72, gender='男')
+    user.set_password('testpass')
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+def _online_weather(temperature=31.4):
+    return {
+        'temperature': temperature,
+        'humidity': 68,
+        'data_source': 'QWeather',
+        'is_mock': False,
+        'is_demo': False,
+    }
+
+
+@pytest.mark.parametrize('raw', ['北京', '101010100', '116.20,29.27', '完全不存在地点'])
+def test_strict_user_location_rejects_external_ids_coordinates_and_unknown(app, raw):
+    from core.location_resolution import resolve_user_location
+
+    with app.app_context():
+        result = resolve_user_location(raw)
+
+    assert result.valid is False
+    assert result.raw == raw
+    assert result.value is None
+    assert '目前仅支持都昌县' in result.error
+
+
+def test_strict_user_location_accepts_county_and_configured_village(app):
+    from core.location_resolution import resolve_user_location
+
+    with app.app_context():
+        county = resolve_user_location('都昌')
+        village = resolve_user_location('都昌县牛家垄周村')
+
+    assert county.valid is True
+    assert county.value == '都昌'
+    assert village.valid is True
+    assert village.value == '牛家垄周村'
+
+
+def test_strict_user_location_rejects_external_default_city_misconfiguration(
+    app,
+    monkeypatch,
+):
+    from core.location_resolution import resolve_user_location
+
+    with app.app_context():
+        monkeypatch.setitem(app.config, 'DEFAULT_CITY', '北京')
+        result = resolve_user_location('北京')
+
+    assert result.valid is False
+
+
+def test_tool_location_accepts_confirmed_dynamic_county_community_but_rejects_beijing(
+    client,
+    db_session,
+    monkeypatch,
+):
+    from core.db_models import Community
+
+    user = _create_user(db_session, username='dynamic-county-community')
+    db_session.add(Community(name='甲村', location='甲村'))
+    db_session.commit()
+    _login_as(client, user.id)
+    monkeypatch.setattr(
+        'blueprints.tools.get_qweather_forecast_with_cache',
+        lambda location, days: ([], False, {'source': 'QWeather'}),
+    )
+
+    accepted = client.get('/forecast-7day?location=甲村')
+    rejected = client.get('/forecast-7day?location=北京')
+
+    assert accepted.status_code == 200
+    assert 'value="甲村"' in accepted.get_data(as_text=True)
+    assert rejected.status_code == 422
+    assert '未找到这个地点' in rejected.get_data(as_text=True)
+
+
+@pytest.mark.parametrize('path', ['/ml-prediction', '/forecast-7day'])
+@pytest.mark.parametrize('invalid_location', ['火星一号社区', '北京'])
+def test_invalid_tool_location_returns_422_preserves_input_and_skips_services(
+    client,
+    db_session,
+    monkeypatch,
+    path,
+    invalid_location,
+):
+    user = _create_user(
+        db_session,
+        username=f"invalid-location-{path.rsplit('/', 1)[-1]}-{len(invalid_location)}",
+    )
+    _login_as(client, user.id)
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('非法地点不得调用天气或预测服务')
+
+    monkeypatch.setattr('blueprints.tools.get_weather_with_cache', unexpected)
+    monkeypatch.setattr('blueprints.tools.get_qweather_forecast_with_cache', unexpected)
+    monkeypatch.setattr('blueprints.tools.get_ml_service', unexpected)
+    monkeypatch.setattr('blueprints.tools.get_forecast_service', unexpected)
+
+    if path == '/ml-prediction':
+        response = client.post(
+            path,
+            data={
+                'location': invalid_location,
+                'age': '72',
+                'csrf_token': 'test-csrf-token',
+            },
+        )
+    else:
+        response = client.get(f'{path}?location={invalid_location}')
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 422
+    assert invalid_location in body
+    assert '未找到这个地点' in body
+    assert 'data-error-code="invalid_location"' in body
+
+
+def test_ml_guest_gets_explicit_auth_requirement_without_weather_call(
+    client,
+    db_session,
+    monkeypatch,
+):
+    del db_session
+    client.get('/guest', follow_redirects=False)
+    with client.session_transaction() as session:
+        session['_csrf_token'] = 'test-csrf-token'
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('游客身份要求应在天气和模型调用前返回')
+
+    monkeypatch.setattr('blueprints.tools.get_weather_with_cache', unexpected)
+    monkeypatch.setattr('blueprints.tools.get_ml_service', unexpected)
+
+    response = client.post(
+        '/ml-prediction',
+        data={
+            'location': '都昌',
+            'age': '72',
+            'csrf_token': 'test-csrf-token',
+        },
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 403
+    assert '生成个人类别线索需要注册或登录正式账号' in body
+    assert 'data-error-code="auth_required"' in body
+
+
+def test_ml_service_error_is_classified_without_leaking_raw_error(
+    client,
+    db_session,
+    monkeypatch,
+):
+    user = _create_user(db_session, username='ml-safe-error-user')
+    _login_as(client, user.id)
+    monkeypatch.setattr(
+        'blueprints.tools.get_weather_with_cache',
+        lambda _location: (_online_weather(), False),
+    )
+
+    class FailedService:
+        def predict_disease_risk(self, *_args, **_kwargs):
+            return {'success': False, 'error': 'secret stack /srv/private/model.pkl'}
+
+    monkeypatch.setattr('blueprints.tools.get_ml_service', lambda: FailedService())
+    response = client.post(
+        '/ml-prediction',
+        data={
+            'location': '都昌',
+            'age': '72',
+            'csrf_token': 'test-csrf-token',
+        },
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert '类别线索模型正在维护' in body
+    assert 'secret stack' not in body
+    assert '/srv/private' not in body
+
+
+@pytest.mark.parametrize(
+    ('field', 'value'),
+    [
+        ('sbp', '59'),
+        ('sbp', '261'),
+        ('sbp', 'nan'),
+        ('sbp', 'inf'),
+        ('sbp', '1e2'),
+        ('sbp', '9' * 64),
+        ('fbg', '1.9'),
+        ('fbg', '30.1'),
+        ('fbg', 'nan'),
+        ('fbg', 'inf'),
+        ('fbg', '-inf'),
+        ('fbg', '2e1'),
+        ('fbg', '9' * 64),
+    ],
+)
+def test_chronic_vital_rejection_is_422_and_stops_weather_and_risk(
+    client,
+    db_session,
+    monkeypatch,
+    field,
+    value,
+):
+    user = _create_user(db_session, username=f'chronic-{field}-{len(value)}-{value[:2]}')
+    _login_as(client, user.id)
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('无效生命体征不得调用天气或慢病风险服务')
+
+    monkeypatch.setattr('blueprints.tools.get_weather_with_cache', unexpected)
+    monkeypatch.setattr('blueprints.tools.get_chronic_service', unexpected)
+    response = client.post(
+        '/chronic-risk',
+        data={
+            'disease': 'hypertension',
+            'sbp': value if field == 'sbp' else '',
+            'fbg': value if field == 'fbg' else '',
+            'csrf_token': 'test-csrf-token',
+        },
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 422
+    assert '请先修正生命体征输入' in body
+    assert 'is-invalid' in body
+    assert '综合风险评分' not in body
+
+
+@pytest.mark.parametrize(
+    ('sbp', 'fbg', 'expected_vitals'),
+    [
+        ('60', '2', {'sbp': 60.0, 'fbg': 2.0}),
+        ('260', '30', {'sbp': 260.0, 'fbg': 30.0}),
+        ('', '', {}),
+    ],
+)
+def test_chronic_vital_boundaries_and_blank_values_are_accepted(
+    client,
+    db_session,
+    monkeypatch,
+    sbp,
+    fbg,
+    expected_vitals,
+):
+    user = _create_user(
+        db_session,
+        username=f'chronic-valid-{sbp or "blank"}-{fbg or "blank"}',
+    )
+    _login_as(client, user.id)
+    monkeypatch.setattr(
+        'blueprints.tools.get_weather_with_cache',
+        lambda _location: (_online_weather(), False),
+    )
+
+    captured = {}
+
+    class StubChronicService:
+        def predict_individual_risk(self, profile, _weather):
+            captured['vitals'] = profile['vitals']
+            return {
+                'overall_risk': {'score': 35, 'level': '低风险'},
+                'disease_risks': {},
+                'recommendations': [],
+            }
+
+    monkeypatch.setattr(
+        'blueprints.tools.get_chronic_service',
+        lambda: StubChronicService(),
+    )
+    response = client.post(
+        '/chronic-risk',
+        data={
+            'disease': 'hypertension',
+            'sbp': sbp,
+            'fbg': fbg,
+            'csrf_token': 'test-csrf-token',
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured['vitals'] == expected_vitals
+
+
+@pytest.mark.parametrize('answered_count', [0, 4])
+def test_incomplete_health_assessment_returns_422_preserves_answers_and_skips_weather(
+    authenticated_client,
+    db_session,
+    monkeypatch,
+    answered_count,
+):
+    answers = [
+        ('outdoor_exposure', 'low'),
+        ('symptom_level', 'none'),
+        ('hydration', 'good'),
+        ('medication_adherence', 'good'),
+        ('sleep_quality', 'good'),
+    ]
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('未完成问卷不得读取天气或调用风险服务')
+
+    monkeypatch.setattr(
+        'services.user.profile_service.get_weather_with_cache',
+        unexpected,
+    )
+    payload = dict(answers[:answered_count])
+    payload['csrf_token'] = 'test-csrf-token'
+    response = authenticated_client.post('/health-assessment', data=payload)
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 422
+    assert f'还差 <span id="assessmentMissingCount">{5 - answered_count}</span> 项' in body
+    assert 'assessment-question is-invalid' in body
+    assert 'validateAssessment()' in body
+    for name, value in answers[:answered_count]:
+        assert f'name="{name}" value="{value}" class="visually-hidden assess-opt" checked' in body
+    assert 'autofocus' in body
+    assert db_session.query(__import__('core.db_models', fromlist=['HealthRiskAssessment']).HealthRiskAssessment).count() == 0
+
+
+def test_formal_action_handoff_has_real_fallback_and_no_fake_code(app, client):
+    app.config['WECHAT_FORMAL_RUNTIME'] = True
+    app.config['WX_MINIPROGRAM_ACTION_CODE_IMAGE'] = ''
+
+    response = client.get('/elder')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'data-testid="miniprogram-action-handoff"' in body
+    assert 'data-miniprogram-path="pages/actions/index"' in body
+    assert '搜索小程序“宜老平安”' in body
+    assert 'data-testid="miniprogram-code-fallback"' in body
+    assert '复制名称' in body
+    assert '公共行动可直接在本机勾选' in body
+    assert '从“照护”选择对应家人' in body
+    assert '返回今日风险' in body
+    assert '今天先做这 3 件事' in body
+    assert 'alt="宜老平安官方小程序码' not in body
+
+
+def test_miniprogram_code_image_contract_rejects_missing_static_and_accepts_https(app):
+    from core.config import _validated_miniprogram_code_image
+
+    assert _validated_miniprogram_code_image(
+        'images/not-present-action-code.png',
+        app.static_folder,
+    ) == ''
+    assert _validated_miniprogram_code_image(
+        '../private/action-code.png',
+        app.static_folder,
+    ) == ''
+    assert _validated_miniprogram_code_image(
+        'https://cdn.example.org/yilao/action-code.png',
+        app.static_folder,
+    ) == 'https://cdn.example.org/yilao/action-code.png'
+    assert _validated_miniprogram_code_image(
+        'brand/yilao-avatar.png',
+        app.static_folder,
+    ) == 'brand/yilao-avatar.png'
+    assert _validated_miniprogram_code_image(
+        'HTTPS://cdn.example.org/yilao/action-code.png',
+        app.static_folder,
+    ) == 'https://cdn.example.org/yilao/action-code.png'
+
+
+def test_formal_action_handoff_renders_normalized_remote_code_without_referrer(app, client):
+    from core.config import _validated_miniprogram_code_image
+
+    app.config['WECHAT_FORMAL_RUNTIME'] = True
+    app.config['WX_MINIPROGRAM_ACTION_CODE_IMAGE'] = _validated_miniprogram_code_image(
+        'HTTPS://cdn.example.org/yilao/action-code.png',
+        app.static_folder,
+    )
+
+    response = client.get('/elder')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'src="https://cdn.example.org/yilao/action-code.png"' in body
+    assert 'referrerpolicy="no-referrer"' in body
+    assert 'data-testid="miniprogram-code-fallback"' not in body
+
+
+def test_invalid_cooling_location_is_422_and_never_reads_weather(
+    client,
+    db_session,
+    monkeypatch,
+):
+    del db_session
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('非法避暑地点不得读取天气快照或旧天气缓存')
+
+    monkeypatch.setattr('services.public_service.get_bootstrap_payload', unexpected)
+    monkeypatch.setattr('services.public_service.get_weather_with_cache', unexpected)
+    response = client.get('/cooling?community=不存在的火星社区')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 422
+    assert 'value="不存在的火星社区"' in body
+    assert '原输入已保留' in body
+    assert 'data-error-code="invalid_location"' in body
+    assert '都昌 · 当前室外' not in body
+
+
+def test_cooling_uses_fresh_bootstrap_snapshot_and_renders_final_temperature_first(
+    client,
+    db_session,
+    monkeypatch,
+):
+    del db_session
+    monkeypatch.setattr(
+        'services.public_service.get_bootstrap_payload',
+        lambda: {
+            'snapshot_id': 'snapshot-cooling-12345678',
+            'fetched_at': '2026-08-12T20:30:00+08:00',
+            'stale': False,
+            'current_stale': False,
+            'risk_stale': False,
+            'current': _online_weather(31.4),
+        },
+    )
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('已有快照时不得混读旧天气缓存')
+
+    monkeypatch.setattr('services.public_service.get_weather_with_cache', unexpected)
+    response = client.get('/cooling?location=都昌')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'data-temp="31.4"' in body
+    assert 'data-static-value="1"' in body
+    assert '<span class="num">31.4</span>' in body
+    assert '<span class="num">0</span>' not in body
+    assert '天气快照 snapshot' in body
+
+
+@pytest.mark.parametrize(
+    'snapshot_overrides',
+    [
+        {'current_stale': True, 'risk_stale': False},
+        {'current_stale': False, 'risk_stale': True},
+        {'current_stale': False, 'risk_stale': False, 'current': {'is_mock': True}},
+    ],
+)
+def test_cooling_existing_unusable_snapshot_never_shows_temperature_or_reads_legacy(
+    client,
+    db_session,
+    monkeypatch,
+    snapshot_overrides,
+):
+    del db_session
+    snapshot = {
+        'snapshot_id': 'snapshot-unusable-current',
+        'stale': False,
+        'current_stale': False,
+        'risk_stale': False,
+        'current': _online_weather(39.5),
+    }
+    snapshot.update(snapshot_overrides)
+    monkeypatch.setattr(
+        'services.public_service.get_bootstrap_payload',
+        lambda: snapshot,
+    )
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('已有快照时即使不可用也不得混读旧天气缓存')
+
+    monkeypatch.setattr('services.public_service.get_weather_with_cache', unexpected)
+    response = client.get('/cooling?location=都昌')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'data-fx="thermometer"' not in body
+    assert '<span class="num">39.5</span>' not in body
+
+
+def test_county_cooling_filter_keeps_all_configured_community_resources(
+    client,
+    db_session,
+    monkeypatch,
+):
+    from core.db_models import CoolingResource
+
+    db_session.add(CoolingResource(
+        community_code='牛家垄周村',
+        name='周村已核验纳凉点',
+        resource_type='社区服务场所',
+        is_active=True,
+    ))
+    db_session.commit()
+    monkeypatch.setattr(
+        'services.public_service.get_bootstrap_payload',
+        lambda: {
+            'snapshot_id': 'snapshot-county-filter',
+            'stale': True,
+            'current': {},
+        },
+    )
+
+    response = client.get('/cooling?community=都昌')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert '周村已核验纳凉点' in body
+    assert '<option value="都昌"></option>' in body
+    assert '<option value="北京"></option>' not in body
+
+
+def test_filtered_cooling_page_hides_unverified_candidate_preview(client, db_session):
+    del db_session
+    response = client.get('/cooling?community=牛家垄周村')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert '待核验场所预览' not in body
+
+
+def test_cooling_templates_explain_disabled_location_and_keep_server_value_static():
+    project_root = Path(__file__).resolve().parents[1]
+    template = (project_root / 'templates' / 'cooling.html').read_text(encoding='utf-8')
+    script = (project_root / 'static' / 'js' / 'yilao-data-fx-extra.js').read_text(encoding='utf-8')
+
+    assert '当前没有已核验地图点位，暂不能按位置查找' in template
+    assert '地图服务尚未配置，暂不能读取位置' in template
+    assert '开放时间未核验，请出发前确认' in template
+    assert "el.dataset.staticValue !== '1'" in script

--- a/tests/test_public_token_flow.py
+++ b/tests/test_public_token_flow.py
@@ -243,7 +243,8 @@ def test_formal_wechat_runtime_stops_web_entry_before_reading_family_data(
     entry = client.get("/e/formal-readonly-page-token", follow_redirects=False)
     assert entry.status_code == 200
     entry_body = entry.get_data(as_text=True)
-    assert "当前网页仅供查看停用说明" in entry_body
+    assert "去“宜老平安”完成家庭打卡" in entry_body
+    assert "data-miniprogram-path=\"pages/actions/index\"" in entry_body
     assert 'name="short_code"' not in entry_body
     response = client.post(
         "/elder/enter",
@@ -253,7 +254,8 @@ def test_formal_wechat_runtime_stops_web_entry_before_reading_family_data(
 
     assert response.status_code == 200
     body = response.get_data(as_text=True)
-    assert "当前网页仅供查看停用说明" in body
+    assert "去“宜老平安”完成家庭打卡" in body
+    assert "data-miniprogram-path=\"pages/actions/index\"" in body
     assert "不会读取短码、兑换安全链接或写入家庭记录" in body
     assert 'name="short_code"' not in body
     assert 'action="/e/formal-readonly-page-token/checkin"' not in body
@@ -306,7 +308,8 @@ def test_formal_wechat_runtime_stops_debrief_get_before_family_lookup(
 
     assert response.status_code == 200
     body = response.get_data(as_text=True)
-    assert "当前网页仅供查看停用说明" in body
+    assert "去“宜老平安”完成家庭打卡" in body
+    assert "data-miniprogram-path=\"pages/actions/index\"" in body
     assert 'name="short_code"' not in body
 
 


### PR DESCRIPTION
## 这次改了什么

为健康评估、慢病指标、ML/7 天预报和避暑资源补齐严格输入边界，并把正式网页行动入口改造成宜老平安小程序的安全交接页。

## 为什么要改

Grok 真人走查发现健康评估不完整提交静默、生命体征越界仍继续计算、县外/无效地点静默回退都昌、ML 游客错误含糊，以及行动 CTA 在正式 Web 只能到停用说明。避暑资源页还存在候选资料看似参与筛选、缺开放时间说明和温度从 0 跳变等问题。

## 怎么测试

- `/opt/anaconda3/envs/case-weather-py312/bin/python -m pytest -q tests/test_input_integrity_and_handoff.py tests/test_tools_page_regressions.py tests/test_health_assessment_page.py tests/test_public_token_flow.py tests/test_motion_widgets.py tests/test_cooling_coordinate_contract.py tests/test_formal_web_gate.py tests/test_web_owner_write_guard.py tests/test_route_redirect_contract.py` → 256 passed
- `node --test tests/cooling_map_privacy.test.js` → 1 passed
- `python -m py_compile` 覆盖所有改动 Python 模块
- `git diff --check` 通过
- 真人浏览器验证：健康评估 0/5 与 4/5 中文错误、聚焦与答案保留；行动交接复制反馈；桌面与 390px 移动端无横向溢出；控制台无 warning/error

## 文件与迁移

- 无数据库迁移。
- 源码、模板、前端脚本与测试均保留在主仓库。
- 未修改 `.sh` 或 `.githooks`，无需 `bash -n`。

## 发布门禁

- 仓库未包含官方永久小程序码。未配置 `WX_MINIPROGRAM_ACTION_CODE_IMAGE` 时，页面会诚实显示微信搜索后备路径，绝不展示假码。
- 官方码资产核验、生产配置与真机扫码需在发布前完成。
- 本 PR 未执行部署、服务器操作或微信上传。

## Notion

当前无法访问 Notion，验收结果与发布门禁待回填。