### PR TITLE
fix: 收口 Grok QA 跨端问题与发布边界

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,9 @@ WX_MINIPROGRAM_SECRET=
 # 两项均使用独立的 32 字节以上随机值。
 WX_MINIPROGRAM_OPENID_PEPPER=
 WX_MINIPROGRAM_SESSION_SECRET=
+# 可选：官方永久小程序码图片。填写 static 下相对文件名（如 images/action-code.png）
+# 或 HTTPS 图片 URL；缺失或文件无效时网页不会显示占位码或假二维码。
+WX_MINIPROGRAM_ACTION_CODE_IMAGE=
 # 网页与微信一次性绑定码专用 pepper，必须与上面两项及 SECRET_KEY 分开生成。
 ACCOUNT_LINK_CODE_PEPPER=
 # 更新隐私指引内容时同步递增版本，旧会话会要求重新同意。

--- a/blueprints/mp_api.py
+++ b/blueprints/mp_api.py
@@ -56,6 +56,7 @@ from core.usage import (
 from core.weather import (
     compact_assessment_weather_condition,
     get_weather_with_cache,
+    is_complete_qweather_weather,
     is_qweather_online_weather,
 )
 from services.location_resolver import resolve_location
@@ -92,6 +93,7 @@ from services.miniprogram_service import (
     public_communities_payload,
     public_cooling_resources_payload,
     public_gis_metadata_payload,
+    snapshot_component_status,
 )
 from services.push.locks import push_owner_lock
 from utils.parsers import safe_json_loads
@@ -1411,7 +1413,8 @@ def elders_list():
     # 只有受支持的 Pair 才读取县级快照；所有受支持老人共享同一 snapshot_id。
     snapshot = get_bootstrap_payload() if any(support_map.values()) else {}
     current = snapshot.get("current") if isinstance(snapshot.get("current"), dict) else {}
-    weather_available = bool(snapshot.get("available"))
+    current_status = snapshot_component_status(snapshot, "current")
+    weather_available = current_status["usable"]
     tmax_value = _finite_or_none(current.get("temperature_max")) if weather_available else None
     tmin_value = _finite_or_none(current.get("temperature_min")) if weather_available else None
     trigger = None
@@ -1480,7 +1483,7 @@ def elders_list():
                     "weather_available": bool(
                         miniprogram_supported and weather_available
                     ),
-                    "stale": bool(snapshot.get("stale")) if miniprogram_supported else False,
+                    "stale": current_status["stale"] if miniprogram_supported else False,
                     "is_mock": bool(current.get("is_mock")) if miniprogram_supported else False,
                 },
             }
@@ -1901,11 +1904,18 @@ def health_assessment():
                 raise ValueError(f"invalid_{field}")
             screening[field] = value
         snapshot = get_bootstrap_payload()
-        if not snapshot.get("available"):
+        current_status = snapshot_component_status(snapshot, "current")
+        if not current_status["available"]:
             return _error("weather_snapshot_unavailable", "天气快照尚未可用，请稍后重试。", 503)
-        if snapshot.get("stale"):
+        if current_status["stale"]:
             return _error("weather_snapshot_stale", "天气快照正在更新，请稍后重试。", 503)
         current = snapshot.get("current") or {}
+        if not is_complete_qweather_weather(current):
+            return _error(
+                "weather_snapshot_incomplete",
+                "天气快照字段尚未完整，请稍后重试。",
+                503,
+            )
         user = db.session.get(User, g.api_user_id)
         profile = {
             "age": member.age if member and member.age is not None else (user.age or 45),
@@ -1974,10 +1984,10 @@ def _daily_status_for_pair(pair):
         snapshot = get_bootstrap_payload()
         current = snapshot.get("current") if isinstance(snapshot.get("current"), dict) else None
         risk = snapshot.get("risk") if isinstance(snapshot.get("risk"), dict) else {}
+        risk_status = snapshot_component_status(snapshot, "risk")
         if (
             not snapshot.get("snapshot_id")
-            or snapshot.get("available") is not True
-            or snapshot.get("stale") is not False
+            or not risk_status["usable"]
             or not is_qweather_online_weather(current)
             or risk.get("available") is not True
         ):
@@ -2163,7 +2173,10 @@ def alerts_list():
 
     snapshot = get_bootstrap_payload()
     weather_data = snapshot.get("current") if isinstance(snapshot.get("current"), dict) else {}
-    weather_available = bool(snapshot.get("available"))
+    current_status = snapshot_component_status(snapshot, "current")
+    warnings_status = snapshot_component_status(snapshot, "warnings")
+    weather_available = current_status["usable"]
+    warnings_available = warnings_status["usable"]
     location = snapshot.get("location") or {}
 
     return jsonify(
@@ -2172,12 +2185,14 @@ def alerts_list():
             "data": {
                 "snapshot_id": snapshot.get("snapshot_id"),
                 "location": location,
-                "warnings": snapshot.get("warnings") or [],
+                "warnings": (snapshot.get("warnings") or []) if warnings_available else [],
+                "warnings_available": warnings_available,
+                "warnings_stale": warnings_status["stale"],
                 "weather": {
                     "temperature_max": weather_data.get("temperature_max") if weather_available else None,
                     "temperature_min": weather_data.get("temperature_min") if weather_available else None,
                     "weather_available": weather_available,
-                    "stale": bool(snapshot.get("stale")),
+                    "stale": current_status["stale"],
                     "is_mock": bool(weather_data.get("is_mock")),
                 },
             },

--- a/blueprints/public.py
+++ b/blueprints/public.py
@@ -38,7 +38,7 @@ from core.extensions import limiter
 from core.extensions import db
 from core.audit import log_audit
 from core.guest import is_guest_user
-from core.security import rate_limit_key
+from core.security import client_rate_limit_key, rate_limit_key
 from core.time_utils import ensure_utc_aware, utcnow
 from core.usage import log_usage_event
 from core.db_models import AlertDelivery, WeatherAlert
@@ -457,7 +457,14 @@ def role_entry():
 
 
 @bp.route('/login', methods=['GET', 'POST'], endpoint='login')
-@limiter.limit(lambda: current_app.config.get('RATE_LIMIT_LOGIN', '5 per 5 minutes'), methods=['POST'], key_func=rate_limit_key)
+@limiter.limit(
+    lambda: current_app.config.get('RATE_LIMIT_LOGIN', '5 per 5 minutes'),
+    methods=['POST'],
+    key_func=client_rate_limit_key,
+    deduct_when=lambda response: response.status_code not in {
+        301, 302, 303, 307, 308,
+    },
+)
 def login():
     """登录"""
     # URL 不经过 HTML 清理，避免把 & 重复转义为 &amp;。
@@ -470,7 +477,7 @@ def login():
 @limiter.limit(
     lambda: current_app.config.get('RATE_LIMIT_REGISTER', '5 per hour'),
     methods=['POST'],
-    key_func=rate_limit_key,
+    key_func=client_rate_limit_key,
 )
 def register():
     """注册"""

--- a/blueprints/tools.py
+++ b/blueprints/tools.py
@@ -1,20 +1,22 @@
 # -*- coding: utf-8 -*-
 """Tooling and prediction pages."""
 from datetime import datetime
+from decimal import Decimal, InvalidOperation
 import math
+import re
 
 from flask import Blueprint, current_app, flash, render_template, request
 from flask_login import current_user, login_required
 
-from core.db_models import FamilyMember
+from core.guest import is_guest_user
+from core.location_resolution import get_user_location_options, resolve_user_location
+from core.db_models import Community, FamilyMember
 from core.time_utils import today_local
 from core.weather import (
     ensure_user_location_valid,
-    get_location_options,
     get_qweather_forecast_with_cache,
     get_weather_with_cache,
     is_qweather_online_weather,
-    normalize_location_name,
 )
 from services.chronic_risk_service import get_chronic_service
 from services.forecast_cards import build_forecast_cards
@@ -55,12 +57,31 @@ def _selected_member(member_id):
     return FamilyMember.query.filter_by(id=parsed_id, user_id=current_user.id).first()
 
 
-def _normalized_location(raw_location):
-    """清洗并标准化地点输入。"""
-    location = sanitize_input(raw_location, max_length=100)
-    if location:
-        return normalize_location_name(location)
-    return ensure_user_location_valid()
+def _tool_location_options():
+    """合并静态县内别名与管理员维护的社区表。"""
+    dynamic_names = []
+    try:
+        communities = Community.query.with_entities(
+            Community.name,
+        ).all()
+    except Exception as exc:
+        current_app.logger.warning('读取工具页社区候选失败: %s', exc)
+        communities = []
+    for (name,) in communities:
+        clean_name = str(name or '').strip()
+        if clean_name:
+            dynamic_names.append(clean_name)
+    return get_user_location_options(extra_names=dynamic_names)
+
+
+def _resolve_tool_location(raw_location, *, location_options=None):
+    """解析工具页地点，非法输入不得回退到默认县域。"""
+    raw = raw_location.strip() if isinstance(raw_location, str) else ''
+    candidate = raw or ensure_user_location_valid()
+    return resolve_user_location(
+        candidate,
+        extra_names=location_options or _tool_location_options(),
+    )
 
 
 def _coerce_age(raw_age, default_age):
@@ -215,16 +236,72 @@ def _build_chronic_breakdown(result, adherence, symptoms):
     return breakdown[:4]
 
 
+_PLAIN_DECIMAL_RE = re.compile(r'^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$')
+
+
+def _parse_optional_vital(raw_value, *, label, minimum, maximum):
+    """只接受短、有限且不使用指数写法的十进制生命体征。"""
+    if raw_value is None:
+        return None, None
+    raw = str(raw_value).strip()
+    if not raw:
+        return None, None
+    if len(raw) > 20:
+        return None, f'{label}输入过长，请重新填写。'
+    if not _PLAIN_DECIMAL_RE.fullmatch(raw):
+        return None, f'{label}格式不正确，请填写普通数字。'
+    try:
+        value = Decimal(raw)
+    except InvalidOperation:
+        return None, f'{label}格式不正确，请填写普通数字。'
+    if not value.is_finite():
+        return None, f'{label}格式不正确，请填写有限数字。'
+    if value < Decimal(str(minimum)) or value > Decimal(str(maximum)):
+        return None, f'{label}需在 {minimum} 到 {maximum} 之间。'
+    return float(value), None
+
+
 def _parse_chronic_vitals(form_state):
-    """解析慢病表单中的自测血压/血糖。"""
-    sbp = parse_float(form_state.get('sbp'))
-    fbg = parse_float(form_state.get('fbg'))
+    """严格解析慢病表单中的可选血压与血糖。"""
     vitals = {}
-    if sbp is not None and 60 <= sbp <= 260:
+    errors = {}
+    sbp, sbp_error = _parse_optional_vital(
+        form_state.get('sbp'),
+        label='最高收缩压',
+        minimum=60,
+        maximum=260,
+    )
+    fbg, fbg_error = _parse_optional_vital(
+        form_state.get('fbg'),
+        label='空腹血糖',
+        minimum=2,
+        maximum=30,
+    )
+    if sbp_error:
+        errors['sbp'] = sbp_error
+    elif sbp is not None:
         vitals['sbp'] = sbp
-    if fbg is not None and 2 <= fbg <= 30:
+    if fbg_error:
+        errors['fbg'] = fbg_error
+    elif fbg is not None:
         vitals['fbg'] = fbg
-    return vitals
+    return vitals, errors
+
+
+def _classified_ml_error(raw_error=None, *, code='model_unavailable'):
+    """把模型内部错误收敛为可安全展示的有限分类。"""
+    normalized = str(raw_error or '').strip().lower()
+    if code == 'auth_required':
+        message = '游客可以浏览说明；生成个人类别线索需要注册或登录正式账号。'
+    elif code == 'invalid_location':
+        message = str(raw_error)
+    elif code == 'weather_unavailable':
+        message = '健康关注线索暂时无法生成：官方天气快照正在更新，请稍后再试。'
+    elif any(marker in normalized for marker in ('model', '模型', 'load', '加载')):
+        message = '类别线索模型正在维护，请稍后再试。'
+    else:
+        message = '类别线索服务暂时不可用，请稍后再试。'
+    return {'code': code, 'message': message}
 
 
 def _normalize_chronic_suggestions(items):
@@ -245,6 +322,7 @@ def ml_prediction():
     """ML预测页面。"""
     family_members = _tool_family_members()
     current_location = ensure_user_location_valid()
+    location_options = _tool_location_options()
     form_state = {
         'member_id': '',
         'location': current_location,
@@ -253,48 +331,72 @@ def ml_prediction():
     prediction = None
     factors = None
     prediction_error = None
+    response_status = 200
 
     if request.method == 'POST':
         selected_member = _selected_member(request.form.get('member_id'))
         default_age = selected_member.age if selected_member and selected_member.age else current_user.age or 65
         default_gender = selected_member.gender if selected_member and selected_member.gender else current_user.gender or '男'
+        raw_location = request.form.get('location')
+        location_resolution = _resolve_tool_location(
+            raw_location,
+            location_options=location_options,
+        )
         form_state = {
             'member_id': str(selected_member.id) if selected_member else '',
-            'location': _normalized_location(request.form.get('location')),
+            'location': (
+                location_resolution.raw
+                if not location_resolution.valid
+                else location_resolution.value
+            ),
             'age': _coerce_age(request.form.get('age'), default_age),
         }
 
-        weather_info, _ = get_weather_with_cache(form_state['location'])
-        if not is_qweather_online_weather(weather_info):
-            prediction_error = '天气正在更新，类别线索暂不显示。请稍后再试。'
+        if is_guest_user(current_user):
+            prediction_error = _classified_ml_error(code='auth_required')
+            response_status = 403
+        elif not location_resolution.valid:
+            prediction_error = _classified_ml_error(
+                location_resolution.error,
+                code='invalid_location',
+            )
+            response_status = 422
         else:
-            user_info = {
-                'age': form_state['age'],
-                'gender': default_gender,
-            }
-            result = get_ml_service().predict_disease_risk(user_info, weather_info)
-            if result.get('success'):
-                prediction = []
-                for rank, item in enumerate((result.get('predictions') or [])[:3], start=1):
-                    adjusted_probability = float(item.get('probability') or 0.0)
-                    original_probability = float(
-                        item.get('original_probability')
-                        if item.get('original_probability') is not None
-                        else adjusted_probability
-                    )
-                    multiplier = item.get('weather_multiplier')
-                    if multiplier is None:
-                        multiplier = adjusted_probability / original_probability if original_probability > 0 else 1.0
-                    prediction.append({
-                        'disease': item.get('disease', '未知风险'),
-                        'score': round(adjusted_probability * 100.0, 1),
-                        'original_score': round(original_probability * 100.0, 1),
-                        'weather_multiplier': round(float(multiplier), 3),
-                        'label': f'关注排序第 {rank}',
-                    })
-                factors = _build_ml_factor_cards(result, form_state['age'], weather_info)
+            weather_info, _ = get_weather_with_cache(form_state['location'])
+            if not is_qweather_online_weather(weather_info):
+                prediction_error = _classified_ml_error(code='weather_unavailable')
             else:
-                prediction_error = result.get('error') or '预测暂时不可用，请稍后再试。'
+                user_info = {
+                    'age': form_state['age'],
+                    'gender': default_gender,
+                }
+                try:
+                    result = get_ml_service().predict_disease_risk(user_info, weather_info)
+                except Exception:
+                    current_app.logger.exception('ML 类别线索服务调用失败')
+                    result = {'success': False, 'error': 'service_exception'}
+                if result.get('success'):
+                    prediction = []
+                    for rank, item in enumerate((result.get('predictions') or [])[:3], start=1):
+                        adjusted_probability = float(item.get('probability') or 0.0)
+                        original_probability = float(
+                            item.get('original_probability')
+                            if item.get('original_probability') is not None
+                            else adjusted_probability
+                        )
+                        multiplier = item.get('weather_multiplier')
+                        if multiplier is None:
+                            multiplier = adjusted_probability / original_probability if original_probability > 0 else 1.0
+                        prediction.append({
+                            'disease': item.get('disease', '未知风险'),
+                            'score': round(adjusted_probability * 100.0, 1),
+                            'original_score': round(original_probability * 100.0, 1),
+                            'weather_multiplier': round(float(multiplier), 3),
+                            'label': f'关注排序第 {rank}',
+                        })
+                    factors = _build_ml_factor_cards(result, form_state['age'], weather_info)
+                else:
+                    prediction_error = _classified_ml_error(result.get('error'))
 
     return render_template(
         'ml_prediction.html',
@@ -303,7 +405,9 @@ def ml_prediction():
         prediction=prediction,
         factors=factors,
         prediction_error=prediction_error,
-    )
+        is_guest=is_guest_user(current_user),
+        location_options=location_options,
+    ), response_status
 
 
 @bp.route('/ai-qa', endpoint='ai_qa')
@@ -318,12 +422,37 @@ def ai_qa():
 @login_required
 def forecast_7day():
     """7天健康预测页面"""
-    current_location = _normalized_location(request.args.get('location'))
+    location_options = _tool_location_options()
+    location_resolution = _resolve_tool_location(
+        request.args.get('location'),
+        location_options=location_options,
+    )
+    current_location = (
+        location_resolution.value
+        if location_resolution.valid
+        else location_resolution.raw
+    )
     start_date = today_local()
     forecast_days = []
     weekly_tips = None
     forecast_error = None
+    location_error = None
     forecast_meta = {'source': 'QWeather'}
+    if not location_resolution.valid:
+        location_error = location_resolution.error
+        return render_template(
+            'forecast_7day.html',
+            family_members=_tool_family_members(),
+            current_location=current_location,
+            location_input=location_resolution.raw,
+            location_options=location_options,
+            location_error=location_error,
+            forecast_days=[],
+            forecast_error=None,
+            forecast_meta=forecast_meta,
+            weekly_tips=None,
+        ), 422
+
     qweather_days, from_cache, forecast_meta = get_qweather_forecast_with_cache(current_location, days=7)
     forecast_meta = dict(forecast_meta or {})
     forecast_meta['source_label'] = '和风天气'
@@ -363,7 +492,9 @@ def forecast_7day():
         'forecast_7day.html',
         family_members=_tool_family_members(),
         current_location=current_location,
-        location_options=get_location_options(),
+        location_input=current_location,
+        location_options=location_options,
+        location_error=location_error,
         forecast_days=forecast_days,
         forecast_error=forecast_error,
         forecast_meta=forecast_meta,
@@ -387,46 +518,55 @@ def chronic_risk():
     breakdown = None
     suggestions = None
     risk_error = None
+    vital_errors = {}
+    response_status = 200
 
     if request.method == 'POST':
         disease_key = sanitize_input(request.form.get('disease'), max_length=32) or 'hypertension'
         disease_key = disease_key if disease_key in CHRONIC_FORM_LABELS else 'hypertension'
         form_state = {
             'disease': disease_key,
-            'sbp': sanitize_input(request.form.get('sbp'), max_length=10) or '',
-            'fbg': sanitize_input(request.form.get('fbg'), max_length=10) or '',
+            'sbp': sanitize_input(request.form.get('sbp'), max_length=32) or '',
+            'fbg': sanitize_input(request.form.get('fbg'), max_length=32) or '',
             'adherence': sanitize_input(request.form.get('adherence'), max_length=20) or 'strict',
             'symptoms': sanitize_input(request.form.get('symptoms'), max_length=100) or '',
         }
 
-        weather_data, _ = get_weather_with_cache(ensure_user_location_valid())
-        if not is_qweather_online_weather(weather_data):
-            risk_error = '天气正在更新，慢病风险提示暂不显示。请稍后再试。'
+        vitals, vital_errors = _parse_chronic_vitals({
+            'sbp': request.form.get('sbp'),
+            'fbg': request.form.get('fbg'),
+        })
+        if vital_errors:
+            risk_error = '请先修正生命体征输入，再生成慢病风险提示。'
+            response_status = 422
         else:
-            vitals = _parse_chronic_vitals(form_state)
-            result = get_chronic_service().predict_individual_risk(
-                {
-                    'age': current_user.age or 65,
-                    'gender': current_user.gender or '未知',
-                    'chronic_diseases': [CHRONIC_FORM_LABELS[disease_key]],
-                    'vitals': vitals,
-                    'sbp': vitals.get('sbp'),
-                    'fbg': vitals.get('fbg'),
-                },
-                weather_data,
-            )
+            weather_data, _ = get_weather_with_cache(ensure_user_location_valid())
+            if not is_qweather_online_weather(weather_data):
+                risk_error = '天气正在更新，本次提醒暂未生成。请稍后再试。'
+            else:
+                result = get_chronic_service().predict_individual_risk(
+                    {
+                        'age': current_user.age or 65,
+                        'gender': current_user.gender or '未知',
+                        'chronic_diseases': [CHRONIC_FORM_LABELS[disease_key]],
+                        'vitals': vitals,
+                        'sbp': vitals.get('sbp'),
+                        'fbg': vitals.get('fbg'),
+                    },
+                    weather_data,
+                )
 
-            overall = result.get('overall_risk') or {}
-            risk_score = int(round(overall.get('score', 0) or 0))
-            risk_level = overall.get('level') or _score_level(risk_score)
-            risk_comment = (
-                f"当前以{CHRONIC_FORM_LABELS[disease_key]}为重点观察对象，结合天气条件判定为{risk_level}。"
-            )
-            vital_factors = ((result.get('vital_adjustment') or {}).get('factors') or [])
-            if vital_factors:
-                risk_comment = f"{risk_comment} 已参考{'；'.join(vital_factors[:2])}。"
-            breakdown = _build_chronic_breakdown(result, form_state['adherence'], form_state['symptoms'])
-            suggestions = _normalize_chronic_suggestions(result.get('recommendations'))[:5]
+                overall = result.get('overall_risk') or {}
+                risk_score = int(round(overall.get('score', 0) or 0))
+                risk_level = overall.get('level') or _score_level(risk_score)
+                risk_comment = (
+                    f"当前以{CHRONIC_FORM_LABELS[disease_key]}为重点观察对象，结合天气条件判定为{risk_level}。"
+                )
+                vital_factors = ((result.get('vital_adjustment') or {}).get('factors') or [])
+                if vital_factors:
+                    risk_comment = f"{risk_comment} 已参考{'；'.join(vital_factors[:2])}。"
+                breakdown = _build_chronic_breakdown(result, form_state['adherence'], form_state['symptoms'])
+                suggestions = _normalize_chronic_suggestions(result.get('recommendations'))[:5]
 
     return render_template(
         'chronic_risk.html',
@@ -436,4 +576,5 @@ def chronic_risk():
         breakdown=breakdown,
         suggestions=suggestions,
         risk_error=risk_error,
-    )
+        vital_errors=vital_errors,
+    ), response_status

--- a/blueprints/tools.py
+++ b/blueprints/tools.py
@@ -84,14 +84,20 @@ def _resolve_tool_location(raw_location, *, location_options=None):
     )
 
 
-def _coerce_age(raw_age, default_age):
-    """安全转换年龄，避免模板和服务层接到异常值。"""
-    age = parse_int(raw_age)
-    if age is None:
-        age = default_age
-    if age is None:
-        age = 65
-    return max(1, min(int(age), 120))
+_ML_AGE_RE = re.compile(r'^[0-9]{1,3}$')
+
+
+def _parse_ml_age(raw_age, default_age):
+    """严格解析 ML 年龄，禁止静默截断或用默认值吞掉非法输入。"""
+    submitted = str(raw_age or '').strip()
+    candidate = submitted or str(default_age or 65).strip()
+    display_value = submitted[:32] if submitted else candidate[:32]
+    if not _ML_AGE_RE.fullmatch(candidate):
+        return None, display_value, '年龄需填写 1 到 120 之间的整数。'
+    age = int(candidate)
+    if age < 1 or age > 120:
+        return None, display_value, '年龄需填写 1 到 120 之间的整数。'
+    return age, age, None
 
 
 def _score_level(score):
@@ -293,7 +299,7 @@ def _classified_ml_error(raw_error=None, *, code='model_unavailable'):
     normalized = str(raw_error or '').strip().lower()
     if code == 'auth_required':
         message = '游客可以浏览说明；生成个人类别线索需要注册或登录正式账号。'
-    elif code == 'invalid_location':
+    elif code in {'invalid_location', 'invalid_age'}:
         message = str(raw_error)
     elif code == 'weather_unavailable':
         message = '健康关注线索暂时无法生成：官方天气快照正在更新，请稍后再试。'
@@ -342,6 +348,10 @@ def ml_prediction():
             raw_location,
             location_options=location_options,
         )
+        parsed_age, age_form_value, age_error = _parse_ml_age(
+            request.form.get('age'),
+            default_age,
+        )
         form_state = {
             'member_id': str(selected_member.id) if selected_member else '',
             'location': (
@@ -349,7 +359,7 @@ def ml_prediction():
                 if not location_resolution.valid
                 else location_resolution.value
             ),
-            'age': _coerce_age(request.form.get('age'), default_age),
+            'age': age_form_value,
         }
 
         if is_guest_user(current_user):
@@ -361,13 +371,19 @@ def ml_prediction():
                 code='invalid_location',
             )
             response_status = 422
+        elif age_error:
+            prediction_error = _classified_ml_error(
+                age_error,
+                code='invalid_age',
+            )
+            response_status = 422
         else:
             weather_info, _ = get_weather_with_cache(form_state['location'])
             if not is_qweather_online_weather(weather_info):
                 prediction_error = _classified_ml_error(code='weather_unavailable')
             else:
                 user_info = {
-                    'age': form_state['age'],
+                    'age': parsed_age,
                     'gender': default_gender,
                 }
                 try:
@@ -394,7 +410,7 @@ def ml_prediction():
                             'weather_multiplier': round(float(multiplier), 3),
                             'label': f'关注排序第 {rank}',
                         })
-                    factors = _build_ml_factor_cards(result, form_state['age'], weather_info)
+                    factors = _build_ml_factor_cards(result, parsed_age, weather_info)
                 else:
                     prediction_error = _classified_ml_error(result.get('error'))
 

--- a/blueprints/user.py
+++ b/blueprints/user.py
@@ -148,6 +148,13 @@ def community_risk():
 @login_required
 def heat_exposure_gis():
     """都昌县 1 km 网格级热暴露 GIS"""
+    if is_guest_user(current_user):
+        return redirect(
+            url_for(
+                'public.login',
+                next=url_for('user.heat_exposure_gis'),
+            )
+        )
     if not current_app.config.get('FEATURE_HEAT_EXPOSURE_GIS'):
         abort(404)
 

--- a/core/app.py
+++ b/core/app.py
@@ -18,6 +18,7 @@ from core.config import configure_app
 from core.constants import CHRONIC_OPTIONS, DEFAULT_CITY_LABEL, GUEST_ID_PREFIX, RISK_TAG_OPTIONS
 from core.extensions import db, init_extensions, login_manager
 from core.hooks import register_hooks
+from core.http_errors import register_http_error_handlers
 from core.logging_privacy import install_formal_logging_privacy
 from core.db_models import (
     AlertDelivery,
@@ -105,6 +106,7 @@ def create_app(register_blueprints=True):
     init_extensions(app)
     register_user_loader(login_manager)
     register_hooks(app)
+    register_http_error_handlers(app)
     if register_blueprints:
         _register_blueprints(app)
     register_cli(app)

--- a/core/config.py
+++ b/core/config.py
@@ -443,6 +443,38 @@ def _normalized_env_value(key, default=None):
     return value if value else default
 
 
+def _validated_miniprogram_code_image(value, static_folder):
+    """只接受 HTTPS 图片或已存在的 static 相对图片。"""
+    normalized = (value or '').strip()
+    if not normalized:
+        return ''
+    allowed_suffixes = {'.png', '.jpg', '.jpeg', '.webp'}
+    try:
+        parsed = urlparse(normalized)
+    except ValueError:
+        return ''
+    if parsed.scheme or parsed.netloc:
+        if (
+            parsed.scheme == 'https'
+            and parsed.hostname
+            and not parsed.username
+            and not parsed.password
+            and Path(parsed.path).suffix.lower() in allowed_suffixes
+        ):
+            return parsed.geturl()
+        return ''
+    if normalized.startswith(('/', '\\')) or '\\' in normalized:
+        return ''
+    relative_path = Path(normalized)
+    if '..' in relative_path.parts or relative_path.suffix.lower() not in allowed_suffixes:
+        return ''
+    static_root = Path(static_folder).resolve()
+    candidate = (static_root / relative_path).resolve()
+    if static_root not in candidate.parents or not candidate.is_file():
+        return ''
+    return relative_path.as_posix()
+
+
 def configure_app(app, logger):
     """Load configuration into the Flask app."""
     secret_key_is_generated = False
@@ -516,6 +548,10 @@ def configure_app(app, logger):
     wx_miniprogram_secret = _normalized_env_value('WX_MINIPROGRAM_SECRET', '')
     wx_miniprogram_openid_pepper = _normalized_env_value('WX_MINIPROGRAM_OPENID_PEPPER', '')
     wx_miniprogram_session_secret = _normalized_env_value('WX_MINIPROGRAM_SESSION_SECRET', '')
+    wx_miniprogram_action_code_image = _validated_miniprogram_code_image(
+        _normalized_env_value('WX_MINIPROGRAM_ACTION_CODE_IMAGE', ''),
+        app.static_folder,
+    )
     account_link_code_pepper = _normalized_env_value('ACCOUNT_LINK_CODE_PEPPER', '')
     wechat_formal_runtime_raw = _normalized_env_value('WECHAT_FORMAL_RUNTIME', '')
     web_private_features_enabled = parse_bool(
@@ -612,6 +648,9 @@ def configure_app(app, logger):
     app.config['WX_MINIPROGRAM_SECRET'] = wx_miniprogram_secret
     app.config['WX_MINIPROGRAM_OPENID_PEPPER'] = wx_miniprogram_openid_pepper
     app.config['WX_MINIPROGRAM_SESSION_SECRET'] = wx_miniprogram_session_secret
+    app.config['WX_MINIPROGRAM_ACTION_CODE_IMAGE'] = wx_miniprogram_action_code_image
+    app.config['WX_MINIPROGRAM_ACTION_PATH'] = 'pages/actions/index'
+    app.config['WX_MINIPROGRAM_NAME'] = '宜老平安'
     app.config['ACCOUNT_LINK_CODE_PEPPER'] = account_link_code_pepper or secret_key
     app.config['WX_MINIPROGRAM_PRIVACY_VERSION'] = wx_miniprogram_privacy_version
     app.config['ANALYTICS_TEST_USER_IDS'] = analytics_test_user_ids

--- a/core/http_errors.py
+++ b/core/http_errors.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""站内 HTML 与 API 的统一 HTTP 错误响应。"""
+import math
+import time
+
+from flask import current_app, g, jsonify, make_response, render_template, request
+from flask_limiter.errors import RateLimitExceeded
+
+from core.extensions import limiter
+
+
+_ERROR_COPY = {
+    403: ('没有访问权限', '此页面仅向具备相应身份的账号开放。'),
+    404: ('页面没有找到', '链接可能已经变化，也可能暂时不可用。'),
+    429: ('操作太频繁', '为保护账号安全，请等待倒计时结束后再试。'),
+    500: ('页面暂时不可用', '我们已经记录问题，请稍后再试。'),
+}
+
+_ERROR_CODES = {
+    403: 'forbidden',
+    404: 'not_found',
+    429: 'rate_limit_exceeded',
+    500: 'internal_server_error',
+}
+
+
+def _request_id():
+    return str(getattr(g, 'request_id', '') or '')
+
+
+def _wants_json_error():
+    path = request.path or ''
+    if path.startswith(('/api/', '/mp/api/')) or request.is_json:
+        return True
+    best = request.accept_mimetypes.best_match(
+        ('text/html', 'application/json')
+    )
+    return bool(
+        best == 'application/json'
+        and request.accept_mimetypes['application/json']
+        > request.accept_mimetypes['text/html']
+    )
+
+
+def _retry_after_seconds():
+    try:
+        current_limit = limiter.current_limit
+        reset_at = getattr(current_limit, 'reset_at', None)
+        if reset_at is not None:
+            return max(1, math.ceil(float(reset_at) - time.time()))
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        pass
+    try:
+        return max(
+            1,
+            int(current_app.config.get('LOGIN_LOCKOUT_SECONDS', 300)),
+        )
+    except (TypeError, ValueError):
+        return 300
+
+
+def _build_error_response(status_code, *, retry_after=None):
+    title, message = _ERROR_COPY[status_code]
+    request_id = _request_id()
+    if _wants_json_error():
+        payload = {
+            'success': False,
+            'error': _ERROR_CODES[status_code],
+            'message': message,
+            'request_id': request_id,
+        }
+        if retry_after is not None:
+            payload['retry_after_seconds'] = retry_after
+        response = make_response(jsonify(payload), status_code)
+    else:
+        response = make_response(
+            render_template(
+                'http_error.html',
+                status_code=status_code,
+                error_title=title,
+                error_message=message,
+                request_id=request_id,
+                retry_after_seconds=retry_after,
+            ),
+            status_code,
+        )
+
+    response.headers['Cache-Control'] = 'no-store, private, max-age=0'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['X-Request-ID'] = request_id
+    if retry_after is not None:
+        response.headers['Retry-After'] = str(retry_after)
+    return response
+
+
+def register_http_error_handlers(app):
+    """注册中文页面和保持结构化的 API 错误响应。"""
+
+    @app.errorhandler(RateLimitExceeded)
+    def handle_rate_limit(_error):
+        return _build_error_response(
+            429,
+            retry_after=_retry_after_seconds(),
+        )
+
+    @app.errorhandler(403)
+    def handle_forbidden(_error):
+        return _build_error_response(403)
+
+    @app.errorhandler(404)
+    def handle_not_found(_error):
+        return _build_error_response(404)
+
+    @app.errorhandler(500)
+    def handle_internal_error(error):
+        app.logger.error(
+            '请求处理失败 request_id=%s',
+            _request_id(),
+            exc_info=(type(error), error, error.__traceback__),
+        )
+        return _build_error_response(500)

--- a/core/http_errors.py
+++ b/core/http_errors.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """站内 HTML 与 API 的统一 HTTP 错误响应。"""
+from html import escape
 import math
 import time
 
@@ -59,6 +60,48 @@ def _retry_after_seconds():
         return 300
 
 
+def _database_safe_internal_error_html(title, message, request_id):
+    """生成不运行模板上下文、也不读取登录主体的 500 应急页。"""
+    safe_title = escape(str(title), quote=True)
+    safe_message = escape(str(message), quote=True)
+    safe_request_id = escape(str(request_id), quote=True)
+    request_id_html = (
+        f'<p class="request-id">请求编号：{safe_request_id}</p>'
+        if safe_request_id
+        else ''
+    )
+    return f'''<!doctype html>
+<html lang="zh-CN">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow, noarchive">
+    <title>{safe_title} · 宜老天气通</title>
+    <style>
+        body {{ margin: 0; background: #f5f7fb; color: #24324a; font-family: system-ui, sans-serif; }}
+        main {{ box-sizing: border-box; max-width: 720px; margin: 10vh auto; padding: 24px; }}
+        section {{ border-radius: 18px; background: #fff; padding: 40px 24px; text-align: center; box-shadow: 0 12px 34px rgba(35, 54, 88, .09); }}
+        .status {{ color: #2367d1; font-size: 2.5rem; font-weight: 750; }}
+        h1 {{ margin: 8px 0 12px; font-size: 1.55rem; }}
+        p {{ line-height: 1.7; }}
+        a {{ display: inline-block; margin-top: 12px; border-radius: 10px; background: #2367d1; color: #fff; padding: 10px 18px; text-decoration: none; }}
+        .request-id {{ margin-top: 24px; color: #68758a; font-size: .875rem; overflow-wrap: anywhere; }}
+    </style>
+</head>
+<body>
+    <main>
+        <section>
+            <div class="status">500</div>
+            <h1>{safe_title}</h1>
+            <p>{safe_message}</p>
+            <a href="/">返回首页</a>
+            {request_id_html}
+        </section>
+    </main>
+</body>
+</html>'''
+
+
 def _build_error_response(status_code, *, retry_after=None):
     title, message = _ERROR_COPY[status_code]
     request_id = _request_id()
@@ -72,6 +115,13 @@ def _build_error_response(status_code, *, retry_after=None):
         if retry_after is not None:
             payload['retry_after_seconds'] = retry_after
         response = make_response(jsonify(payload), status_code)
+    elif status_code == 500:
+        # 数据库故障后不能渲染继承 base.html 的模板：base 与上下文处理器会读取
+        # current_user/location，可能在处理原始 500 时再次访问同一个故障数据库。
+        response = make_response(
+            _database_safe_internal_error_html(title, message, request_id),
+            status_code,
+        )
     else:
         response = make_response(
             render_template(
@@ -113,6 +163,8 @@ def register_http_error_handlers(app):
 
     @app.errorhandler(500)
     def handle_internal_error(error):
+        # 复用响应日志已有的“不要解析身份”哨兵，阻止 after_request 再读 ORM 用户。
+        g.formal_web_gate_blocked = True
         app.logger.error(
             '请求处理失败 request_id=%s',
             _request_id(),

--- a/core/location_resolution.py
+++ b/core/location_resolution.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""面向网页用户输入的严格地点解析。
+
+后台同步仍可继续使用 ``normalize_location_name`` 的历史回退语义。网页表单必须
+显式识别地点，避免把拼错或县外地点悄悄替换成都昌县。
+"""
+from dataclasses import dataclass
+
+from flask import current_app
+
+from core.constants import DEFAULT_CITY_LABEL
+
+
+@dataclass(frozen=True)
+class UserLocationResolution:
+    """严格地点解析结果。"""
+
+    raw: str
+    value: str | None
+    valid: bool
+    error: str | None = None
+
+
+def _clean_name(value):
+    if not isinstance(value, str):
+        return ''
+    return value.strip()
+
+
+def _configured_aliases(extra_names=()):
+    """构造县内可接受名称，排除旧配置里的县外城市和原始坐标。"""
+    default_city = _clean_name(current_app.config.get('DEFAULT_CITY'))
+    default_location = _clean_name(current_app.config.get('DEFAULT_LOCATION'))
+    community_names = {
+        _clean_name(name)
+        for name in (current_app.config.get('COMMUNITY_COORDS_GCJ') or {})
+        if _clean_name(name)
+    }
+    accepted = {
+        DEFAULT_CITY_LABEL,
+        '都昌',
+        '都昌县',
+        *community_names,
+        *(_clean_name(name) for name in extra_names),
+    }
+    accepted.discard('')
+
+    city_map = current_app.config.get('CITY_LOCATION_MAP') or {}
+    for name, mapped_value in city_map.items():
+        clean_name = _clean_name(name)
+        clean_value = _clean_name(mapped_value)
+        if clean_name in community_names or (
+            clean_value and default_location and clean_value == default_location
+        ):
+            accepted.add(clean_name)
+
+    aliases = {name: name for name in accepted}
+    for name in ('都昌', '都昌县', default_city):
+        if name and name in accepted:
+            aliases[name] = name
+
+    configured_aliases = current_app.config.get('USER_LOCATION_ALIASES') or {}
+    for alias, target in configured_aliases.items():
+        clean_alias = _clean_name(alias)
+        clean_target = _clean_name(target)
+        if clean_alias and clean_target in accepted:
+            aliases[clean_alias] = aliases.get(clean_target, clean_target)
+
+    # 支持“都昌县 + 已配置村/社区名”的常见完整写法。
+    for name in tuple(accepted):
+        if name not in {'都昌', '都昌县'} and not name.startswith('都昌县'):
+            aliases[f'都昌县{name}'] = aliases.get(name, name)
+    return aliases
+
+
+def get_user_location_options(*, extra_names=()):
+    """返回与严格解析器一致的地点候选，避免表单提示县外旧别名。"""
+    aliases = _configured_aliases(extra_names)
+    preferred = ['都昌', '都昌县']
+    options = [name for name in preferred if name in aliases]
+    options.extend(sorted(name for name in aliases if name not in options))
+    return options
+
+
+def resolve_user_location(raw_location, *, extra_names=(), default_if_blank=True):
+    """严格解析网页地点。
+
+    空值可按调用方要求回到默认县域；非空且未识别的值一律返回错误，不接受
+    QWeather ID、经纬度或旧配置中的县外城市。
+    """
+    raw = _clean_name(raw_location)
+    if not raw:
+        if default_if_blank:
+            return UserLocationResolution('', DEFAULT_CITY_LABEL, True)
+        return UserLocationResolution('', None, True)
+
+    if len(raw) > 100:
+        return UserLocationResolution(
+            raw[:100],
+            None,
+            False,
+            '地点名称过长，请从都昌县或已配置的乡镇、社区中选择。',
+        )
+
+    aliases = _configured_aliases(extra_names)
+    resolved = aliases.get(raw)
+    if resolved:
+        return UserLocationResolution(raw, resolved, True)
+    return UserLocationResolution(
+        raw,
+        None,
+        False,
+        '未找到这个地点。目前仅支持都昌县及已配置的乡镇、社区，请从提示中选择。',
+    )

--- a/core/security.py
+++ b/core/security.py
@@ -53,18 +53,36 @@ def csrf_failure_response():
 
 
 _AUTO_PEPPER: str | None = None  # 进程级自动生成的 pepper 回退
-_RATE_LIMIT_CLIENT_SECRET = secrets.token_bytes(32)
+
+
+def _rate_limit_client_secret():
+    """从生产稳定密钥派生限流专用密钥，避免跨用途直接复用。"""
+    configured = (
+        current_app.config.get('PAIR_TOKEN_PEPPER')
+        or current_app.config.get('SECRET_KEY')
+        or os.getenv('PAIR_TOKEN_PEPPER')
+        or os.getenv('SECRET_KEY')
+        or _pair_token_pepper()
+    )
+    raw_secret = (
+        configured
+        if isinstance(configured, bytes)
+        else str(configured).encode('utf-8')
+    )
+    return hashlib.sha256(
+        b'yilao-client-rate-limit-v1\0' + raw_secret
+    ).digest()
 
 
 def client_rate_limit_key():
-    """按受信代理边界解析客户端，并生成只在本进程有效的限流摘要。"""
+    """按受信代理边界解析客户端，并生成跨 worker 稳定的限流摘要。"""
     # 延迟导入避免 core.audit 在模块加载时与本模块形成循环依赖。
     from core.audit import _get_client_ip
 
     client_ip = _get_client_ip() or request.remote_addr or 'unknown'
     digest = hashlib.blake2s(
         str(client_ip).encode('utf-8'),
-        key=_RATE_LIMIT_CLIENT_SECRET,
+        key=_rate_limit_client_secret(),
         digest_size=20,
     ).hexdigest()
     return f'client:{digest}'

--- a/core/security.py
+++ b/core/security.py
@@ -9,14 +9,16 @@ from flask import abort, current_app, has_app_context, jsonify, request, session
 
 logger = logging.getLogger(__name__)
 from flask_login import current_user
-from flask_limiter.util import get_remote_address
 
 
 def rate_limit_key():
-    """按用户或IP进行限流"""
-    if current_user.is_authenticated:
-        return str(getattr(current_user, 'id', 'anonymous'))
-    return get_remote_address()
+    """正式账号按账号限流，匿名与游客按临时客户端摘要限流。"""
+    if (
+        current_user.is_authenticated
+        and not bool(getattr(current_user, 'is_guest', False))
+    ):
+        return f'user:{getattr(current_user, "id", "anonymous")}'
+    return client_rate_limit_key()
 
 
 def generate_csrf_token():
@@ -51,6 +53,21 @@ def csrf_failure_response():
 
 
 _AUTO_PEPPER: str | None = None  # 进程级自动生成的 pepper 回退
+_RATE_LIMIT_CLIENT_SECRET = secrets.token_bytes(32)
+
+
+def client_rate_limit_key():
+    """按受信代理边界解析客户端，并生成只在本进程有效的限流摘要。"""
+    # 延迟导入避免 core.audit 在模块加载时与本模块形成循环依赖。
+    from core.audit import _get_client_ip
+
+    client_ip = _get_client_ip() or request.remote_addr or 'unknown'
+    digest = hashlib.blake2s(
+        str(client_ip).encode('utf-8'),
+        key=_RATE_LIMIT_CLIENT_SECRET,
+        digest_size=20,
+    ).hexdigest()
+    return f'client:{digest}'
 
 
 def _pair_token_pepper():

--- a/miniprogram/pages/action-checkin/index.js
+++ b/miniprogram/pages/action-checkin/index.js
@@ -8,7 +8,11 @@ const {
   suspendHealthMutation,
   trackHealthMutation,
 } = require('../elders/care-session');
-const { normalizeList, normalizeSnapshot } = require('../elders/care-logic');
+const {
+  normalizeList,
+  normalizeSnapshot,
+  trustedWeatherTrigger,
+} = require('../elders/care-logic');
 const { duchangDateKey } = require('../../utils/format');
 
 const ACTION_PLANS = {
@@ -39,10 +43,11 @@ function actionPlan(trigger) {
 }
 
 function weatherStatus(weather) {
+  const trigger = trustedWeatherTrigger(weather);
+  if (trigger === 'heat') return '高温留意';
+  if (trigger === 'cold') return '低温留意';
   if (!weather || !weather.available) return '天气待更新';
   if (weather.stale) return '较早天气，待刷新';
-  if (weather.trigger === 'heat') return '高温留意';
-  if (weather.trigger === 'cold') return '低温留意';
   return '常规天气提示';
 }
 
@@ -288,7 +293,7 @@ Page({
         throw new Error('miniprogram_pair_unsupported');
       }
       const weather = normalizeSnapshot(snapshot);
-      const plan = actionPlan(weather.stale ? '' : weather.trigger);
+      const plan = actionPlan(trustedWeatherTrigger(weather));
       const restored = restoreTodayActions(plan, elder.today);
       this.setData({
         elderName: elder.member && elder.member.name ? elder.member.name : '家人',

--- a/miniprogram/pages/actions/index.js
+++ b/miniprogram/pages/actions/index.js
@@ -43,6 +43,22 @@ function isCompletionReceiptShare(options) {
   return Boolean(event.from === 'button' && dataset && dataset.shareKind === 'completion_receipt');
 }
 
+function usableFamilyReminder(reminder, snapshot, currentFreshness, warningsFreshness) {
+  const source = reminder && typeof reminder === 'object' ? reminder : null;
+  if (!source || source.dependenciesValid !== true || !source.message) return null;
+  const dependencies = Array.isArray(source.dependsOn) ? source.dependsOn : [];
+  const currentUsable = snapshot.current
+    && snapshot.current.available === true
+    && currentFreshness.stale === false;
+  const warningsUsable = snapshot.warningsSourceAvailable === true
+    && Array.isArray(snapshot.warnings)
+    && snapshot.warnings.length > 0
+    && warningsFreshness.stale === false;
+  if (dependencies.includes('current') && !currentUsable) return null;
+  if (dependencies.includes('warnings') && !warningsUsable) return null;
+  return source;
+}
+
 Page({
   data: {
     loading: true,
@@ -117,8 +133,11 @@ Page({
   renderActions(result) {
     const snapshot = normalizeBootstrap(result.data);
     const freshness = freshnessView(result.meta, snapshot, 'risk');
+    const currentFreshness = freshnessView(result.meta, snapshot, 'current');
     const warningsFreshness = freshnessView(result.meta, snapshot, 'warnings');
-    const generalMode = freshness.stale || !snapshot.available || !snapshot.actions.length;
+    const generalMode = freshness.stale
+      || snapshot.risk.available !== true
+      || !snapshot.actions.length;
     const sourceActions = generalMode ? GENERAL_ACTIONS : snapshot.actions;
     const actions = this.mergeChecked(sourceActions);
     const completedCount = actions.filter((item) => item.checked).length;
@@ -129,7 +148,12 @@ Page({
       completedCount,
       progressPercent: actions.length ? Math.round(completedCount / actions.length * 100) : 0,
       generalMode,
-      familyReminder: freshness.stale || warningsFreshness.stale ? null : snapshot.familyReminder,
+      familyReminder: usableFamilyReminder(
+        snapshot.familyReminder,
+        snapshot,
+        currentFreshness,
+        warningsFreshness,
+      ),
       locationName: snapshot.location.name,
       freshness,
     });

--- a/miniprogram/pages/actions/index.js
+++ b/miniprogram/pages/actions/index.js
@@ -116,7 +116,8 @@ Page({
 
   renderActions(result) {
     const snapshot = normalizeBootstrap(result.data);
-    const freshness = freshnessView(result.meta, snapshot);
+    const freshness = freshnessView(result.meta, snapshot, 'risk');
+    const warningsFreshness = freshnessView(result.meta, snapshot, 'warnings');
     const generalMode = freshness.stale || !snapshot.available || !snapshot.actions.length;
     const sourceActions = generalMode ? GENERAL_ACTIONS : snapshot.actions;
     const actions = this.mergeChecked(sourceActions);
@@ -128,7 +129,7 @@ Page({
       completedCount,
       progressPercent: actions.length ? Math.round(completedCount / actions.length * 100) : 0,
       generalMode,
-      familyReminder: freshness.stale ? null : snapshot.familyReminder,
+      familyReminder: freshness.stale || warningsFreshness.stale ? null : snapshot.familyReminder,
       locationName: snapshot.location.name,
       freshness,
     });

--- a/miniprogram/pages/alerts/index.js
+++ b/miniprogram/pages/alerts/index.js
@@ -73,7 +73,8 @@ Page({
 
   renderWarnings(result) {
     const snapshot = normalizeBootstrap(result.data);
-    const freshness = freshnessView(result.meta, snapshot);
+    const freshness = freshnessView(result.meta, snapshot, 'warnings');
+    const currentFreshness = freshnessView(result.meta, snapshot, 'current');
     this.setData({
       loading: false,
       error: result.meta && result.meta.networkError
@@ -82,7 +83,7 @@ Page({
       // 较早缓存中的预警可能已经失效，刷新前不继续标成有效预警。
       warnings: freshness.stale ? [] : snapshot.warnings,
       warningsSourceAvailable: freshness.stale ? false : snapshot.warningsSourceAvailable,
-      current: snapshot.current,
+      current: Object.assign({}, snapshot.current, { stale: currentFreshness.stale }),
       locationName: snapshot.location.name,
       freshness,
     });

--- a/miniprogram/pages/alerts/index.wxml
+++ b/miniprogram/pages/alerts/index.wxml
@@ -11,7 +11,7 @@
   <block wx:if="{{current}}">
     <freshness-bar updated-text="{{freshness.updatedText}}" stale="{{freshness.stale}}" source="{{freshness.source}}" refresh-deferred="{{freshness.refreshDeferred}}" refresh-started="{{freshness.refreshStarted}}" />
     <view class="card weather-strip">
-      <view><view class="small muted">{{freshness.stale ? '较早观测' : '当前'}}</view><view class="strip-value">{{current.temperatureText}}</view></view>
+      <view><view class="small muted">{{current.stale ? '较早观测' : '当前'}}</view><view class="strip-value">{{current.temperatureText}}</view></view>
       <view><view class="small muted">最高</view><view class="strip-value">{{current.highText}}</view></view>
       <view><view class="small muted">最低</view><view class="strip-value">{{current.lowText}}</view></view>
     </view>

--- a/miniprogram/pages/elders/care-logic.js
+++ b/miniprogram/pages/elders/care-logic.js
@@ -221,6 +221,113 @@ function pickFirst(source, keys) {
   return undefined;
 }
 
+function hasOwn(source, key) {
+  return Boolean(source && Object.prototype.hasOwnProperty.call(source, key));
+}
+
+function componentAliases(component) {
+  return component === 'current' ? ['current', 'current_weather', 'weather'] : [component];
+}
+
+function snapshotComponentStatus(rootValue, metaValue, component, fallbackAvailable, nowMs) {
+  const root = rootValue && typeof rootValue === 'object' ? rootValue : {};
+  const meta = metaValue && typeof metaValue === 'object' ? metaValue : {};
+  const sourceStatus = root.source_status && typeof root.source_status === 'object'
+    && !Array.isArray(root.source_status)
+    ? root.source_status
+    : {};
+  const aliases = componentAliases(component);
+  const stateEntries = aliases
+    .filter((key) => hasOwn(sourceStatus, key))
+    .map((key) => ({ key, value: sourceStatus[key] }));
+  const stateObjects = stateEntries
+    .map((entry) => entry.value)
+    .filter((value) => value && typeof value === 'object' && !Array.isArray(value));
+  const stateContractValid = stateEntries.every((entry) => {
+    const state = entry.value;
+    const expiresValue = state && pickFirst(state, ['expires_at', 'expiresAt']);
+    const hasValidExpiry = expiresValue !== undefined
+      && Number.isFinite(Date.parse(String(expiresValue)));
+    const hasStale = Boolean(state && hasOwn(state, 'stale'));
+    return Boolean(
+      state
+      && typeof state === 'object'
+      && !Array.isArray(state)
+      && typeof state.available === 'boolean'
+      && (!hasStale || typeof state.stale === 'boolean')
+      && (expiresValue === undefined || hasValidExpiry)
+      && (hasStale || hasValidExpiry)
+    );
+  });
+  const stateAvailable = stateEntries.length === 0
+    || (stateContractValid && stateObjects.every((state) => state.available === true));
+  const componentPayload = aliases
+    .map((key) => root[key])
+    .find((value) => value && typeof value === 'object' && !Array.isArray(value));
+  const payloadAvailable = componentPayload && hasOwn(componentPayload, 'available')
+    ? componentPayload.available === true
+    : true;
+  const currentTime = Number.isFinite(Number(nowMs)) ? Number(nowMs) : Date.now();
+  const expiryValues = stateObjects.map((state) => pickFirst(state, ['expires_at', 'expiresAt']));
+  const parsedExpiries = expiryValues.map((value) => Date.parse(String(value || '')));
+  const invalidExpiry = expiryValues.some((value, index) => value !== undefined && !Number.isFinite(parsedExpiries[index]));
+  const expired = parsedExpiries.some((value) => Number.isFinite(value) && currentTime >= value);
+  const staleKeys = aliases.map((key) => `${key}_stale`);
+  const malformedRootStale = staleKeys.some((key) => hasOwn(root, key) && typeof root[key] !== 'boolean');
+  const explicitRootStale = staleKeys.some((key) => root[key] === true);
+  const explicitStateStale = stateObjects.some((state) => state.stale === true);
+  const globalStale = meta.stale === true
+    || cleanText(meta.source, 30) === 'stale-cache'
+    || root.stale === true;
+  const verifiedFreshState = stateEntries.length > 0
+    && stateContractValid
+    && stateObjects.every((state, index) => (
+      state.available === true
+      && state.stale === false
+      && Number.isFinite(parsedExpiries[index])
+      && currentTime < parsedExpiries[index]
+    ));
+  const stale = malformedRootStale
+    || invalidExpiry
+    || expired
+    || explicitRootStale
+    || explicitStateStale
+    || (globalStale && !verifiedFreshState);
+  const rootAvailabilityDeclared = hasOwn(root, 'available');
+  const rootCurrentAvailable = !rootAvailabilityDeclared || root.available === true;
+  const rootAvailable = component === 'warnings'
+    ? (stateEntries.length > 0
+      ? (root.available === true || verifiedFreshState)
+      : root.available === true)
+    : (['current', 'risk'].includes(component)
+      ? rootCurrentAvailable
+      : true);
+  const available = Boolean(fallbackAvailable)
+    && stateContractValid
+    && stateAvailable
+    && payloadAvailable
+    && rootAvailable;
+  const firstState = stateObjects[0] || {};
+  const expiresValue = pickFirst(firstState, ['expires_at', 'expiresAt']);
+  return {
+    available,
+    stale,
+    usable: available && !stale,
+    verified: verifiedFreshState,
+    expiresAt: expiresValue === undefined ? '' : cleanText(expiresValue, 50),
+    fetchedAt: cleanText(pickFirst(firstState, ['fetched_at', 'fetchedAt', 'updated_at']), 50),
+  };
+}
+
+function warningTrigger(warnings) {
+  const text = (Array.isArray(warnings) ? warnings : [])
+    .map((item) => `${item && item.title ? item.title : ''}${item && item.type ? item.type : ''}`)
+    .join(' ');
+  if (/高温|heat/i.test(text)) return 'heat';
+  if (/寒潮|低温|cold/i.test(text)) return 'cold';
+  return '';
+}
+
 function normalizeSnapshot(snapshot) {
   const envelope = snapshot && typeof snapshot === 'object' ? snapshot : {};
   const meta = envelope.meta && typeof envelope.meta === 'object' ? envelope.meta : {};
@@ -244,16 +351,30 @@ function normalizeSnapshot(snapshot) {
   const warnings = Array.isArray(warningsSource)
     ? warningsSource
     : (warningsSource && (warningsSource.items || warningsSource.list)) || [];
-  const warningText = warnings.map((item) => `${item.title || ''}${item.type || ''}`).join(' ');
-  let trigger = '';
-  if (/高温|heat/i.test(warningText) || (tmax !== null && tmax >= 35)) trigger = 'heat';
-  else if (/寒潮|低温|cold/i.test(warningText) || (tmin !== null && tmin <= 5)) trigger = 'cold';
-  const available = temperature !== null || tmax !== null || tmin !== null || warnings.length > 0;
+  const currentStatus = snapshotComponentStatus(
+    root,
+    meta,
+    'current',
+    temperature !== null || tmax !== null || tmin !== null,
+  );
+  const warningsStatus = snapshotComponentStatus(root, meta, 'warnings', true);
+  const riskSource = root.risk && typeof root.risk === 'object' ? root.risk : {};
+  const riskFallback = riskSource.available === true
+    || toFiniteNumber(pickFirst(riskSource, ['score', 'risk_score'])) !== null
+    || Boolean(cleanText(pickFirst(riskSource, ['level', 'label', 'risk_level']), 30));
+  const riskStatus = snapshotComponentStatus(root, meta, 'risk', riskFallback);
+  const safeWarnings = warningsStatus.usable ? warnings : [];
+  let trigger = warningTrigger(safeWarnings);
+  if (!trigger && currentStatus.usable && tmax !== null && tmax >= 35) trigger = 'heat';
+  else if (!trigger && currentStatus.usable && tmin !== null && tmin <= 5) trigger = 'cold';
+  const available = currentStatus.available;
   const cacheSource = cleanText(meta.source, 30);
-  const stale = available && (meta.stale === true || cacheSource === 'stale-cache' || root.stale === true);
+  const stale = available && currentStatus.stale;
   const freshnessState = !available ? 'unavailable' : (stale ? 'stale' : 'fresh');
   const rootUpdatedValue = pickFirst(root, ['updated_at', 'updatedAt', 'fetched_at', 'generated_at']);
-  const updatedValue = rootUpdatedValue !== undefined ? rootUpdatedValue : pickFirst(meta, ['storedAt']);
+  const componentUpdatedValue = currentStatus.fetchedAt || warningsStatus.fetchedAt;
+  const updatedValue = componentUpdatedValue
+    || (rootUpdatedValue !== undefined ? rootUpdatedValue : pickFirst(meta, ['storedAt']));
   const updatedAt = typeof updatedValue === 'number' && Number.isFinite(updatedValue)
     ? new Date(updatedValue).toISOString()
     : cleanText(updatedValue, 40);
@@ -265,25 +386,61 @@ function normalizeSnapshot(snapshot) {
     humidity,
     condition: cleanText(pickFirst(current, ['condition', 'text', 'weather', 'weather_text']), 40),
     trigger,
-    warnings,
+    warnings: safeWarnings,
     updatedAt,
     updatedText: formatDateTime(updatedValue),
     available,
     stale,
     cacheSource,
     freshnessState,
+    componentStatus: {
+      current: currentStatus,
+      warnings: warningsStatus,
+      risk: riskStatus,
+    },
   };
 }
 
 function markSnapshotStale(weather) {
   const source = weather && typeof weather === 'object' ? weather : normalizeSnapshot({});
   const available = Boolean(source.available);
+  const componentStatus = Object.keys(source.componentStatus || {}).reduce((result, key) => {
+    const status = source.componentStatus[key] || {};
+    result[key] = {
+      ...status,
+      stale: Boolean(status.available),
+      usable: false,
+      verified: false,
+    };
+    return result;
+  }, {});
   return {
     ...source,
+    trigger: '',
+    warnings: [],
     stale: available,
     cacheSource: available ? 'stale-cache' : (source.cacheSource || ''),
     freshnessState: available ? 'stale' : 'unavailable',
+    componentStatus,
   };
+}
+
+function trustedWeatherTrigger(weather) {
+  const source = weather && typeof weather === 'object' ? weather : {};
+  const status = source.componentStatus && typeof source.componentStatus === 'object'
+    ? source.componentStatus
+    : {};
+  const warnings = Array.isArray(source.warnings) ? source.warnings : [];
+  const fromWarning = status.warnings && status.warnings.usable
+    ? warningTrigger(warnings)
+    : '';
+  if (fromWarning) return fromWarning;
+  if (!status.current || !status.current.usable) return '';
+  const tmax = toFiniteNumber(source.temperatureMax);
+  const tmin = toFiniteNumber(source.temperatureMin);
+  if (tmax !== null && tmax >= 35) return 'heat';
+  if (tmin !== null && tmin <= 5) return 'cold';
+  return '';
 }
 
 function buildReminderMessage(input) {
@@ -332,7 +489,9 @@ module.exports = {
   markSnapshotStale,
   normalizeList,
   normalizeSnapshot,
+  snapshotComponentStatus,
   splitChronic,
+  trustedWeatherTrigger,
   validateAssessment,
   validateDiaryInput,
   validateElderInput,

--- a/miniprogram/pages/forecast/index.js
+++ b/miniprogram/pages/forecast/index.js
@@ -82,7 +82,7 @@ Page({
 
   renderForecast(result) {
     const snapshot = normalizeBootstrap(result.data);
-    const freshness = freshnessView(result.meta, snapshot);
+    const freshness = freshnessView(result.meta, snapshot, 'forecast');
     const forecast = freshness.stale
       ? staleForecast(snapshot.forecast)
       : snapshot.forecast;

--- a/miniprogram/pages/home/index.js
+++ b/miniprogram/pages/home/index.js
@@ -17,16 +17,16 @@ const {
   sourceFromShareEvent,
 } = require('../../utils/share');
 
-function homeSnapshotView(snapshot) {
+function homeSnapshotView(snapshot, warningsStale) {
   const source = snapshot || {};
   // 首页只跨逻辑层与视图层传递实际渲染字段，避免复制预报、来源等整份快照。
   return {
     available: source.available,
     location: source.location,
     current: source.current,
-    warnings: Array.isArray(source.warnings) ? source.warnings : [],
-    warningsSourceAvailable: source.warningsSourceAvailable === true,
-    warningsStatusText: source.warningsStatusText,
+    warnings: warningsStale ? [] : (Array.isArray(source.warnings) ? source.warnings : []),
+    warningsSourceAvailable: warningsStale ? false : source.warningsSourceAvailable === true,
+    warningsStatusText: warningsStale ? '官方预警待刷新' : source.warningsStatusText,
     risk: source.risk,
   };
 }
@@ -145,7 +145,8 @@ Page({
 
   renderSnapshot(result) {
     const snapshot = normalizeBootstrap(result.data);
-    const freshness = freshnessView(result.meta, snapshot);
+    const freshness = freshnessView(result.meta, snapshot, 'risk');
+    const warningsFreshness = freshnessView(result.meta, snapshot, 'warnings');
     // 较早天气可以继续展示观测值，风险分数和定制行动必须等刷新后再启用。
     const displaySnapshot = freshness.stale ? staleHomeSnapshot(snapshot) : snapshot;
     this.setData({
@@ -153,7 +154,7 @@ Page({
       error: result.meta && result.meta.networkError
         ? '天气更新失败，正在显示较早观测；风险、预警和定制行动已暂停。稍后会自动重试。'
         : '',
-      snapshot: homeSnapshotView(displaySnapshot),
+      snapshot: homeSnapshotView(displaySnapshot, warningsFreshness.stale),
       topActions: freshness.stale ? [] : snapshot.actions.slice(0, 3),
       freshness,
     });

--- a/miniprogram/pages/home/index.js
+++ b/miniprogram/pages/home/index.js
@@ -31,12 +31,12 @@ function homeSnapshotView(snapshot, warningsStale) {
   };
 }
 
-function staleHomeSnapshot(snapshot) {
+function staleHomeSnapshot(snapshot, warningsStale) {
   if (!snapshot) return null;
   return Object.assign({}, snapshot, {
-    warnings: [],
-    warningsSourceAvailable: false,
-    warningsStatusText: '官方预警待刷新',
+    warnings: warningsStale ? [] : (Array.isArray(snapshot.warnings) ? snapshot.warnings : []),
+    warningsSourceAvailable: warningsStale ? false : snapshot.warningsSourceAvailable === true,
+    warningsStatusText: warningsStale ? '官方预警待刷新' : snapshot.warningsStatusText,
     risk: Object.assign({}, snapshot.risk || {}, {
       available: false,
       score: null,
@@ -49,12 +49,26 @@ function staleHomeSnapshot(snapshot) {
   });
 }
 
+function networkFailureMessage(riskStale, warningsStale) {
+  if (riskStale && warningsStale) {
+    return '天气联网刷新失败，风险、预警和定制行动已暂停。稍后会自动重试。';
+  }
+  if (riskStale) {
+    return '天气联网刷新失败，风险和定制行动已暂停；已核验的官方预警仍可查看。稍后会自动重试。';
+  }
+  if (warningsStale) {
+    return '天气联网刷新失败，当前风险和行动仍可使用；官方预警待刷新。稍后会自动重试。';
+  }
+  return '天气联网刷新失败，正在显示仍然有效的风险、预警和行动。稍后会自动重试。';
+}
+
 Page({
   data: {
     loading: true,
     error: '',
     snapshot: null,
     freshness: {},
+    warningsFreshness: {},
     topActions: [],
     familyShareEntry: false,
     entryContextReady: false,
@@ -129,17 +143,23 @@ Page({
     } catch (error) {
       if (!pageCanRender(this)) return;
       const hasSnapshot = Boolean(this.data.snapshot);
-      const freshness = staleRetryMeta(this.data.freshness, PUBLIC_RETRY_DELAY_MS);
+      const retryMeta = staleRetryMeta(this.data.freshness, PUBLIC_RETRY_DELAY_MS);
+      // 请求完全失败时没有组件级到期证明，旧页面状态按不可核验处理。
+      const riskStale = true;
+      const warningsStale = true;
+      const freshness = retryMeta;
       this.setData({
         loading: false,
         error: hasSnapshot
-          ? '天气更新失败，正在显示较早观测；风险、预警和定制行动已暂停。稍后会自动重试。'
+          ? networkFailureMessage(riskStale, warningsStale)
           : '天气数据暂时无法获取。请检查网络，稍后再试。',
-        snapshot: hasSnapshot ? staleHomeSnapshot(this.data.snapshot) : null,
-        topActions: [],
+        snapshot: hasSnapshot && riskStale
+          ? staleHomeSnapshot(this.data.snapshot, warningsStale)
+          : this.data.snapshot,
+        topActions: riskStale ? [] : this.data.topActions,
         freshness,
       });
-      schedulePublicRefresh(this, freshness, () => this.loadData());
+      schedulePublicRefresh(this, retryMeta, () => this.loadData());
     }
   },
 
@@ -148,15 +168,19 @@ Page({
     const freshness = freshnessView(result.meta, snapshot, 'risk');
     const warningsFreshness = freshnessView(result.meta, snapshot, 'warnings');
     // 较早天气可以继续展示观测值，风险分数和定制行动必须等刷新后再启用。
-    const displaySnapshot = freshness.stale ? staleHomeSnapshot(snapshot) : snapshot;
+    const displaySnapshot = freshness.stale
+      ? staleHomeSnapshot(snapshot, warningsFreshness.stale)
+      : snapshot;
+    const riskUsable = !freshness.stale && snapshot.risk.available === true;
     this.setData({
       loading: false,
       error: result.meta && result.meta.networkError
-        ? '天气更新失败，正在显示较早观测；风险、预警和定制行动已暂停。稍后会自动重试。'
+        ? networkFailureMessage(!riskUsable, warningsFreshness.stale)
         : '',
       snapshot: homeSnapshotView(displaySnapshot, warningsFreshness.stale),
-      topActions: freshness.stale ? [] : snapshot.actions.slice(0, 3),
+      topActions: riskUsable ? snapshot.actions.slice(0, 3) : [],
       freshness,
+      warningsFreshness,
     });
     schedulePublicRefresh(this, result.meta, () => this.loadData());
   },

--- a/miniprogram/pages/home/index.wxml
+++ b/miniprogram/pages/home/index.wxml
@@ -29,7 +29,7 @@
 
   <block wx:if="{{snapshot}}">
     <freshness-bar updated-text="{{freshness.updatedText}}" stale="{{freshness.stale}}" source="{{freshness.source}}" refresh-deferred="{{freshness.refreshDeferred}}" refresh-started="{{freshness.refreshStarted}}" />
-    <status-card wx:if="{{error}}" state="error" title="天气更新失败，风险信息已暂停" detail="{{error}}" action-label="重试" bind:action="retry" />
+    <status-card wx:if="{{error}}" state="error" title="{{freshness.stale ? '天气更新失败，风险信息已暂停' : '天气联网刷新失败'}}" detail="{{error}}" action-label="重试" bind:action="retry" />
 
     <status-card wx:if="{{!snapshot.available || !snapshot.current.available}}" state="empty" title="实时天气正在更新" detail="页面不会用演示天气代替真实观测。你仍可查看通用防护和避暑资源。" />
 

--- a/miniprogram/pages/template/index.js
+++ b/miniprogram/pages/template/index.js
@@ -1,5 +1,10 @@
 const { authApi, getSnapshot, requireToken } = require('../elders/care-session');
-const { buildReminderMessage, normalizeList, normalizeSnapshot } = require('../elders/care-logic');
+const {
+  buildReminderMessage,
+  normalizeList,
+  normalizeSnapshot,
+  trustedWeatherTrigger,
+} = require('../elders/care-logic');
 
 function lifecycleIsActive(page, lifecycle) {
   return page._unloaded !== true && Number(page._lifecycleGeneration || 0) === lifecycle;
@@ -103,11 +108,15 @@ Page({
       }
       const member = item.member || {};
       const weather = normalizeSnapshot(snapshot);
-      const usesGenericWeather = weather.stale || !weather.available;
-      const weatherNotice = weather.stale
+      const trigger = trustedWeatherTrigger(weather);
+      const currentStatus = weather.componentStatus && weather.componentStatus.current;
+      const weatherNotice = trigger
+        ? ''
+        : (currentStatus && currentStatus.stale
         ? '天气数据较早，复制内容已切换为通用提醒。'
-        : (!weather.available ? '天气数据待更新，复制内容使用通用提醒。' : '');
-      const trigger = usesGenericWeather ? '' : weather.trigger;
+        : (!currentStatus || !currentStatus.usable
+          ? '天气数据待更新，复制内容使用通用提醒。'
+          : ''));
       const message = buildReminderMessage({
         trigger,
         elderName: member.name,

--- a/miniprogram/tests/care.test.js
+++ b/miniprogram/tests/care.test.js
@@ -28,7 +28,9 @@ const {
   isValidDateText,
   markSnapshotStale,
   normalizeSnapshot,
+  snapshotComponentStatus,
   splitChronic,
+  trustedWeatherTrigger,
   validateAssessment,
   validateDiaryInput,
   validateElderInput,
@@ -206,6 +208,151 @@ test('照护天气明确区分 fresh、stale 和 unavailable', () => {
   assert.equal(unavailable.available, false);
   assert.equal(unavailable.stale, false);
   assert.equal(unavailable.updatedText, '07月17日 12:00');
+});
+
+test('照护组件支持当前天气别名并严格校验 available', () => {
+  ['current', 'current_weather', 'weather'].forEach((alias) => {
+    const normalized = normalizeSnapshot({
+      data: {
+        available: true,
+        stale: true,
+        [alias]: { temperature: 36, temperature_max: 38, temperature_min: 28 },
+        risk: { available: true, level: '高风险' },
+        source_status: {
+          [alias]: {
+            available: true,
+            stale: false,
+            expires_at: '2099-01-01T00:00:00Z',
+          },
+          risk: {
+            available: true,
+            stale: false,
+            expires_at: '2099-01-01T00:00:00Z',
+          },
+        },
+      },
+      meta: { source: 'stale-cache', stale: true },
+    });
+
+    assert.equal(normalized.componentStatus.current.usable, true, alias);
+    assert.equal(normalized.componentStatus.risk.usable, true, alias);
+    assert.equal(trustedWeatherTrigger(normalized), 'heat', alias);
+  });
+
+  const malformedStates = [
+    { available: 'false', stale: false, expires_at: '2099-01-01T00:00:00Z' },
+    { stale: false, expires_at: '2099-01-01T00:00:00Z' },
+  ];
+  malformedStates.forEach((state) => {
+    const root = {
+      available: true,
+      current: { temperature: 36, temperature_max: 38, temperature_min: 28 },
+      warnings: [{ title: '来源不明的高温预警' }],
+      source_status: { current: state, warnings: state },
+    };
+    assert.equal(
+      snapshotComponentStatus(root, { source: 'network', stale: false }, 'current', true).usable,
+      false,
+    );
+    assert.equal(
+      snapshotComponentStatus(root, { source: 'network', stale: false }, 'warnings', true).usable,
+      false,
+    );
+  });
+});
+
+test('旧缓存只有精确布尔状态和未来过期时间才能解锁组件', () => {
+  const malformedStates = [
+    { available: true },
+    { available: true, expires_at: '不是日期' },
+    { available: 'true', expires_at: '2099-01-01T00:00:00Z' },
+    { expires_at: '2099-01-01T00:00:00Z' },
+  ];
+
+  malformedStates.forEach((state) => {
+    const root = {
+      available: true,
+      stale: true,
+      current: { temperature: 36, temperature_max: 38, temperature_min: 28 },
+      warnings: [{ title: '旧高温预警' }],
+      source_status: { current: state, warnings: state },
+    };
+    const normalized = normalizeSnapshot({ data: root, meta: { source: 'stale-cache', stale: true } });
+    assert.equal(normalized.componentStatus.current.usable, false);
+    assert.equal(normalized.componentStatus.warnings.usable, false);
+    assert.deepEqual(normalized.warnings, []);
+    assert.equal(trustedWeatherTrigger(normalized), '');
+  });
+});
+
+test('新鲜官方预警可在当前天气不可用时独立触发照护提醒', () => {
+  const normalized = normalizeSnapshot({
+    data: {
+      available: false,
+      stale: true,
+      current_stale: true,
+      risk_stale: true,
+      warnings_stale: false,
+      current: {},
+      risk: { available: false, level: '未知' },
+      warnings: [{ title: '都昌县高温橙色预警' }],
+      source_status: {
+        current: { available: false, expires_at: '2099-01-01T00:00:00Z' },
+        risk: { available: false, expires_at: '2099-01-01T00:00:00Z' },
+        warnings: { available: true, stale: false, expires_at: '2099-01-01T00:00:00Z' },
+      },
+    },
+    meta: { source: 'stale-cache', stale: true },
+  });
+
+  assert.equal(normalized.available, false);
+  assert.equal(normalized.componentStatus.warnings.usable, true);
+  assert.equal(normalized.warnings.length, 1);
+  assert.equal(normalized.trigger, 'heat');
+  assert.equal(trustedWeatherTrigger(normalized), 'heat');
+});
+
+test('根快照不可用时预警必须有显式精确来源状态', () => {
+  [false, undefined].forEach((rootAvailable) => {
+    const data = {
+      warnings: [{ title: '无来源状态的高温预警' }],
+    };
+    if (rootAvailable !== undefined) data.available = rootAvailable;
+    const legacy = normalizeSnapshot({
+      data,
+      meta: { source: 'network', stale: false },
+    });
+    assert.equal(legacy.componentStatus.warnings.usable, false);
+    assert.deepEqual(legacy.warnings, []);
+    assert.equal(trustedWeatherTrigger(legacy), '');
+  });
+
+  const explicit = normalizeSnapshot({
+    data: {
+      available: false,
+      warnings: [{ title: '都昌县高温橙色预警' }],
+      source_status: {
+        warnings: { available: true, stale: false, expires_at: '2099-01-01T00:00:00Z' },
+      },
+    },
+    meta: { source: 'stale-cache', stale: true },
+  });
+  assert.equal(explicit.componentStatus.warnings.usable, true);
+  assert.equal(trustedWeatherTrigger(explicit), 'heat');
+});
+
+test('根快照明确不可用时旧 current 无来源状态也不能解锁', () => {
+  const normalized = normalizeSnapshot({
+    data: {
+      available: false,
+      current: { temperature: 38, temperature_max: 40 },
+    },
+    meta: { source: 'network', stale: false },
+  });
+
+  assert.equal(normalized.componentStatus.current.usable, false);
+  assert.equal(normalized.available, false);
+  assert.equal(trustedWeatherTrigger(normalized), '');
 });
 
 test('刷新失败保留旧天气并降级为 stale，空天气保持 unavailable', () => {

--- a/miniprogram/tests/format.test.js
+++ b/miniprogram/tests/format.test.js
@@ -79,6 +79,53 @@ test('更新时间优先采用服务端真实抓取时间', () => {
   assert.match(view.updatedText, /08:00/);
 });
 
+test('页面只按自身依赖来源判断快照新鲜度', () => {
+  const now = Date.parse('2026-07-17T08:00:00Z');
+  const snapshot = normalizeBootstrap({
+    stale: true,
+    current_stale: false,
+    forecast_stale: true,
+    warnings_stale: false,
+    risk_stale: false,
+    current: { temperature: 35 },
+    risk: { available: true, score: 28, level: '低风险' },
+    source_status: {
+      current: { available: true, stale: false, expires_at: '2026-07-17T08:30:00Z' },
+      forecast: { available: true, stale: true, expires_at: '2026-07-17T07:59:00Z' },
+      warnings: { available: true, stale: false, expires_at: '2026-07-17T08:30:00Z' },
+      risk: { available: true, stale: false, expires_at: '2026-07-17T08:30:00Z' },
+    },
+  });
+
+  assert.equal(freshnessView({ stale: true }, snapshot, 'risk', now).stale, false);
+  assert.equal(freshnessView({ stale: true }, snapshot, 'forecast', now).stale, true);
+  assert.equal(freshnessView({ stale: true }, snapshot, 'warnings', now).stale, false);
+  assert.equal(
+    freshnessView({ stale: true }, snapshot, 'risk', Date.parse('2026-07-17T08:31:00Z')).stale,
+    true,
+  );
+  assert.equal(snapshot.current.available, true);
+  assert.equal(snapshot.risk.available, true);
+
+  const warningsExpired = normalizeBootstrap({
+    warnings_stale: true,
+    warnings: [{ title: '旧高温预警' }],
+    source_status: {
+      warnings: { available: true, stale: true },
+    },
+  });
+  assert.deepEqual(warningsExpired.warnings, []);
+  assert.equal(warningsExpired.warningsSourceAvailable, false);
+  assert.equal(warningsExpired.warningsStatusText, '来源暂不可用');
+
+  const legacyWithoutExpiry = normalizeBootstrap({
+    risk_stale: false,
+    risk: { available: true, score: 28, level: '低风险' },
+    source_status: { risk: { available: true, stale: false } },
+  });
+  assert.equal(freshnessView({ stale: true }, legacyWithoutExpiry, 'risk', now).stale, true);
+});
+
 test('都昌县时间展示不受运行环境时区影响', () => {
   assert.equal(formatDateTime('2026-07-17T00:00:00Z'), '07月17日 08:00');
   assert.equal(formatDateTime('2026-07-17 08:00:00'), '07月17日 08:00');

--- a/miniprogram/tests/format.test.js
+++ b/miniprogram/tests/format.test.js
@@ -101,7 +101,7 @@ test('页面只按自身依赖来源判断快照新鲜度', () => {
   assert.equal(freshnessView({ stale: true }, snapshot, 'forecast', now).stale, true);
   assert.equal(freshnessView({ stale: true }, snapshot, 'warnings', now).stale, false);
   assert.equal(
-    freshnessView({ stale: true }, snapshot, 'risk', Date.parse('2026-07-17T08:31:00Z')).stale,
+    freshnessView({ stale: true }, snapshot, 'risk', Date.parse('2026-07-17T08:30:00Z')).stale,
     true,
   );
   assert.equal(snapshot.current.available, true);
@@ -117,6 +117,21 @@ test('页面只按自身依赖来源判断快照新鲜度', () => {
   assert.deepEqual(warningsExpired.warnings, []);
   assert.equal(warningsExpired.warningsSourceAvailable, false);
   assert.equal(warningsExpired.warningsStatusText, '来源暂不可用');
+
+  const warningsUnavailable = normalizeBootstrap({
+    warnings_stale: false,
+    warnings: [{ title: '来源失败前的旧高温预警' }],
+    source_status: {
+      warnings: {
+        available: false,
+        stale: false,
+        expires_at: '2026-07-17T08:30:00Z',
+      },
+    },
+  });
+  assert.deepEqual(warningsUnavailable.warnings, []);
+  assert.equal(warningsUnavailable.warningsSourceAvailable, false);
+  assert.equal(freshnessView({}, warningsUnavailable, 'warnings', now).stale, true);
 
   const legacyWithoutExpiry = normalizeBootstrap({
     risk_stale: false,
@@ -179,6 +194,7 @@ test('预警列表为空时区分暂无预警与来源不可用', () => {
 
 test('预警保留发布单位、发布时间和生效时间', () => {
   const result = normalizeBootstrap({
+    source_status: { warnings: { available: true, stale: false } },
     warnings: [{
       title: '高温黄色预警',
       start_time: '2026-07-17T08:30:00+08:00',
@@ -199,11 +215,13 @@ test('预警保留发布单位、发布时间和生效时间', () => {
   assert.match(warning.effectiveText, /08:30/);
 
   const objectSender = normalizeBootstrap({
+    source_status: { warnings: { available: true, stale: false } },
     warnings: [{ raw: { sender: { name: '九江市气象台' } } }],
   });
   assert.equal(objectSender.warnings[0].issuer, '九江市气象台');
 
   const publishedOnly = normalizeBootstrap({
+    source_status: { warnings: { available: true, stale: false } },
     warnings: [{
       start_time: '2026-07-17T08:00:00+08:00',
       raw: { pubTime: '2026-07-17T08:00:00+08:00' },

--- a/miniprogram/tests/format.test.js
+++ b/miniprogram/tests/format.test.js
@@ -24,6 +24,7 @@ test('bootstrap 兼容正式天气字段与 reasons', () => {
       date: '2026-07-17',
       message: '今天高温，我们一人负责一次联系。',
       follow_up_question: '上午谁先联系？',
+      depends_on: ['current'],
     },
   });
   assert.equal(result.current.condition, '晴');
@@ -53,6 +54,28 @@ test('不完整天气的未知风险必须保持不可用', () => {
   assert.equal(result.risk.scoreText, '待计算');
 });
 
+test('畸形组件 available 在新鲜网络响应中也会关闭天气和风险', () => {
+  [
+    { available: 'false', stale: false, expires_at: '2099-01-01T00:00:00Z' },
+    { available: true, stale: 'false', expires_at: 'garbage' },
+    { available: true },
+  ].forEach((state) => {
+    const result = normalizeBootstrap({
+      available: true,
+      current: { temperature: 38, temperature_max: 40 },
+      risk: { available: true, score: 90, level: '高风险' },
+      actions: [{ id: 'old-risk-action', title: '旧高温行动' }],
+      source_status: { current: state, risk: state },
+    });
+
+    assert.equal(result.current.available, false);
+    assert.equal(result.current.stale, true);
+    assert.equal(result.risk.available, false);
+    assert.equal(result.risk.stale, true);
+    assert.equal(freshnessView({ source: 'network', stale: false }, result, 'risk').stale, true);
+  });
+});
+
 test('归一化结果不保留未使用的原始大对象镜像', () => {
   const bootstrap = normalizeBootstrap({
     forecast: [{ date: '2026-07-18', temperature_max: 36, provider_payload: { verbose: true } }],
@@ -77,6 +100,47 @@ test('更新时间优先采用服务端真实抓取时间', () => {
     { fetchedAt: '2026-07-17T08:00:00+08:00' }
   );
   assert.match(view.updatedText, /08:00/);
+});
+
+test('组件更新时间优先采用自己的 fetched_at', () => {
+  const snapshot = normalizeBootstrap({
+    fetched_at: '2026-07-17T08:00:00+08:00',
+    source_status: {
+      warnings: {
+        available: true,
+        stale: false,
+        fetched_at: '2026-07-17T10:00:00+08:00',
+        expires_at: '2099-01-01T00:00:00Z',
+      },
+    },
+    warnings: [],
+  });
+
+  assert.equal(snapshot.freshness.warnings.fetchedAt, '2026-07-17T10:00:00+08:00');
+  assert.equal(freshnessView({}, snapshot, 'warnings').updatedText, '07月17日 10:00');
+});
+
+test('家庭提醒依赖允许明确空数组且拒绝缺失未知和重复值', () => {
+  const normalizeReminder = (familyReminder) => normalizeBootstrap({
+    family_reminder: familyReminder,
+  }).familyReminder;
+
+  const generic = normalizeReminder({
+    id: 'generic',
+    message: '今天方便时问问家里老人。',
+    depends_on: [],
+  });
+  assert.equal(generic.dependenciesValid, true);
+  assert.deepEqual(generic.dependsOn, []);
+
+  [
+    { id: 'missing', message: '旧格式提醒' },
+    { id: 'not-array', message: '畸形提醒', depends_on: 'current' },
+    { id: 'unknown', message: '未知依赖', depends_on: ['forecast'] },
+    { id: 'duplicate', message: '重复依赖', depends_on: ['current', 'current'] },
+  ].forEach((value) => {
+    assert.equal(normalizeReminder(value).dependenciesValid, false, value.id);
+  });
 });
 
 test('页面只按自身依赖来源判断快照新鲜度', () => {
@@ -180,7 +244,7 @@ test('预警列表为空时区分暂无预警与来源不可用', () => {
 
   const noWarnings = normalizeBootstrap({
     warnings: [],
-    source_status: { warnings: { available: true } },
+    source_status: { warnings: { available: true, stale: false } },
   });
   assert.equal(noWarnings.warnings.length, 0);
   assert.equal(noWarnings.warningsSourceAvailable, true);

--- a/miniprogram/tests/page-resilience.test.js
+++ b/miniprogram/tests/page-resilience.test.js
@@ -887,6 +887,89 @@ test('提醒话术遇到较早或不可用天气时退回通用提醒', async ()
   assert.match(unavailablePage.data.message, /【都昌县天气提醒】/);
 });
 
+test('只有新鲜官方预警时仍生成对应家庭行动和提醒', async () => {
+  authApiImpl = async () => ({
+    items: [{ pair_id: 9, member: { name: '奶奶', relation: '祖母' } }],
+  });
+  snapshotImpl = async () => ({
+    data: {
+      available: false,
+      stale: true,
+      current_stale: true,
+      risk_stale: true,
+      warnings_stale: false,
+      current: {},
+      risk: { available: false, level: '未知' },
+      warnings: [{ title: '都昌县高温橙色预警' }],
+      source_status: {
+        current: { available: false, expires_at: '2099-01-01T00:00:00Z' },
+        risk: { available: false, expires_at: '2099-01-01T00:00:00Z' },
+        warnings: { available: true, stale: false, expires_at: '2099-01-01T00:00:00Z' },
+      },
+    },
+    meta: { source: 'stale-cache', stale: true },
+  });
+
+  const actionDefinition = loadPage('../pages/action-checkin/index');
+  const actionPage = makePage(actionDefinition, { pairId: 9 });
+  await actionPage.loadContext.call(actionPage);
+
+  assert.equal(actionPage.data.weather.available, false);
+  assert.equal(actionPage.data.weather.componentStatus.warnings.usable, true);
+  assert.equal(actionPage.data.weatherStatus, '高温留意');
+  assert.deepEqual(actionPage.data.actions.map((item) => item.id), [
+    'drink_water',
+    'avoid_noon',
+    'cool_rest',
+  ]);
+
+  const templateDefinition = loadPage('../pages/template/index');
+  const templatePage = makePage(templateDefinition, { pairId: 9 });
+  await templatePage.loadTemplate.call(templatePage);
+
+  assert.equal(templatePage.data.trigger, 'heat');
+  assert.equal(templatePage.data.weatherNotice, '');
+  assert.match(templatePage.data.message, /【都昌县高温提醒】/);
+  assert.doesNotMatch(templatePage.data.message, /最高约/);
+});
+
+test('畸形 fresh-network 状态不能触发高温行动或提醒', async () => {
+  authApiImpl = async () => ({
+    items: [{ pair_id: 9, member: { name: '奶奶', relation: '祖母' } }],
+  });
+  snapshotImpl = async () => ({
+    data: {
+      available: true,
+      stale: false,
+      current: { temperature: 38, temperature_max: 40, temperature_min: 30 },
+      risk: { available: true, level: '高风险' },
+      warnings: [{ title: '来源不明的高温预警' }],
+      source_status: {
+        current: { available: 'false', stale: false, expires_at: '2099-01-01T00:00:00Z' },
+        risk: { available: 'false', stale: false, expires_at: '2099-01-01T00:00:00Z' },
+        warnings: { available: 'false', stale: false, expires_at: '2099-01-01T00:00:00Z' },
+      },
+    },
+    meta: { source: 'network', stale: false },
+  });
+
+  const actionDefinition = loadPage('../pages/action-checkin/index');
+  const actionPage = makePage(actionDefinition, { pairId: 9 });
+  await actionPage.loadContext.call(actionPage);
+  assert.deepEqual(actionPage.data.actions.map((item) => item.id), [
+    'check_weather',
+    'carry_water',
+    'contact_family',
+  ]);
+
+  const templateDefinition = loadPage('../pages/template/index');
+  const templatePage = makePage(templateDefinition, { pairId: 9 });
+  await templatePage.loadTemplate.call(templatePage);
+  assert.equal(templatePage.data.trigger, '');
+  assert.match(templatePage.data.message, /【都昌县天气提醒】/);
+  assert.doesNotMatch(templatePage.data.message, /高温提醒/);
+});
+
 test('复制提醒事件不上传家庭配对标识', () => {
   const requests = [];
   authApiImpl = (options) => {
@@ -1064,7 +1147,7 @@ test('公共天气页面失败会安全降级、统一退避并提供真实重�
     const alertsView = fs.readFileSync(path.join(miniRoot, 'pages/alerts/index.wxml'), 'utf8');
     const actionsView = fs.readFileSync(path.join(miniRoot, 'pages/actions/index.wxml'), 'utf8');
     const transparencyView = fs.readFileSync(path.join(miniRoot, 'pages/transparency/index.wxml'), 'utf8');
-    assert.match(homeView, /wx:if="\{\{error\}\}"[^>]*title="天气更新失败，风险信息已暂停"/);
+    assert.match(homeView, /wx:if="\{\{error\}\}"[^>]*freshness\.stale \? '天气更新失败，风险信息已暂停'/);
     assert.match(forecastView, /wx:if="\{\{error\}\}"[^>]*title="预报更新失败，风险等级已暂停"/);
     assert.match(alertsView, /error \? '预警更新失败，有效性待核对'/);
     assert.match(actionsView, /action-label="\{\{error \? '重新获取天气' : ''\}\}"[^>]*bind:action="retry"/);

--- a/miniprogram/tests/share.test.js
+++ b/miniprogram/tests/share.test.js
@@ -275,6 +275,257 @@ test('较早公共天气隐藏旧风险分数并退回通用行动', () => {
   assert.match(actionsView, /较早天气已切换为通用清单/);
 });
 
+test('首页保留独立新鲜的官方预警', () => {
+  const page = pageInstance(loadHomePageDefinition());
+  page.renderSnapshot.call(page, {
+    data: {
+      available: false,
+      stale: true,
+      current_stale: true,
+      risk_stale: true,
+      warnings_stale: false,
+      location: { name: '都昌县' },
+      current: {},
+      risk: { available: false, level: '未知', score: null },
+      warnings: [{ id: 'fresh-warning', title: '都昌县高温橙色预警' }],
+      source_status: {
+        current: { available: false, expires_at: '2099-01-01T00:00:00Z' },
+        risk: { available: false, expires_at: '2099-01-01T00:00:00Z' },
+        warnings: { available: true, stale: false, expires_at: '2099-01-01T00:00:00Z' },
+      },
+    },
+    meta: { source: 'stale-cache', stale: true },
+  });
+
+  assert.equal(page.data.freshness.stale, true);
+  assert.equal(page.data.snapshot.risk.label, '风险待刷新');
+  assert.equal(page.data.snapshot.warnings.length, 1);
+  assert.equal(page.data.snapshot.warnings[0].id, 'fresh-warning');
+  assert.equal(page.data.snapshot.warningsSourceAvailable, true);
+  assert.equal(page.data.snapshot.warningsStatusText, '1 条有效信息');
+});
+
+test('风险组件仍新鲜时联网失败文案不宣称风险行动暂停', () => {
+  const page = pageInstance(loadHomePageDefinition());
+  page.renderSnapshot.call(page, {
+    data: {
+      available: true,
+      stale: true,
+      current_stale: false,
+      risk_stale: false,
+      warnings_stale: false,
+      location: { name: '都昌县' },
+      current: { temperature: 35 },
+      risk: { available: true, score: 72, level: '高风险' },
+      warnings: [],
+      actions: [{ id: 'hydrate', title: '少量多次补水' }],
+      source_status: {
+        current: { available: true, stale: false, expires_at: '2099-01-01T00:00:00Z' },
+        risk: { available: true, stale: false, expires_at: '2099-01-01T00:00:00Z' },
+        warnings: { available: true, stale: false, expires_at: '2099-01-01T00:00:00Z' },
+      },
+    },
+    meta: { source: 'stale-cache', stale: true, networkError: true },
+  });
+
+  assert.equal(page.data.freshness.stale, false);
+  assert.equal(page.data.snapshot.risk.available, true);
+  assert.deepEqual(page.data.topActions.map((item) => item.id), ['hydrate']);
+  assert.match(page.data.error, /联网|网络/);
+  assert.doesNotMatch(page.data.error, /风险.*暂停|行动.*暂停|较早观测/);
+
+  const view = fs.readFileSync(path.join(__dirname, '..', 'pages/home/index.wxml'), 'utf8');
+  assert.match(view, /freshness\.stale \? '天气更新失败，风险信息已暂停'/);
+});
+
+test('首页和行动页拒绝畸形 fresh-network 风险状态', () => {
+  [
+    { available: 'false', stale: false, expires_at: '2099-01-01T00:00:00Z' },
+    { available: true, stale: 'false', expires_at: 'garbage' },
+  ].forEach((state) => {
+    const result = {
+      data: {
+        available: true,
+        location: { name: '都昌县' },
+        current: { temperature: 38, temperature_max: 40 },
+        risk: { available: true, score: 90, level: '高风险' },
+        actions: [{ id: 'old-risk-action', title: '旧高温行动' }],
+        source_status: {
+          current: state,
+          risk: state,
+          warnings: { available: true, stale: false, expires_at: '2099-01-01T00:00:00Z' },
+        },
+      },
+      meta: { source: 'network', stale: false },
+    };
+
+    const home = pageInstance(loadHomePageDefinition());
+    home.renderSnapshot.call(home, result);
+    assert.equal(home.data.freshness.stale, true);
+    assert.equal(home.data.snapshot.risk.available, false);
+    assert.deepEqual(home.data.topActions, []);
+
+    const actions = pageInstance(loadActionsPageDefinition());
+    actions.renderActions.call(actions, result);
+    assert.equal(actions.data.generalMode, true);
+    assert.equal(actions.data.actions.some((item) => item.id === 'old-risk-action'), false);
+  });
+});
+
+test('行动页按风险可用性和提醒依赖分别校验', () => {
+  const componentStates = {
+    current: { available: true, stale: false, expires_at: '2099-01-01T00:00:00Z' },
+    risk: { available: true, stale: false, expires_at: '2099-01-01T00:00:00Z' },
+    warnings: { available: true, stale: true, expires_at: '2000-01-01T00:00:00Z' },
+  };
+  const baseData = {
+    available: true,
+    stale: true,
+    current_stale: false,
+    risk_stale: false,
+    warnings_stale: true,
+    location: { name: '都昌县' },
+    current: { temperature: 36 },
+    risk: { available: true, score: 72, level: '高风险' },
+    warnings: [],
+    actions: [{ id: 'hydrate', title: '少量多次补水' }],
+    source_status: componentStates,
+  };
+
+  const currentOnly = pageInstance(loadActionsPageDefinition());
+  currentOnly.renderActions.call(currentOnly, {
+    data: {
+      ...baseData,
+      family_reminder: {
+        id: 'current-only',
+        message: '今天较热，记得联系家人。',
+        depends_on: ['current'],
+      },
+    },
+    meta: { source: 'network', stale: true },
+  });
+  assert.equal(currentOnly.data.familyReminder.id, 'current-only');
+
+  const generic = pageInstance(loadActionsPageDefinition());
+  generic.renderActions.call(generic, {
+    data: {
+      ...baseData,
+      available: false,
+      current_stale: true,
+      risk_stale: true,
+      risk: { available: false, level: '未知' },
+      actions: [],
+      source_status: {
+        current: { available: false, stale: true, expires_at: '2000-01-01T00:00:00Z' },
+        risk: { available: false, stale: true, expires_at: '2000-01-01T00:00:00Z' },
+        warnings: { available: false, stale: true, expires_at: '2000-01-01T00:00:00Z' },
+      },
+      family_reminder: {
+        id: 'generic',
+        message: '今天方便时问问家里老人。',
+        depends_on: [],
+      },
+    },
+    meta: { source: 'stale-cache', stale: true },
+  });
+  assert.equal(generic.data.familyReminder.id, 'generic');
+  assert.deepEqual(generic.data.familyReminder.dependsOn, []);
+
+  const warningOnly = pageInstance(loadActionsPageDefinition());
+  warningOnly.renderActions.call(warningOnly, {
+    data: {
+      ...baseData,
+      available: false,
+      current_stale: true,
+      risk_stale: true,
+      warnings_stale: false,
+      current: {},
+      risk: { available: false, level: '未知' },
+      actions: [],
+      warnings: [{ title: '都昌县高温橙色预警' }],
+      source_status: {
+        current: { available: false, stale: true, expires_at: '2000-01-01T00:00:00Z' },
+        risk: { available: false, stale: true, expires_at: '2000-01-01T00:00:00Z' },
+        warnings: { available: true, stale: false, expires_at: '2099-01-01T00:00:00Z' },
+      },
+      family_reminder: {
+        id: 'warning-only',
+        message: '高温预警已生效，请联系家人。',
+        depends_on: ['warnings'],
+      },
+    },
+    meta: { source: 'stale-cache', stale: true },
+  });
+  assert.equal(warningOnly.data.familyReminder.id, 'warning-only');
+  assert.deepEqual(warningOnly.data.familyReminder.dependsOn, ['warnings']);
+
+  const invalidReminders = [
+    { id: 'missing', message: '旧预警提醒。' },
+    { id: 'unknown', message: '未知依赖提醒。', depends_on: ['forecast'] },
+    { id: 'duplicate', message: '重复依赖提醒。', depends_on: ['current', 'current'] },
+    { id: 'expired-warning', message: '旧高温预警提醒。', depends_on: ['warnings'] },
+  ];
+  invalidReminders.forEach((familyReminder) => {
+    const page = pageInstance(loadActionsPageDefinition());
+    page.renderActions.call(page, {
+      data: { ...baseData, family_reminder: familyReminder },
+      meta: { source: 'network', stale: true },
+    });
+    assert.equal(page.data.familyReminder, null, familyReminder.id);
+  });
+
+  const unavailableRisk = pageInstance(loadActionsPageDefinition());
+  unavailableRisk.renderActions.call(unavailableRisk, {
+    data: {
+      ...baseData,
+      risk: { available: false, level: '未知' },
+      actions: [{ id: 'old-risk-action', title: '旧风险行动' }],
+      source_status: {
+        ...componentStates,
+        risk: { available: false, stale: false, expires_at: '2099-01-01T00:00:00Z' },
+      },
+    },
+    meta: { source: 'network', stale: false },
+  });
+  assert.equal(unavailableRisk.data.generalMode, true);
+  assert.equal(unavailableRisk.data.actions.some((item) => item.id === 'old-risk-action'), false);
+});
+
+test('旧预警提醒被隐藏后复制内容不含旧预警', () => {
+  const page = pageInstance(loadActionsPageDefinition());
+  page.renderActions.call(page, {
+    data: {
+      available: true,
+      current_stale: false,
+      risk_stale: false,
+      warnings_stale: true,
+      current: { temperature: 35 },
+      risk: { available: true, score: 72, level: '高风险' },
+      warnings: [],
+      actions: [{ id: 'hydrate', title: '少量多次补水' }],
+      family_reminder: { id: 'legacy', message: '旧高温预警仍然生效。' },
+      source_status: {
+        current: { available: true, stale: false, expires_at: '2099-01-01T00:00:00Z' },
+        risk: { available: true, stale: false, expires_at: '2099-01-01T00:00:00Z' },
+        warnings: { available: true, stale: true, expires_at: '2000-01-01T00:00:00Z' },
+      },
+    },
+    meta: { source: 'network', stale: false },
+  });
+
+  let clipboard = '';
+  const previousWx = global.wx;
+  global.wx = { setClipboardData: ({ data }) => { clipboard = data; } };
+  try {
+    page.copyReminder.call(page);
+  } finally {
+    global.wx = previousWx;
+  }
+  assert.equal(page.data.familyReminder, null);
+  assert.doesNotMatch(clipboard, /旧高温预警/);
+  assert.match(clipboard, /少量多次补水/);
+});
+
 test('复制给家人的提醒使用当日模板并保留未确认行动', () => {
   const definition = loadActionsPageDefinition();
   const page = pageInstance(definition);
@@ -313,7 +564,10 @@ test('首页只向视图层传递当前天气和前三项行动', () => {
       current: { temperature: 35, temperature_max: 38, temperature_min: 28 },
       risk: { score: 72, level: '高风险' },
       warnings: [],
-      source_status: { warnings: { available: true }, weather: { available: true } },
+      source_status: {
+        warnings: { available: true, stale: false },
+        weather: { available: true, stale: false },
+      },
       forecast: Array.from({ length: 7 }, (_, index) => ({
         date: `2026-07-${String(index + 18).padStart(2, '0')}`,
         temperature_max: 36 + index,

--- a/miniprogram/utils/format.js
+++ b/miniprogram/utils/format.js
@@ -286,7 +286,11 @@ function normalizeBootstrap(payload) {
   const riskScore = finiteNumber(firstDefined(riskSource, ['score', 'risk_score', 'value', 'index'], null));
   const currentStale = Boolean(data.current_stale === true || currentState.stale === true);
   const forecastStale = Boolean(data.forecast_stale === true || forecastState.stale === true);
-  const warningsStale = Boolean(data.warnings_stale === true || warningsState.stale === true);
+  const warningsStale = Boolean(
+    data.warnings_stale === true
+    || warningsState.stale === true
+    || warningsState.available !== true
+  );
   const riskStale = Boolean(data.risk_stale === true || riskState.stale === true);
   const componentFreshness = (state, stale, explicitKey) => {
     const expiresValue = state && (state.expires_at || state.expiresAt);
@@ -468,7 +472,7 @@ function freshnessView(resultMeta, snapshot, component, nowMs) {
   const stale = componentState && componentState.known
     ? Boolean(
       componentState.stale
-      || (Number.isFinite(componentState.expiresAt) && currentTime > componentState.expiresAt)
+      || (Number.isFinite(componentState.expiresAt) && currentTime >= componentState.expiresAt)
     )
     : Boolean(meta.stale || data.stale);
   return {

--- a/miniprogram/utils/format.js
+++ b/miniprogram/utils/format.js
@@ -7,6 +7,52 @@ function firstDefined(object, keys, fallback) {
   return fallback;
 }
 
+function isPlainRecord(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function componentSourceContract(sourceStatus, aliases) {
+  const source = isPlainRecord(sourceStatus) ? sourceStatus : {};
+  const entries = aliases
+    .filter((key) => Object.prototype.hasOwnProperty.call(source, key))
+    .map((key) => source[key]);
+  const present = entries.length > 0;
+  const valid = !present || entries.every((state) => {
+    if (!isPlainRecord(state) || typeof state.available !== 'boolean') return false;
+    const hasStale = Object.prototype.hasOwnProperty.call(state, 'stale');
+    if (hasStale && typeof state.stale !== 'boolean') {
+      return false;
+    }
+    const expiresValue = firstDefined(state, ['expires_at', 'expiresAt'], '');
+    const hasValidExpiry = Boolean(expiresValue)
+      && Number.isFinite(Date.parse(String(expiresValue)));
+    if (expiresValue && !hasValidExpiry) return false;
+    // 显式组件状态必须带可核验的新鲜度信号，不能只凭 available 解锁。
+    return hasStale || hasValidExpiry;
+  });
+  const states = entries.filter(isPlainRecord);
+  const available = present && valid && states.every((state) => state.available === true);
+  const independentlyVerifiable = available && states.every((state) => {
+    const expiresValue = firstDefined(state, ['expires_at', 'expiresAt'], '');
+    const expiresAt = Date.parse(String(expiresValue || ''));
+    return state.stale === false && Number.isFinite(expiresAt);
+  });
+  return {
+    present,
+    valid,
+    available,
+    independentlyVerifiable,
+    stale: present && (
+      !valid
+      || !available
+      || states.some((state) => state.stale === true)
+    ),
+    state: states[0] || {},
+  };
+}
+
 function finiteNumber(value) {
   if (value === null || value === undefined || value === '') return null;
   const number = Number(value);
@@ -219,12 +265,23 @@ function normalizeAction(item, index) {
 
 function normalizeFamilyReminder(value) {
   const source = value && typeof value === 'object' ? value : {};
+  const hasSnakeDependencies = Object.prototype.hasOwnProperty.call(source, 'depends_on');
+  const hasCamelDependencies = Object.prototype.hasOwnProperty.call(source, 'dependsOn');
+  const rawDependencies = hasSnakeDependencies
+    ? source.depends_on
+    : (hasCamelDependencies ? source.dependsOn : undefined);
+  const allowedDependencies = new Set(['current', 'warnings']);
+  const dependenciesValid = Array.isArray(rawDependencies)
+    && rawDependencies.every((item) => typeof item === 'string' && allowedDependencies.has(item))
+    && new Set(rawDependencies).size === rawDependencies.length;
   return {
     id: String(firstDefined(source, ['id'], '')),
     date: String(firstDefined(source, ['date'], '')),
     message: String(firstDefined(source, ['message'], '')),
     followUpQuestion: String(firstDefined(source, ['follow_up_question', 'followUpQuestion'], '')),
     text: String(firstDefined(source, ['text'], '')),
+    dependsOn: Array.isArray(rawDependencies) ? rawDependencies.slice() : [],
+    dependenciesValid,
   };
 }
 
@@ -253,12 +310,8 @@ function normalizeSources(sourceStatus) {
 }
 
 function warningSourceAvailable(sourceStatus) {
-  if (!sourceStatus || typeof sourceStatus !== 'object' || Array.isArray(sourceStatus)) return false;
-  const warnings = sourceStatus.warnings;
-  if (typeof warnings === 'boolean') return warnings;
-  if (warnings && typeof warnings === 'object' && typeof warnings.available === 'boolean') {
-    return warnings.available;
-  }
+  const contract = componentSourceContract(sourceStatus, ['warnings']);
+  if (contract.present) return contract.valid && contract.available;
   // 来源状态缺失时无法确认确实没有预警，按不可用处理更安全。
   return false;
 }
@@ -271,40 +324,82 @@ function warningStatusText(warnings, sourceAvailable) {
 
 function normalizeBootstrap(payload) {
   const data = payload && typeof payload === 'object' ? payload : {};
-  const sourceStatus = data.source_status && typeof data.source_status === 'object'
+  const sourceStatus = isPlainRecord(data.source_status)
     ? data.source_status
     : {};
-  const currentState = sourceStatus.current || sourceStatus.weather || {};
+  const currentContract = componentSourceContract(
+    sourceStatus,
+    ['current', 'current_weather', 'weather'],
+  );
+  const forecastContract = componentSourceContract(sourceStatus, ['forecast']);
+  const warningsContract = componentSourceContract(sourceStatus, ['warnings']);
+  const riskContract = componentSourceContract(sourceStatus, ['risk']);
+  const currentState = currentContract.state;
   const forecastState = sourceStatus.forecast || {};
-  const warningsState = sourceStatus.warnings || {};
-  const riskState = sourceStatus.risk || {};
-  const currentSource = data.current && typeof data.current === 'object' ? data.current : {};
-  const riskSource = data.risk && typeof data.risk === 'object' ? data.risk : {};
+  const warningsState = warningsContract.state;
+  const riskState = riskContract.state;
+  const currentCandidate = data.current || data.current_weather || data.weather;
+  const currentSource = isPlainRecord(currentCandidate) ? currentCandidate : {};
+  const riskSource = isPlainRecord(data.risk) ? data.risk : {};
   const temperature = finiteNumber(firstDefined(currentSource, ['temperature', 'temp', 'temp_now', 'temperature_current'], null));
   const high = finiteNumber(firstDefined(currentSource, ['temperature_max', 'temp_max', 'tempMax', 'high'], null));
   const low = finiteNumber(firstDefined(currentSource, ['temperature_min', 'temp_min', 'tempMin', 'low'], null));
   const riskScore = finiteNumber(firstDefined(riskSource, ['score', 'risk_score', 'value', 'index'], null));
-  const currentStale = Boolean(data.current_stale === true || currentState.stale === true);
-  const forecastStale = Boolean(data.forecast_stale === true || forecastState.stale === true);
-  const warningsStale = Boolean(
-    data.warnings_stale === true
-    || warningsState.stale === true
-    || warningsState.available !== true
+  const rootAvailable = Object.prototype.hasOwnProperty.call(data, 'available')
+    ? data.available === true
+    : true;
+  const currentRootAvailable = rootAvailable;
+  const riskRootAvailable = rootAvailable;
+  const warningsRootAvailable = rootAvailable;
+  const currentStateAvailable = currentContract.present ? currentContract.available : true;
+  const riskStateAvailable = riskContract.present ? riskContract.available : true;
+  const warningsStateAvailable = warningsContract.present && warningsContract.available;
+  const warningsIndependentAvailable = warningsRootAvailable
+    || (warningsContract.present && warningsContract.independentlyVerifiable);
+  const malformedTopStale = (key) => (
+    Object.prototype.hasOwnProperty.call(data, key) && typeof data[key] !== 'boolean'
   );
-  const riskStale = Boolean(data.risk_stale === true || riskState.stale === true);
+  const currentStale = Boolean(
+    malformedTopStale('current_stale')
+    || data.current_stale === true
+    || currentContract.stale
+    || (currentContract.present && !currentRootAvailable)
+  );
+  const forecastStale = Boolean(
+    malformedTopStale('forecast_stale')
+    || data.forecast_stale === true
+    || forecastState.stale === true
+    || forecastContract.stale
+  );
+  const warningsStale = Boolean(
+    malformedTopStale('warnings_stale')
+    || data.warnings_stale === true
+    || warningsContract.stale
+    || !warningsStateAvailable
+    || !warningsIndependentAvailable
+  );
+  const riskStale = Boolean(
+    malformedTopStale('risk_stale')
+    || data.risk_stale === true
+    || riskContract.stale
+    || (riskContract.present && !riskRootAvailable)
+  );
   const componentFreshness = (state, stale, explicitKey) => {
     const expiresValue = state && (state.expires_at || state.expiresAt);
     const expiresAt = expiresValue ? Date.parse(String(expiresValue)) : NaN;
+    const fetchedAt = state && firstDefined(state, ['fetched_at', 'fetchedAt', 'updated_at'], '');
     return {
       stale,
       // 只有服务端已判定过期，或有可验证的过期时间时，组件状态才能覆盖旧全局合同。
       known: stale || Number.isFinite(expiresAt),
       expiresAt: Number.isFinite(expiresAt) ? expiresAt : null,
       explicit: explicitKey in data,
+      fetchedAt: String(fetchedAt || ''),
     };
   };
-  const riskAvailable = data.available !== false
-    && riskSource.available !== false
+  const riskAvailable = riskRootAvailable
+    && riskStateAvailable
+    && (!Object.prototype.hasOwnProperty.call(riskSource, 'available') || riskSource.available === true)
     && !riskStale
     && (riskScore !== null || Boolean(riskSource.level || riskSource.label));
   const riskLevelValue = firstDefined(riskSource, ['label', 'level', 'risk_level'], '');
@@ -319,7 +414,7 @@ function normalizeBootstrap(payload) {
     : (Array.isArray(data.actions && data.actions.items) ? data.actions.items : []);
   // 过期预警不能继续以“当前有效”展示，首页与预警页共用这个安全结果。
   const warnings = warningsStale ? [] : warningsRaw.map(normalizeWarning);
-  const warningsSourceAvailable = !warningsStale && warningSourceAvailable(data.source_status);
+  const warningsSourceAvailable = !warningsStale && warningsStateAvailable;
   return {
     snapshotId: String(data.snapshot_id || ''),
     location: {
@@ -330,7 +425,7 @@ function normalizeBootstrap(payload) {
     fetchedAt: data.fetched_at || data.generated_at || '',
     expiresAt: data.expires_at || '',
     ttlSeconds: finiteNumber(data.ttl_seconds) || 1800,
-    available: data.available !== false,
+    available: rootAvailable,
     stale: Boolean(data.stale),
     currentStale,
     forecastStale,
@@ -343,7 +438,11 @@ function normalizeBootstrap(payload) {
       risk: componentFreshness(riskState, riskStale, 'risk_stale'),
     },
     current: {
-      available: data.available !== false && currentSource.available !== false && !currentStale && temperature !== null,
+      available: currentRootAvailable
+        && currentStateAvailable
+        && (!Object.prototype.hasOwnProperty.call(currentSource, 'available') || currentSource.available === true)
+        && !currentStale
+        && temperature !== null,
       stale: currentStale,
       temperature,
       temperatureText: formatTemperature(temperature),
@@ -466,8 +565,11 @@ function normalizeCommunity(payload) {
 function freshnessView(resultMeta, snapshot, component, nowMs) {
   const meta = resultMeta || {};
   const data = snapshot || {};
-  const storedAt = data.fetchedAt || data.generatedAt || meta.storedAt;
   const componentState = component && data.freshness && data.freshness[component];
+  const storedAt = (componentState && componentState.fetchedAt)
+    || data.fetchedAt
+    || data.generatedAt
+    || meta.storedAt;
   const currentTime = Number.isFinite(Number(nowMs)) ? Number(nowMs) : Date.now();
   const stale = componentState && componentState.known
     ? Boolean(

--- a/miniprogram/utils/format.js
+++ b/miniprogram/utils/format.js
@@ -271,13 +271,38 @@ function warningStatusText(warnings, sourceAvailable) {
 
 function normalizeBootstrap(payload) {
   const data = payload && typeof payload === 'object' ? payload : {};
+  const sourceStatus = data.source_status && typeof data.source_status === 'object'
+    ? data.source_status
+    : {};
+  const currentState = sourceStatus.current || sourceStatus.weather || {};
+  const forecastState = sourceStatus.forecast || {};
+  const warningsState = sourceStatus.warnings || {};
+  const riskState = sourceStatus.risk || {};
   const currentSource = data.current && typeof data.current === 'object' ? data.current : {};
   const riskSource = data.risk && typeof data.risk === 'object' ? data.risk : {};
   const temperature = finiteNumber(firstDefined(currentSource, ['temperature', 'temp', 'temp_now', 'temperature_current'], null));
   const high = finiteNumber(firstDefined(currentSource, ['temperature_max', 'temp_max', 'tempMax', 'high'], null));
   const low = finiteNumber(firstDefined(currentSource, ['temperature_min', 'temp_min', 'tempMin', 'low'], null));
   const riskScore = finiteNumber(firstDefined(riskSource, ['score', 'risk_score', 'value', 'index'], null));
-  const riskAvailable = data.available !== false && riskSource.available !== false && (riskScore !== null || Boolean(riskSource.level || riskSource.label));
+  const currentStale = Boolean(data.current_stale === true || currentState.stale === true);
+  const forecastStale = Boolean(data.forecast_stale === true || forecastState.stale === true);
+  const warningsStale = Boolean(data.warnings_stale === true || warningsState.stale === true);
+  const riskStale = Boolean(data.risk_stale === true || riskState.stale === true);
+  const componentFreshness = (state, stale, explicitKey) => {
+    const expiresValue = state && (state.expires_at || state.expiresAt);
+    const expiresAt = expiresValue ? Date.parse(String(expiresValue)) : NaN;
+    return {
+      stale,
+      // 只有服务端已判定过期，或有可验证的过期时间时，组件状态才能覆盖旧全局合同。
+      known: stale || Number.isFinite(expiresAt),
+      expiresAt: Number.isFinite(expiresAt) ? expiresAt : null,
+      explicit: explicitKey in data,
+    };
+  };
+  const riskAvailable = data.available !== false
+    && riskSource.available !== false
+    && !riskStale
+    && (riskScore !== null || Boolean(riskSource.level || riskSource.label));
   const riskLevelValue = firstDefined(riskSource, ['label', 'level', 'risk_level'], '');
   const forecastRaw = Array.isArray(data.forecast)
     ? data.forecast
@@ -288,8 +313,9 @@ function normalizeBootstrap(payload) {
   const actionsRaw = Array.isArray(data.actions)
     ? data.actions
     : (Array.isArray(data.actions && data.actions.items) ? data.actions.items : []);
-  const warnings = warningsRaw.map(normalizeWarning);
-  const warningsSourceAvailable = warningSourceAvailable(data.source_status);
+  // 过期预警不能继续以“当前有效”展示，首页与预警页共用这个安全结果。
+  const warnings = warningsStale ? [] : warningsRaw.map(normalizeWarning);
+  const warningsSourceAvailable = !warningsStale && warningSourceAvailable(data.source_status);
   return {
     snapshotId: String(data.snapshot_id || ''),
     location: {
@@ -302,8 +328,19 @@ function normalizeBootstrap(payload) {
     ttlSeconds: finiteNumber(data.ttl_seconds) || 1800,
     available: data.available !== false,
     stale: Boolean(data.stale),
+    currentStale,
+    forecastStale,
+    warningsStale,
+    riskStale,
+    freshness: {
+      current: componentFreshness(currentState, currentStale, 'current_stale'),
+      forecast: componentFreshness(forecastState, forecastStale, 'forecast_stale'),
+      warnings: componentFreshness(warningsState, warningsStale, 'warnings_stale'),
+      risk: componentFreshness(riskState, riskStale, 'risk_stale'),
+    },
     current: {
-      available: data.available !== false && currentSource.available !== false && temperature !== null,
+      available: data.available !== false && currentSource.available !== false && !currentStale && temperature !== null,
+      stale: currentStale,
       temperature,
       temperatureText: formatTemperature(temperature),
       high,
@@ -320,6 +357,7 @@ function normalizeBootstrap(payload) {
     warningsStatusText: warningStatusText(warnings, warningsSourceAvailable),
     risk: {
       available: riskAvailable,
+      stale: riskStale,
       score: riskScore,
       scoreText: riskScore === null ? '待计算' : String(Math.round(riskScore)),
       level: String(riskLevelValue),
@@ -421,13 +459,21 @@ function normalizeCommunity(payload) {
   };
 }
 
-function freshnessView(resultMeta, snapshot) {
+function freshnessView(resultMeta, snapshot, component, nowMs) {
   const meta = resultMeta || {};
   const data = snapshot || {};
   const storedAt = data.fetchedAt || data.generatedAt || meta.storedAt;
+  const componentState = component && data.freshness && data.freshness[component];
+  const currentTime = Number.isFinite(Number(nowMs)) ? Number(nowMs) : Date.now();
+  const stale = componentState && componentState.known
+    ? Boolean(
+      componentState.stale
+      || (Number.isFinite(componentState.expiresAt) && currentTime > componentState.expiresAt)
+    )
+    : Boolean(meta.stale || data.stale);
   return {
     updatedText: formatDateTime(storedAt),
-    stale: Boolean(meta.stale || data.stale),
+    stale,
     source: meta.source || 'unknown',
     refreshDeferred: Boolean(meta.refreshDeferred),
     refreshStarted: Boolean(meta.refreshStarted),

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -772,6 +772,8 @@ LOCAL_RELEASE_EXPORT_DIR=""
 
 # 两种远端模式都只上传冻结提交快照，避免 rsync 在校验后继续读取可变化的工作目录。
 prepare_release_source() {
+    local release_archive="$LOCAL_DEPLOY_TEMP_DIR/release-source.tar"
+
     if [ -z "$VERIFIED_COMMIT_FILE" ] || [ ! -f "$VERIFIED_COMMIT_FILE" ]; then
         echo "远端发布缺少同一次校验生成的目标提交票据。" >&2
         exit 64
@@ -796,8 +798,14 @@ prepare_release_source() {
     esac
     LOCAL_RELEASE_EXPORT_DIR="$LOCAL_DEPLOY_TEMP_DIR/release-source"
     mkdir -m 0700 "$LOCAL_RELEASE_EXPORT_DIR"
-    git -C "$LOCAL_DIR" archive --format=tar "$VERIFIED_COMMIT" \
-        | tar -xf - -C "$LOCAL_RELEASE_EXPORT_DIR"
+    # macOS 的 tar 可能提前关闭管道，令 git archive 在 pipefail 下以 141 退出。
+    # 先在本轮 0700 临时目录生成 0600 归档，再从同一文件解包。
+    (umask 077; git -C "$LOCAL_DIR" archive \
+        --format=tar \
+        --output="$release_archive" \
+        "$VERIFIED_COMMIT")
+    chmod 0600 "$release_archive"
+    tar -xf "$release_archive" -C "$LOCAL_RELEASE_EXPORT_DIR"
     RELEASE_SOURCE_DIR="$LOCAL_RELEASE_EXPORT_DIR"
 }
 

--- a/services/miniprogram_service.py
+++ b/services/miniprogram_service.py
@@ -231,7 +231,7 @@ def _component_state(
             break
     expires_at = _source_datetime(raw.get("expires_at")) or fallback_expires_at
     fetched_at = _source_datetime(raw.get("fetched_at"))
-    stale = expires_at is None or now > expires_at
+    stale = expires_at is None or now >= expires_at
     available = bool(raw.get("available", fallback_available))
     state = {
         **raw,
@@ -268,7 +268,8 @@ def _payload_source_status(record, current, forecast, warnings, *, now, expires_
         "warnings",
         now=now,
         fallback_expires_at=expires_at,
-        fallback_available=isinstance(warnings, list),
+        # 未知预警来源不能因为 payload 恰好是列表就被视为核验成功。
+        fallback_available=False,
     )
     risk_stale = current_state["stale"] or not current_state["available"]
     risk_state = {
@@ -553,7 +554,7 @@ def snapshot_payload(record=None, *, now=None) -> dict:
     current = safe_json_loads(record.current_json, {})
     forecast = safe_json_loads(record.forecast_json, [])
     warnings = safe_json_loads(record.warnings_json, [])
-    stale = current_time > expires_at
+    stale = current_time >= expires_at
     source_status = _payload_source_status(
         record,
         current,
@@ -570,7 +571,7 @@ def snapshot_payload(record=None, *, now=None) -> dict:
         record,
         current,
         # 过期预警不能继续参与家庭提醒话术，当前天气风险仍可独立使用。
-        [] if warnings_stale else warnings,
+        [] if warnings_stale or not source_status["warnings"]["available"] else warnings,
         available=bool(record.available) and not risk_stale,
         date_value=current_time,
     )

--- a/services/miniprogram_service.py
+++ b/services/miniprogram_service.py
@@ -146,6 +146,7 @@ def _source_status(
     forecast_meta=None,
     warning_status=None,
     source_timing=None,
+    current_available=None,
 ) -> dict:
     source = str((current or {}).get("data_source") or (current or {}).get("source") or "").strip()
     forecast_sources = sorted(
@@ -167,7 +168,11 @@ def _source_status(
         "refresh_interval_seconds": SNAPSHOT_TTL_SECONDS,
         "canonical_location_only": True,
         "weather": {
-            "available": _weather_available(current),
+            "available": (
+                _weather_available(current)
+                if current_available is None
+                else current_available is True
+            ),
             "provider": source or "unavailable",
             "is_mock": bool((current or {}).get("is_mock")),
             **(timing.get("current") or {}),
@@ -202,6 +207,94 @@ def _source_datetime(value):
         return ensure_utc_aware(datetime.fromisoformat(str(value)))
     except (TypeError, ValueError, OverflowError):
         return None
+
+
+def snapshot_component_status(payload, component, *, now=None) -> dict:
+    """按精确组件合同判断可用性，旧快照才回退到总状态。"""
+    data = payload if isinstance(payload, dict) else {}
+    component_name = str(component or "").strip().lower()
+    aliases = {
+        "current": ("current", "current_weather", "weather"),
+        "risk": ("risk",),
+        "forecast": ("forecast",),
+        "warnings": ("warnings",),
+    }
+    source_status = data.get("source_status")
+    source_status = source_status if isinstance(source_status, dict) else {}
+    state = None
+    state_present = False
+    for key in aliases.get(component_name, (component_name,)):
+        if key in source_status:
+            state_present = True
+            candidate = source_status.get(key)
+            state = candidate if isinstance(candidate, dict) else {}
+            break
+    state_is_mapping = isinstance(state, dict)
+    state = state if state_is_mapping else {}
+
+    root_available = data.get("available") is True
+    root_stale = data.get("stale") is not False
+    state_has_availability = isinstance(state.get("available"), bool)
+    state_stale_value = state.get("stale")
+    state_stale_valid = (
+        "stale" not in state or isinstance(state_stale_value, bool)
+    )
+    raw_expires_at = state.get("expires_at")
+    expires_at = _source_datetime(raw_expires_at)
+    state_expiry_valid = raw_expires_at in (None, "") or expires_at is not None
+    state_contract_valid = (
+        (not state_present)
+        or (
+            state_is_mapping
+            and state_has_availability
+            and state_stale_valid
+            and state_expiry_valid
+        )
+    )
+    component_available = (
+        state["available"]
+        if state_contract_valid and state_has_availability
+        else False if state_present else root_available
+    )
+
+    stale_signals = []
+    top_stale = data.get(f"{component_name}_stale")
+    if isinstance(top_stale, bool):
+        stale_signals.append(top_stale)
+    state_stale = state_stale_value
+    if isinstance(state_stale, bool):
+        stale_signals.append(state_stale)
+    if expires_at is not None:
+        stale_signals.append(ensure_utc_aware(now or utcnow()) >= expires_at)
+
+    explicit_contract = (
+        state_present
+        and state_contract_valid
+        and state_has_availability
+        and bool(stale_signals)
+    )
+    component_stale = (
+        True
+        if state_present and not state_contract_valid
+        else any(stale_signals) if stale_signals else root_stale
+    )
+    if component_name in {"current", "risk"}:
+        # 根 available 表示当前天气是否可用，风险必须继承这一硬门禁。
+        available = root_available and component_available
+    elif explicit_contract:
+        # 预报与官方预警可在当前天气失败时独立存活。
+        available = component_available
+    else:
+        available = root_available and component_available
+
+    return {
+        "available": available,
+        "stale": component_stale,
+        "usable": available and not component_stale,
+        "explicit": explicit_contract,
+        "fetched_at": state.get("fetched_at"),
+        "expires_at": state.get("expires_at"),
+    }
 
 
 def snapshot_display_time(value):
@@ -349,6 +442,7 @@ def persist_snapshot(
     forecast_meta=None,
     warning_status=None,
     source_timing=None,
+    current_available=None,
     commit=True,
 ):
     """在一个事务中保存完整快照，所有消费者共享同一 snapshot_id。"""
@@ -379,7 +473,11 @@ def persist_snapshot(
         location_code=location["code"],
         fetched_at=fetched_at,
         expires_at=expires_at,
-        available=_weather_available(current),
+        available=(
+            _weather_available(current)
+            if current_available is None
+            else current_available is True
+        ),
         current_json=json.dumps(current, ensure_ascii=False),
         forecast_json=json.dumps(forecast, ensure_ascii=False),
         warnings_json=json.dumps(warnings, ensure_ascii=False),
@@ -393,6 +491,7 @@ def persist_snapshot(
                 forecast_meta,
                 warning_status,
                 source_timing,
+                current_available,
             ),
             ensure_ascii=False,
         ),
@@ -681,6 +780,7 @@ def refresh_snapshot_from_cycle(
     commit=True,
 ):
     """完成一次 canonical 同步周期的预报/预警收集并落库。"""
+    current_available = None
     forecast = []
     forecast_meta = {}
     warnings = []
@@ -758,10 +858,47 @@ def refresh_snapshot_from_cycle(
             today_max=current.get("temperature_max"),
         )
 
+    source_timing = dict(cycle_source_timing)
     if not _weather_available(current):
         existing = latest_snapshot_record()
-        if existing is not None and existing.available:
-            return existing
+        independent_update = bool(forecast) or warning_status.get("available") is True
+        if existing is not None:
+            stored_current = safe_json_loads(existing.current_json, {})
+            if _weather_available(stored_current):
+                # 保留旧实况仅供溯源；current_available=False 会阻止任何消费者使用它。
+                current = stored_current
+            stored_status = safe_json_loads(existing.source_status_json, {})
+            stored_status = stored_status if isinstance(stored_status, dict) else {}
+            stored_current_status = (
+                stored_status.get("current")
+                or stored_status.get("current_weather")
+                or stored_status.get("weather")
+                or {}
+            )
+            if isinstance(stored_current_status, dict):
+                source_timing.setdefault(
+                    "current",
+                    {
+                        key: stored_current_status.get(key)
+                        for key in ("fetched_at", "expires_at")
+                        if stored_current_status.get(key) is not None
+                    },
+                )
+            if not independent_update:
+                return existing
+        current_available = False
+
+    if "current" not in source_timing and (current_fetched_at or fetched_at):
+        source_time = ensure_utc_aware(current_fetched_at or fetched_at)
+        source_timing["current"] = {
+            "fetched_at": source_time,
+            "expires_at": source_time + timedelta(seconds=SNAPSHOT_TTL_SECONDS),
+        }
+    if forecast and "forecast" not in source_timing:
+        source_timing["forecast"] = forecast_meta
+    if warning_status.get("available") is True and "warnings" not in source_timing:
+        source_timing["warnings"] = warning_status
+
     return persist_snapshot(
         current,
         forecast,
@@ -769,19 +906,8 @@ def refresh_snapshot_from_cycle(
         fetched_at=fetched_at,
         forecast_meta=forecast_meta,
         warning_status=warning_status,
-        source_timing=cycle_source_timing or {
-            "current": {
-                "fetched_at": (current_fetched_at or fetched_at),
-                "expires_at": (
-                    ensure_utc_aware(current_fetched_at or fetched_at)
-                    + timedelta(seconds=SNAPSHOT_TTL_SECONDS)
-                    if (current_fetched_at or fetched_at) is not None
-                    else None
-                ),
-            },
-            "forecast": forecast_meta,
-            "warnings": warning_status,
-        },
+        source_timing=source_timing,
+        current_available=current_available,
         commit=commit,
     )
 

--- a/services/miniprogram_service.py
+++ b/services/miniprogram_service.py
@@ -24,7 +24,13 @@ from core.db_models import (
     WeatherCache,
 )
 from core.extensions import db
-from core.time_utils import ensure_utc_aware, today_local, utc_to_local_date, utcnow
+from core.time_utils import (
+    ensure_utc_aware,
+    today_local,
+    utc_to_local_date,
+    utc_to_local_datetime,
+    utcnow,
+)
 from core.weather import get_consecutive_hot_days, get_qweather_forecast_with_cache
 from services.qweather_auth import is_qweather_configured
 from services.miniprogram_auth import current_privacy_version
@@ -196,6 +202,91 @@ def _source_datetime(value):
         return ensure_utc_aware(datetime.fromisoformat(str(value)))
     except (TypeError, ValueError, OverflowError):
         return None
+
+
+def snapshot_display_time(value):
+    """把快照 UTC 时间转换为都昌页面使用的本地时间文字。"""
+    parsed = _source_datetime(value)
+    if parsed is None:
+        return None
+    return utc_to_local_datetime(parsed).strftime("%Y-%m-%d %H:%M")
+
+
+def _component_state(
+    source_status,
+    name,
+    *,
+    now,
+    fallback_expires_at,
+    fallback_available,
+):
+    """在读取时计算单个来源的新鲜度，旧快照继续回退到总过期时间。"""
+    source = source_status if isinstance(source_status, dict) else {}
+    aliases = {"current": ("current", "weather")}
+    raw = {}
+    for key in aliases.get(name, (name,)):
+        candidate = source.get(key)
+        if isinstance(candidate, dict):
+            raw = dict(candidate)
+            break
+    expires_at = _source_datetime(raw.get("expires_at")) or fallback_expires_at
+    fetched_at = _source_datetime(raw.get("fetched_at"))
+    stale = expires_at is None or now > expires_at
+    available = bool(raw.get("available", fallback_available))
+    state = {
+        **raw,
+        "available": available,
+        "stale": stale,
+    }
+    if fetched_at is not None:
+        state["fetched_at"] = fetched_at.isoformat()
+    if expires_at is not None:
+        state["expires_at"] = expires_at.isoformat()
+    return state
+
+
+def _payload_source_status(record, current, forecast, warnings, *, now, expires_at):
+    """补齐各来源状态；总 stale 保留兼容，页面按组件状态决定是否展示。"""
+    stored = safe_json_loads(record.source_status_json, {})
+    stored = dict(stored) if isinstance(stored, dict) else {}
+    current_state = _component_state(
+        stored,
+        "current",
+        now=now,
+        fallback_expires_at=expires_at,
+        fallback_available=bool(record.available) and _weather_available(current),
+    )
+    forecast_state = _component_state(
+        stored,
+        "forecast",
+        now=now,
+        fallback_expires_at=expires_at,
+        fallback_available=bool(forecast),
+    )
+    warnings_state = _component_state(
+        stored,
+        "warnings",
+        now=now,
+        fallback_expires_at=expires_at,
+        fallback_available=isinstance(warnings, list),
+    )
+    risk_stale = current_state["stale"] or not current_state["available"]
+    risk_state = {
+        "available": not risk_stale and public_risk_weather_is_ready(current),
+        "stale": risk_stale,
+        "depends_on": ["current"],
+        "fetched_at": current_state.get("fetched_at"),
+        "expires_at": current_state.get("expires_at"),
+    }
+    # weather 是旧客户端使用的键，current 是新合同的直观别名。
+    stored.update({
+        "weather": dict(current_state),
+        "current": dict(current_state),
+        "forecast": forecast_state,
+        "warnings": warnings_state,
+        "risk": risk_state,
+    })
+    return stored
 
 
 def _normalize_source_timing(
@@ -431,6 +522,10 @@ def snapshot_payload(record=None, *, now=None) -> dict:
             "ttl_seconds": SNAPSHOT_TTL_SECONDS,
             "available": False,
             "stale": True,
+            "current_stale": True,
+            "forecast_stale": True,
+            "warnings_stale": True,
+            "risk_stale": True,
             "current": {"is_mock": True},
             "forecast": [],
             "warnings": [],
@@ -442,18 +537,41 @@ def snapshot_payload(record=None, *, now=None) -> dict:
                 "status": "missing",
                 "refresh_interval_seconds": SNAPSHOT_TTL_SECONDS,
                 "canonical_location_only": True,
+                "current": {"available": False, "stale": True},
+                "weather": {"available": False, "stale": True},
+                "forecast": {"available": False, "stale": True},
+                "warnings": {"available": False, "stale": True},
+                "risk": {
+                    "available": False,
+                    "stale": True,
+                    "depends_on": ["current"],
+                },
             },
             "required_privacy_consent_version": current_privacy_version(),
         }
     expires_at = ensure_utc_aware(record.expires_at)
     current = safe_json_loads(record.current_json, {})
+    forecast = safe_json_loads(record.forecast_json, [])
     warnings = safe_json_loads(record.warnings_json, [])
     stale = current_time > expires_at
+    source_status = _payload_source_status(
+        record,
+        current,
+        forecast,
+        warnings,
+        now=current_time,
+        expires_at=expires_at,
+    )
+    current_stale = bool(source_status["current"]["stale"])
+    forecast_stale = bool(source_status["forecast"]["stale"])
+    warnings_stale = bool(source_status["warnings"]["stale"])
+    risk_stale = bool(source_status["risk"]["stale"])
     public_context = _persisted_public_context(
         record,
         current,
-        warnings,
-        available=bool(record.available) and not stale,
+        # 过期预警不能继续参与家庭提醒话术，当前天气风险仍可独立使用。
+        [] if warnings_stale else warnings,
+        available=bool(record.available) and not risk_stale,
         date_value=current_time,
     )
     return {
@@ -468,13 +586,17 @@ def snapshot_payload(record=None, *, now=None) -> dict:
         "ttl_seconds": SNAPSHOT_TTL_SECONDS,
         "available": bool(record.available),
         "stale": stale,
+        "current_stale": current_stale,
+        "forecast_stale": forecast_stale,
+        "warnings_stale": warnings_stale,
+        "risk_stale": risk_stale,
         "current": current,
-        "forecast": safe_json_loads(record.forecast_json, []),
+        "forecast": forecast,
         "warnings": warnings,
         "risk": public_context["risk"],
         "actions": public_context["actions"],
         "family_reminder": public_context["family_reminder"],
-        "source_status": safe_json_loads(record.source_status_json, {}),
+        "source_status": source_status,
         "required_privacy_consent_version": current_privacy_version(),
     }
 

--- a/services/miniprogram_service.py
+++ b/services/miniprogram_service.py
@@ -567,11 +567,16 @@ def snapshot_payload(record=None, *, now=None) -> dict:
     forecast_stale = bool(source_status["forecast"]["stale"])
     warnings_stale = bool(source_status["warnings"]["stale"])
     risk_stale = bool(source_status["risk"]["stale"])
+    warnings_usable = (
+        not warnings_stale
+        and source_status["warnings"]["available"] is True
+    )
+    public_warnings = warnings if warnings_usable else []
     public_context = _persisted_public_context(
         record,
         current,
         # 过期预警不能继续参与家庭提醒话术，当前天气风险仍可独立使用。
-        [] if warnings_stale or not source_status["warnings"]["available"] else warnings,
+        public_warnings,
         available=bool(record.available) and not risk_stale,
         date_value=current_time,
     )
@@ -593,7 +598,7 @@ def snapshot_payload(record=None, *, now=None) -> dict:
         "risk_stale": risk_stale,
         "current": current,
         "forecast": forecast,
-        "warnings": warnings,
+        "warnings": public_warnings,
         "risk": public_context["risk"],
         "actions": public_context["actions"],
         "family_reminder": public_context["family_reminder"],

--- a/services/pipelines/sync_weather_cache.py
+++ b/services/pipelines/sync_weather_cache.py
@@ -40,6 +40,7 @@ from services.miniprogram_service import (  # noqa: E402
     latest_snapshot_record,
     qweather_runtime_configured,
     refresh_snapshot_from_cycle,
+    snapshot_component_status,
     snapshot_payload,
 )
 from services.weather_service import WeatherService  # noqa: E402
@@ -486,7 +487,7 @@ def _resolve_locations(locations):
 
 
 def _trusted_complete_snapshot(payload):
-    """只有三项官方来源都成功时，本周期才可触发下游预警派发。"""
+    """保留三项官方来源完整度指标，供观测降级状态。"""
     source_status = (payload or {}).get('source_status') or {}
     weather_status = source_status.get('weather') or {}
     forecast_status = source_status.get('forecast') or {}
@@ -506,15 +507,39 @@ def _trusted_complete_snapshot(payload):
     )
 
 
+def _dispatch_ready_snapshot(payload, *, updated, previous_snapshot_id):
+    """当前天气或官方预警任一形成新鲜组件时即可触发派发。"""
+    if (
+        not isinstance(payload, dict)
+        or not payload.get("snapshot_id")
+        or payload.get("snapshot_id") == previous_snapshot_id
+    ):
+        return False
+    current_status = snapshot_component_status(payload, "current")
+    warnings_status = snapshot_component_status(payload, "warnings")
+    current = payload.get("current")
+    current_ready = bool(
+        updated == 1
+        and current_status["usable"]
+        and isinstance(current, dict)
+        and not current.get("is_mock")
+    )
+    warnings_ready = bool(
+        warnings_status["explicit"] and warnings_status["usable"]
+    )
+    return current_ready or warnings_ready
+
+
 def _trusted_cycle_current(payload, *, fetched_at, previous_snapshot_id):
     """只返回本周期补齐且可供网页风险使用的同源实况。"""
     if (
         not isinstance(payload, dict)
         or not payload.get('snapshot_id')
         or payload.get('snapshot_id') == previous_snapshot_id
-        or not payload.get('available')
-        or payload.get('stale', True)
     ):
+        return None
+    current_status = snapshot_component_status(payload, 'current')
+    if not current_status['usable']:
         return None
     current = payload.get('current')
     weather_status = (payload.get('source_status') or {}).get('weather') or {}
@@ -660,14 +685,10 @@ def _sync_weather_cache_locked(locations=None, update_daily=True, include_nowcas
                 CANONICAL_LOCATION_NAME,
                 cycle_current,
             )
-        snapshot_ready = bool(
-            updated == 1
-            and persisted.get('snapshot_id')
-            and persisted.get('snapshot_id') != previous_snapshot_id
-            and persisted.get('available')
-            and not persisted.get('stale', True)
-            and not (persisted.get('current') or {}).get('is_mock', False)
-            and trusted_complete_cycle
+        snapshot_ready = _dispatch_ready_snapshot(
+            persisted,
+            updated=updated,
+            previous_snapshot_id=previous_snapshot_id,
         )
         return {
             'locations': 1,

--- a/services/public_risk_service.py
+++ b/services/public_risk_service.py
@@ -105,15 +105,22 @@ def build_public_family_reminder(
     date_value=None,
 ) -> dict:
     """只使用已持久化天气与风险，稳定生成当日家庭提醒。"""
-    weather = current if isinstance(current, dict) and available else {}
-    warning_rows = warnings if isinstance(warnings, list) and available else []
+    weather = current if isinstance(current, dict) and current and available is True else {}
+    # 官方预警有独立来源状态，当前天气不可用时仍可生成 warning-only 提醒。
+    warning_rows = warnings if isinstance(warnings, list) else []
     risk_payload = risk if isinstance(risk, dict) else {}
-    return select_action_reminder(
+    reminder = select_action_reminder(
         date_value=date_value,
-        risk_level=(risk_payload.get("level") if available else "low"),
+        risk_level=(risk_payload.get("level") if available is True else "low"),
         weather_tags=infer_weather_tags(weather, warning_rows),
         audience="family_group",
     )
+    dependencies = []
+    if weather:
+        dependencies.append("current")
+    if warning_rows:
+        dependencies.append("warnings")
+    return {**reminder, "depends_on": dependencies}
 
 
 def build_public_risk_context(

--- a/services/public_service.py
+++ b/services/public_service.py
@@ -58,7 +58,7 @@ from services.community_daily_service import (
     refresh_community_daily_best_effort as _refresh_community_daily_best_effort,
 )
 from services.heat_action_service import HeatActionService
-from services.miniprogram_service import get_bootstrap_payload
+from services.miniprogram_service import get_bootstrap_payload, snapshot_display_time
 from services.cross_platform_identity import (
     AccountLinkError,
     create_account_link_challenge,
@@ -1750,6 +1750,12 @@ def render_public_risk_page(location):
         actions=snapshot.get('actions') or [],
         risk_reasons=risk_reasons,
         family_reminder=snapshot.get('family_reminder'),
+        weather_snapshot_id=snapshot.get('snapshot_id'),
+        weather_snapshot_fetched_at=snapshot.get('fetched_at'),
+        weather_snapshot_display_time=snapshot_display_time(snapshot.get('fetched_at')),
+        weather_snapshot_expires_at=snapshot.get('expires_at'),
+        weather_risk_stale=snapshot.get('risk_stale', True),
+        weather_source_status=snapshot.get('source_status') or {},
     )
 
 

--- a/services/public_service.py
+++ b/services/public_service.py
@@ -19,7 +19,7 @@ from flask import (
     url_for,
 )
 from flask_login import current_user, login_user, logout_user
-from sqlalchemy import or_
+from sqlalchemy import false, or_
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from werkzeug.exceptions import MethodNotAllowed, NotFound
 from werkzeug.routing import RequestRedirect
@@ -27,6 +27,7 @@ from werkzeug.security import check_password_hash, generate_password_hash
 
 from core.constants import GUEST_ID_PREFIX
 from core.extensions import db
+from core.location_resolution import get_user_location_options, resolve_user_location
 from core.security import hash_identifier, hash_pair_token, hash_short_code, rate_limit_key, verify_pair_token
 from core.time_utils import today_local, utcnow, ensure_utc_aware
 from core.weather import (
@@ -1632,20 +1633,62 @@ def render_cooling_resources_page(
 ):
     open_only_flag = parse_bool(open_only, default=False)
     location_query = sanitize_input(request.args.get('location'), max_length=100)
-    weather_location = normalize_location_name(community or location_query or None)
+    raw_location = community or location_query or ''
+    all_resources = CoolingResource.query.filter_by(is_active=True).all()
+    communities = sorted({item.community_code for item in all_resources if item.community_code})
+    resource_types = sorted({item.resource_type for item in all_resources if item.resource_type})
+    location_resolution = resolve_user_location(
+        raw_location,
+        extra_names=communities,
+    )
+    location_error = location_resolution.error if not location_resolution.valid else None
+    weather_location = (
+        location_resolution.value
+        if location_resolution.valid
+        else location_resolution.raw
+    )
     cooling_weather = {}
-    try:
-        cooling_weather, _ = get_weather_with_cache(weather_location)
-    except Exception as exc:
-        logger.warning("避暑资源页天气读取失败，已隐藏室外温度计: %s", exc)
-        cooling_weather = {}
+    snapshot_meta = {}
+    if not location_error:
+        snapshot = get_bootstrap_payload()
+        snapshot_id = snapshot.get('snapshot_id')
+        if snapshot_id:
+            current_stale = snapshot.get('current_stale', snapshot.get('stale', True))
+            risk_stale = snapshot.get('risk_stale', snapshot.get('stale', True))
+            current_snapshot = snapshot.get('current')
+            if (
+                current_stale is False
+                and risk_stale is False
+                and is_qweather_online_weather(current_snapshot)
+            ):
+                cooling_weather = current_snapshot
+            snapshot_location = snapshot.get('location') or {}
+            if isinstance(snapshot_location, dict) and snapshot_location.get('name'):
+                weather_location = str(snapshot_location['name'])
+            snapshot_meta = {
+                'id_short': str(snapshot_id)[:8],
+                'fetched_at': snapshot.get('fetched_at'),
+            }
+        else:
+            # 本地测试和首次启动尚无持久快照时兼容旧缓存；线上已有快照后不混读。
+            try:
+                cooling_weather, _ = get_weather_with_cache(weather_location)
+            except Exception as exc:
+                logger.warning("避暑资源页天气读取失败，已隐藏室外温度计: %s", exc)
+                cooling_weather = {}
     outdoor_temp = None
-    if cooling_weather and not cooling_weather.get('is_mock'):
-        outdoor_temp = cooling_weather.get('temperature')
+    if is_qweather_online_weather(cooling_weather):
+        parsed_temperature = parse_float(cooling_weather.get('temperature'))
+        if parsed_temperature is not None and math.isfinite(parsed_temperature):
+            outdoor_temp = parsed_temperature
 
     query = CoolingResource.query.filter_by(is_active=True)
-    if community:
-        query = query.filter(CoolingResource.community_code == community)
+    if location_error:
+        query = query.filter(false())
+    elif raw_location and location_resolution.value not in {'都昌', '都昌县'}:
+        query = query.filter(
+            CoolingResource.community_code == location_resolution.value
+        )
     if resource_type:
         query = query.filter(CoolingResource.resource_type == resource_type)
     if has_ac_raw not in (None, ''):
@@ -1670,14 +1713,21 @@ def render_cooling_resources_page(
         CoolingResource.community_code,
         CoolingResource.name
     ).all()
-    all_resources = CoolingResource.query.filter_by(is_active=True).all()
+    location_filter_active = bool(
+        raw_location and location_resolution.value not in {'都昌', '都昌县'}
+    )
+    filters_active = bool(
+        location_filter_active
+        or resource_type
+        or has_ac_raw not in (None, '')
+        or is_accessible_raw not in (None, '')
+        or open_only_flag
+    )
     candidate_preview = (
         list(cooling_candidates or [])
-        if not all_resources
+        if not all_resources and not filters_active and not location_error
         else []
     )
-    communities = sorted({item.community_code for item in all_resources if item.community_code})
-    resource_types = sorted({item.resource_type for item in all_resources if item.resource_type})
     grouped = {}
     map_points = []
     for item in resources:
@@ -1694,7 +1744,7 @@ def render_cooling_resources_page(
         total=len(resources),
         communities=communities,
         resource_types=resource_types,
-        selected_community=community or '',
+        selected_community=location_resolution.raw if raw_location else '',
         selected_resource_type=resource_type or '',
         selected_has_ac=has_ac_raw if has_ac_raw is not None else '',
         selected_is_accessible=is_accessible_raw if is_accessible_raw is not None else '',
@@ -1707,7 +1757,12 @@ def render_cooling_resources_page(
         cooling_weather_location=weather_location,
         outdoor_temp=outdoor_temp,
         cooling_candidates=candidate_preview,
+        cooling_location_error=location_error,
+        cooling_location_options=get_user_location_options(extra_names=communities),
+        cooling_snapshot_meta=snapshot_meta,
     ))
+    if location_error:
+        response.status_code = 422
     if not map_points:
         # 没有可计算距离的正式点位时，浏览器不应提供定位能力。
         response.headers['Permissions-Policy'] = (

--- a/services/public_service.py
+++ b/services/public_service.py
@@ -59,7 +59,11 @@ from services.community_daily_service import (
     refresh_community_daily_best_effort as _refresh_community_daily_best_effort,
 )
 from services.heat_action_service import HeatActionService
-from services.miniprogram_service import get_bootstrap_payload, snapshot_display_time
+from services.miniprogram_service import (
+    get_bootstrap_payload,
+    snapshot_component_status,
+    snapshot_display_time,
+)
 from services.cross_platform_identity import (
     AccountLinkError,
     create_account_link_challenge,
@@ -578,10 +582,10 @@ def _build_action_context(pair, status_date):
     stored_heat_result = calculation.get('heat_result')
     stored_risk_reasons = calculation.get('risk_reasons')
     current = snapshot.get('current') if isinstance(snapshot.get('current'), dict) else None
+    risk_status = snapshot_component_status(snapshot, 'risk')
     risk_available = (
         bool(snapshot.get('snapshot_id'))
-        and snapshot.get('available') is True
-        and snapshot.get('stale') is False
+        and risk_status['usable']
         and is_qweather_online_weather(current)
         and risk.get('available') is True
         and risk.get('score') is not None
@@ -1471,6 +1475,11 @@ def handle_login(next_url):
 
 def handle_register():
     communities = Community.query.all()
+    community_names = [
+        community.name
+        for community in communities
+        if str(community.name or '').strip()
+    ]
     form_data = {
         'username': '',
         'email': '',
@@ -1529,10 +1538,14 @@ def handle_register():
         if not valid:
             form_errors['gender'] = gender_result
 
-        community = sanitize_input(
+        community_resolution = resolve_user_location(
             request.form.get('community'),
-            max_length=100,
+            extra_names=community_names,
+            default_if_blank=False,
         )
+        community = community_resolution.value
+        if not community_resolution.valid:
+            form_errors['community'] = community_resolution.error
 
         if form_errors:
             return render_template(
@@ -1547,7 +1560,8 @@ def handle_register():
             email=email,
             age=age,
             gender=gender,
-            community=community
+            community=community,
+            last_login=utcnow(),
         )
         user.set_password(password)
 
@@ -1583,12 +1597,21 @@ def handle_register():
                 form_data=form_data,
                 form_errors=form_errors,
             ), 422
+        except SQLAlchemyError:
+            db.session.rollback()
+            logger.exception("注册事务提交失败")
+            form_errors['account'] = '注册暂时无法完成，请稍后重试。'
+            return render_template(
+                'register.html',
+                communities=communities,
+                form_data=form_data,
+                form_errors=form_errors,
+            ), 503
 
         logger.info("新用户注册: user_id=%s", user.id)
+        # 只有账号事务落库后，才替换浏览器里的游客或旧身份状态。
         _clear_identity_scoped_session()
         login_user(user, remember=False)
-        user.last_login = utcnow()
-        db.session.commit()
         flash('注册成功，已登录。现在可以添加需要照护的家人。', 'success')
         if (
             current_app.config.get('WECHAT_FORMAL_RUNTIME')
@@ -1709,12 +1732,10 @@ def render_cooling_resources_page(
         snapshot = get_bootstrap_payload()
         snapshot_id = snapshot.get('snapshot_id')
         if snapshot_id:
-            current_stale = snapshot.get('current_stale', snapshot.get('stale', True))
-            risk_stale = snapshot.get('risk_stale', snapshot.get('stale', True))
+            current_status = snapshot_component_status(snapshot, 'current')
             current_snapshot = snapshot.get('current')
             if (
-                current_stale is False
-                and risk_stale is False
+                current_status['usable']
                 and is_qweather_online_weather(current_snapshot)
             ):
                 cooling_weather = current_snapshot
@@ -1724,6 +1745,7 @@ def render_cooling_resources_page(
             snapshot_meta = {
                 'id_short': str(snapshot_id)[:8],
                 'fetched_at': snapshot.get('fetched_at'),
+                'display_time': snapshot_display_time(snapshot.get('fetched_at')),
             }
         else:
             # 本地测试和首次启动尚无持久快照时兼容旧缓存；线上已有快照后不混读。
@@ -1838,11 +1860,13 @@ def render_public_risk_page(location):
     )
     location_name = str(snapshot_location.get('name') or fallback_location)
     risk = snapshot.get('risk') or {}
+    risk_status = snapshot_component_status(snapshot, 'risk')
     calculation = risk.get('calculation') if isinstance(risk.get('calculation'), dict) else {}
     stored_heat_result = calculation.get('heat_result')
     stored_risk_reasons = calculation.get('risk_reasons')
     risk_ready = (
-        risk.get('available') is True
+        risk_status['usable']
+        and risk.get('available') is True
         and risk.get('score') is not None
         and isinstance(stored_heat_result, dict)
         and isinstance(stored_risk_reasons, list)

--- a/services/public_service.py
+++ b/services/public_service.py
@@ -1279,6 +1279,10 @@ def handle_account_link_code():
 
 def handle_login(next_url):
     safe_next = _safe_next_url(next_url)
+    login_form = {
+        'username': '',
+        'remember': False,
+    }
     if request.method == 'POST':
         # 输入验证
         username = request.form.get('username', '').strip()
@@ -1289,16 +1293,28 @@ def handle_login(next_url):
             normalized_phone = None
         password = request.form.get('password', '')
         remember_flag = request.form.get('remember') in ('1', 'on', 'true', 'yes')
+        login_form = {
+            'username': username,
+            'remember': remember_flag,
+        }
 
         # 基本验证
         if not username or not password:
-            flash('请输入用户名或已验证手机号和密码', 'error')
-            return render_template('login.html', next=safe_next)
+            flash('请输入用户名和密码', 'error')
+            return render_template(
+                'login.html',
+                next=safe_next,
+                login_form=login_form,
+            )
 
         # 限制长度防止攻击
         if len(username) > 50 or len(password) > 100:
             flash('输入内容过长', 'error')
-            return render_template('login.html', next=safe_next)
+            return render_template(
+                'login.html',
+                next=safe_next,
+                login_form=login_form,
+            )
 
         if normalized_phone:
             user = User.query.filter(
@@ -1342,7 +1358,11 @@ def handle_login(next_url):
                         remaining,
                     )
                     flash(f'登录失败次数过多，请 {remaining // 60 + 1} 分钟后再试', 'error')
-                    return render_template('login.html', next=safe_next)
+                    return render_template(
+                        'login.html',
+                        next=safe_next,
+                        login_form=login_form,
+                    )
             except Exception:
                 logger.warning("Redis 锁定检查失败，回退数据库兜底", exc_info=True)
                 redis_client = None
@@ -1362,7 +1382,11 @@ def handle_login(next_url):
                         db_remaining,
                     )
                     flash(f'登录失败次数过多，请 {db_remaining // 60 + 1} 分钟后再试', 'error')
-                    return render_template('login.html', next=safe_next)
+                    return render_template(
+                        'login.html',
+                        next=safe_next,
+                        login_form=login_form,
+                    )
             except Exception:
                 logger.warning("数据库锁定检查失败", exc_info=True)
 
@@ -1434,98 +1458,114 @@ def handle_login(next_url):
                 logger.warning("数据库递增失败计数失败", exc_info=True)
 
         logger.warning("登录失败: identifier_len=%s", len(username))
-        flash('用户名、已验证手机号或密码错误', 'error')
+        # 页面只承诺用户名登录；后端继续兼容已经完成验证的历史手机号。
+        flash('用户名或密码错误', 'error')
 
-    return render_template('login.html', next=safe_next)
+    return render_template(
+        'login.html',
+        next=safe_next,
+        login_form=login_form,
+    )
 
 
 def handle_register():
+    communities = Community.query.all()
+    form_data = {
+        'username': '',
+        'email': '',
+        'age': '',
+        'gender': '',
+        'community': '',
+    }
+    form_errors = {}
     if request.method == 'POST':
-        # 验证用户名
-        valid, result = validate_username(request.form.get('username'))
+        form_data = {
+            'username': str(request.form.get('username') or '').strip()[:25],
+            'email': str(request.form.get('email') or '').strip()[:120],
+            'age': str(request.form.get('age') or '').strip()[:3],
+            'gender': str(request.form.get('gender') or '').strip()[:10],
+            'community': str(request.form.get('community') or '').strip()[:100],
+        }
+
+        valid, username_result = validate_username(request.form.get('username'))
+        username = username_result if valid else None
         if not valid:
-            flash(result, 'error')
-            return redirect(url_for('public.register'))
-        username = result
-        if is_reserved_internal_username(username):
-            flash('该用户名属于系统保留命名空间，请换一个用户名。', 'error')
-            return redirect(url_for('public.register'))
-        try:
-            username_as_phone = normalize_phone(username)
-        except ValueError:
-            username_as_phone = None
-        if username_as_phone:
-            flash('用户名不能使用手机号格式，请换一个用户名。', 'error')
-            return redirect(url_for('public.register'))
+            form_errors['username'] = username_result
+        elif is_reserved_internal_username(username):
+            form_errors['username'] = '该用户名属于系统保留命名空间，请换一个用户名。'
+        else:
+            try:
+                username_as_phone = normalize_phone(username)
+            except ValueError:
+                username_as_phone = None
+            if username_as_phone:
+                form_errors['username'] = '用户名不能使用手机号格式，请换一个用户名。'
 
-        # 验证密码
-        valid, result = validate_password(request.form.get('password'))
+        raw_password = request.form.get('password', '')
+        valid, password_result = validate_password(raw_password)
+        password = password_result if valid else None
         if not valid:
-            flash(result, 'error')
-            return redirect(url_for('public.register'))
-        password = result
+            form_errors['password'] = password_result
 
-        # 验证邮箱
-        valid, result = validate_email(request.form.get('email'))
+        confirm_password = request.form.get('confirm_password', '')
+        if not confirm_password:
+            form_errors['confirm_password'] = '请再次输入密码'
+        elif confirm_password != raw_password:
+            form_errors['confirm_password'] = '两次输入的密码不一致'
+
+        valid, email_result = validate_email(request.form.get('email'))
+        email = email_result if valid else None
         if not valid:
-            flash(result, 'error')
-            return redirect(url_for('public.register'))
-        email = result
+            form_errors['email'] = email_result
 
-        # 手机号只保存为待验证标识；接入短信校验前不能用于登录。
-        try:
-            phone_normalized = normalize_phone(request.form.get('phone'))
-        except ValueError as exc:
-            flash(str(exc), 'error')
-            return redirect(url_for('public.register'))
-
-        # 验证年龄
-        valid, result = validate_age(request.form.get('age'))
+        valid, age_result = validate_age(request.form.get('age'))
+        age = age_result if valid else None
         if not valid:
-            flash(result, 'error')
-            return redirect(url_for('public.register'))
-        age = result
+            form_errors['age'] = age_result
 
-        # 验证性别
-        valid, result = validate_gender(request.form.get('gender'))
+        valid, gender_result = validate_gender(request.form.get('gender'))
+        gender = gender_result if valid else None
         if not valid:
-            flash(result, 'error')
-            return redirect(url_for('public.register'))
-        gender = result
+            form_errors['gender'] = gender_result
 
-        # 社区信息
-        community = sanitize_input(request.form.get('community'), max_length=100)
+        community = sanitize_input(
+            request.form.get('community'),
+            max_length=100,
+        )
+
+        if form_errors:
+            return render_template(
+                'register.html',
+                communities=communities,
+                form_data=form_data,
+                form_errors=form_errors,
+            ), 422
 
         user = User(
             username=username,
             email=email,
-            phone_normalized=phone_normalized,
             age=age,
             gender=gender,
             community=community
         )
         user.set_password(password)
 
-        # 所有占用结果使用相同提示与跳转，减少匿名访客据此枚举手机号或邮箱。
-        processed_message = (
-            '注册申请已处理，请尝试登录。若无法登录，请更换用户名或联系管理员。'
-        )
         username_taken = User.query.filter(
             db.func.lower(User.username) == _normalize_login_identifier(username)
         ).first() is not None
         email_taken = bool(
             email and User.query.filter_by(email=email).first() is not None
         )
-        if any(
-            (
-                username_taken,
-                email_taken,
+        if username_taken or email_taken:
+            form_errors['account'] = (
+                '这些账号信息暂时无法使用，请更换用户名或邮箱后重试。'
             )
-        ):
-            flash(processed_message, 'success')
-            return redirect(
-                url_for('public.login', next=url_for('public.account_link'))
-            )
+            return render_template(
+                'register.html',
+                communities=communities,
+                form_data=form_data,
+                form_errors=form_errors,
+            ), 422
 
         try:
             db.session.add(user)
@@ -1533,19 +1573,35 @@ def handle_register():
         except IntegrityError:
             # 用户名与邮箱唯一索引负责处理并发注册竞争。
             db.session.rollback()
-            flash(processed_message, 'success')
-            return redirect(
-                url_for('public.login', next=url_for('public.account_link'))
+            form_errors['account'] = (
+                '这些账号信息暂时无法使用，请更换用户名或邮箱后重试。'
             )
+            return render_template(
+                'register.html',
+                communities=communities,
+                form_data=form_data,
+                form_errors=form_errors,
+            ), 422
 
         logger.info("新用户注册: user_id=%s", user.id)
-        flash(processed_message, 'success')
-        return redirect(
-            url_for('public.login', next=url_for('public.account_link'))
-        )
+        _clear_identity_scoped_session()
+        login_user(user, remember=False)
+        user.last_login = utcnow()
+        db.session.commit()
+        flash('注册成功，已登录。现在可以添加需要照护的家人。', 'success')
+        if (
+            current_app.config.get('WECHAT_FORMAL_RUNTIME')
+            and not current_app.config.get('WEB_PRIVATE_FEATURES_ENABLED')
+        ):
+            return redirect(url_for('public.account_link'))
+        return redirect(url_for('user.pair_management', welcome=1))
 
-    communities = Community.query.all()
-    return render_template('register.html', communities=communities)
+    return render_template(
+        'register.html',
+        communities=communities,
+        form_data=form_data,
+        form_errors=form_errors,
+    )
 
 
 def _verified_cooling_map_point(resource):

--- a/services/push/dispatch.py
+++ b/services/push/dispatch.py
@@ -28,7 +28,11 @@ from core.time_utils import ensure_utc_aware, utcnow
 from core.usage import log_usage_event
 from core.weather import is_qweather_online_weather
 from services.miniprogram_auth import current_privacy_version
-from services.miniprogram_service import canonical_location, get_bootstrap_payload
+from services.miniprogram_service import (
+    canonical_location,
+    get_bootstrap_payload,
+    snapshot_component_status,
+)
 from services.push.locks import push_owner_lock
 from services.push.wxpusher import send as wxpusher_send
 
@@ -727,7 +731,7 @@ def _pair_allows_family_push(pair: Pair, profile_map: Dict[int, FamilyMemberProf
 
 
 def _load_dispatch_snapshot(now) -> Optional[Tuple[Dict[str, Any], Dict[str, str]]]:
-    """只接收新鲜、可用且属于都昌县的持久化快照。"""
+    """按当前天气与官方预警各自状态读取都昌县持久化快照。"""
     canonical = canonical_location()
     try:
         payload = get_bootstrap_payload(now=now)
@@ -738,12 +742,8 @@ def _load_dispatch_snapshot(now) -> Optional[Tuple[Dict[str, Any], Dict[str, str
     if not isinstance(payload, dict):
         logger.warning("小程序天气快照格式无效，本轮推送已关闭")
         return None
-    if (
-        not payload.get("snapshot_id")
-        or payload.get("available") is not True
-        or bool(payload.get("stale", True))
-    ):
-        logger.info("小程序天气快照缺失、不可用或已陈旧，本轮推送已关闭")
+    if not payload.get("snapshot_id"):
+        logger.info("小程序天气快照缺失，本轮推送已关闭")
         return None
 
     location = payload.get("location")
@@ -755,7 +755,18 @@ def _load_dispatch_snapshot(now) -> Optional[Tuple[Dict[str, Any], Dict[str, str
     if snapshot_name != canonical["name"] or snapshot_code != canonical["code"]:
         logger.warning("小程序天气快照不属于当前都昌县范围，本轮推送已关闭")
         return None
-    return payload, canonical
+    current_status = snapshot_component_status(payload, "current", now=now)
+    warnings_status = snapshot_component_status(payload, "warnings", now=now)
+    if not current_status["usable"] and not warnings_status["usable"]:
+        logger.info("当前天气与官方预警均不可用，本轮推送已关闭")
+        return None
+
+    sanitized = dict(payload)
+    if not current_status["usable"]:
+        sanitized["current"] = {}
+    if not warnings_status["usable"]:
+        sanitized["warnings"] = []
+    return sanitized, canonical
 
 
 def _render_push_content(

--- a/services/user/_common.py
+++ b/services/user/_common.py
@@ -290,5 +290,8 @@ def _normalize_code(value):
 def _require_roles(*roles):
     if getattr(current_user, 'role', None) in roles:
         return True
-    flash('权限不足', 'error')
+    if 'community' in roles:
+        flash('该页面仅限社区工作人员或管理员使用，请切换对应账号。', 'error')
+    else:
+        flash('当前账号没有此页面所需权限。', 'error')
     return False

--- a/services/user/caregiver_service.py
+++ b/services/user/caregiver_service.py
@@ -153,10 +153,12 @@ def _load_daily_risk_snapshot():
     snapshot_id = str(snapshot.get('snapshot_id') or '').strip()
     current = snapshot.get('current')
     risk = snapshot.get('risk')
+    from services.miniprogram_service import snapshot_component_status
+
+    risk_status = snapshot_component_status(snapshot, 'risk')
     if (
         not snapshot_id
-        or snapshot.get('available') is not True
-        or snapshot.get('stale') is not False
+        or not risk_status['usable']
         or not _heat_weather_available(current)
         or not isinstance(risk, dict)
         or risk.get('available') is not True

--- a/services/user/dashboard_service.py
+++ b/services/user/dashboard_service.py
@@ -52,6 +52,13 @@ def snapshot_display_time(value):
     return format_time(value)
 
 
+def snapshot_component_status(payload, component):
+    """延迟导入组件状态解析，保持 user 服务初始化无循环依赖。"""
+    from services.miniprogram_service import snapshot_component_status as load_status
+
+    return load_status(payload, component)
+
+
 def _clamp(value, lower=0.0, upper=1.0):
     return max(lower, min(upper, value))
 
@@ -270,9 +277,9 @@ def _dashboard_metric_cards(user_id):
     return [cards[key] for key in ('sbp', 'heart_rate', 'blood_sugar') if key in cards]
 
 
-def _dashboard_snapshot_forecast_days(snapshot, start_date):
+def _dashboard_snapshot_forecast_days(snapshot, start_date, *, usable):
     """把已落库的逐日天气风险直接转换成首页卡片。"""
-    if snapshot.get('forecast_stale'):
+    if not usable:
         return []
     forecast = snapshot.get('forecast')
     if not isinstance(forecast, list):
@@ -322,12 +329,16 @@ def user_dashboard(force_elder=False):
     snapshot_id = snapshot.get('snapshot_id')
     snapshot_mode = bool(snapshot_id)
     snapshot_location = snapshot.get('location') or {}
+    current_status = snapshot_component_status(snapshot, 'current')
+    risk_status = snapshot_component_status(snapshot, 'risk')
+    forecast_status = snapshot_component_status(snapshot, 'forecast')
+    warnings_status = snapshot_component_status(snapshot, 'warnings')
     weather_source_city = str(
         snapshot_location.get('name')
         or resolve_weather_city_label(user_location)
     )
     weather_data = snapshot.get('current') or {}
-    if not snapshot_mode or snapshot.get('current_stale'):
+    if not snapshot_mode or not current_status['usable']:
         weather_data = {}
     weather_is_mock = bool(weather_data.get('is_mock'))
     weather_available = _dashboard_weather_available(weather_data)
@@ -354,7 +365,7 @@ def user_dashboard(force_elder=False):
     stored_heat_result = calculation.get('heat_result') if isinstance(calculation, dict) else None
     snapshot_risk_ready = (
         snapshot_mode
-        and not snapshot.get('risk_stale')
+        and risk_status['usable']
         and risk.get('available') is True
         and isinstance(stored_heat_result, dict)
     )
@@ -370,7 +381,11 @@ def user_dashboard(force_elder=False):
         getattr(weather, 'temperature', None) if weather_available else None
     )
     dashboard_metric_cards = [] if is_guest else _dashboard_metric_cards(current_user.id)
-    forecast_days = _dashboard_snapshot_forecast_days(snapshot, today) if snapshot_mode else []
+    forecast_days = _dashboard_snapshot_forecast_days(
+        snapshot,
+        today,
+        usable=forecast_status['usable'],
+    ) if snapshot_mode else []
 
     # 获取最新风险评估
     if is_guest:
@@ -385,11 +400,9 @@ def user_dashboard(force_elder=False):
         assessment_explain = safe_json_loads(latest_assessment.explain, {})
 
     # 预警与温度、风险共用同一快照；来源未知、不可用或过期时不展示旧预警。
-    warning_state = (snapshot.get('source_status') or {}).get('warnings') or {}
     warnings_ready = (
         snapshot_mode
-        and not snapshot.get('warnings_stale')
-        and warning_state.get('available') is True
+        and warnings_status['usable']
     )
     alerts = [
         _dashboard_snapshot_alert_card(item, weather_source_city)

--- a/services/user/dashboard_service.py
+++ b/services/user/dashboard_service.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import math
-from datetime import timedelta
 from types import SimpleNamespace
 
 from flask import current_app, has_app_context, render_template, request
@@ -25,7 +24,6 @@ from core.db_models import (
     HealthRiskAssessment,
     MedicationReminder,
     Notification,
-    WeatherAlert,
 )
 from services.forecast_cards import build_forecast_cards
 from utils.parsers import safe_json_loads
@@ -139,6 +137,31 @@ def _dashboard_alert_card(alert):
         'alert_date_local': local_date.strftime('%Y-%m-%d') if local_date else '日期未标注',
         'location': location,
         'description': alert.description,
+        'is_high': is_high,
+    }
+
+
+def _dashboard_snapshot_alert_card(warning, location):
+    """将同一县级快照中的官方预警转换成首页卡片。"""
+    row = warning if isinstance(warning, dict) else {}
+    level_text = str(row.get('level') or row.get('severity') or '未分级').strip()
+    normalized_level = level_text.lower()
+    is_high = normalized_level in {'high', 'extreme', 'severe', 'moderate', 'red'} or any(
+        marker in level_text for marker in ('高', '严重', '红', '橙')
+    )
+    published_at = str(
+        row.get('start_time')
+        or row.get('issued_at')
+        or row.get('published_at')
+        or ''
+    ).strip()
+    date_text = published_at[:10] if len(published_at) >= 10 else '日期未标注'
+    return {
+        'alert_type': str(row.get('title') or row.get('type') or '天气预警').strip(),
+        'alert_level': level_text,
+        'alert_date_local': date_text,
+        'location': location or '都昌县',
+        'description': str(row.get('text') or row.get('instruction') or '').strip(),
         'is_high': is_high,
     }
 
@@ -295,7 +318,6 @@ def user_dashboard(force_elder=False):
     # 首页和公开风险、小程序共用同一份只读快照；缺少快照时统一安全降级。
     today = today_local()
     user_location = ensure_user_location_valid()
-    alert_locations = _dashboard_alert_locations(user_location)
     snapshot = get_bootstrap_payload()
     snapshot_id = snapshot.get('snapshot_id')
     snapshot_mode = bool(snapshot_id)
@@ -362,11 +384,17 @@ def user_dashboard(force_elder=False):
     if latest_assessment and getattr(latest_assessment, 'explain', None):
         assessment_explain = safe_json_loads(latest_assessment.explain, {})
 
-    # 获取天气预警（最近24小时）
-    alerts = WeatherAlert.query.filter(
-        WeatherAlert.alert_date >= utcnow() - timedelta(days=1),
-        WeatherAlert.location.in_(alert_locations)
-    ).order_by(WeatherAlert.alert_date.desc()).limit(5).all()
+    # 预警与温度、风险共用同一快照；来源未知、不可用或过期时不展示旧预警。
+    warning_state = (snapshot.get('source_status') or {}).get('warnings') or {}
+    warnings_ready = (
+        snapshot_mode
+        and not snapshot.get('warnings_stale')
+        and warning_state.get('available') is True
+    )
+    alerts = [
+        _dashboard_snapshot_alert_card(item, weather_source_city)
+        for item in (snapshot.get('warnings') or [])[:5]
+    ] if warnings_ready else []
 
     # 用药提醒（根据天气触发）
     reminders = []
@@ -451,7 +479,7 @@ def user_dashboard(force_elder=False):
             weather_source_status=snapshot.get('source_status') or {},
         )
 
-    alert_cards = [_dashboard_alert_card(alert) for alert in alerts]
+    alert_cards = alerts
 
     return render_template('user_dashboard.html',
                          weather=weather if weather_available else None,

--- a/services/user/dashboard_service.py
+++ b/services/user/dashboard_service.py
@@ -15,9 +15,6 @@ from core.health_profiles import reminder_triggered
 from core.time_utils import today_local, utc_to_local_date, utcnow
 from core.weather import (
     ensure_user_location_valid,
-    get_consecutive_hot_days,
-    get_qweather_forecast_with_cache,
-    get_weather_with_cache,
     is_demo_mode,
     is_qweather_online_weather,
     resolve_weather_city_label
@@ -29,14 +26,9 @@ from core.db_models import (
     MedicationReminder,
     Notification,
     WeatherAlert,
-    WeatherData
 )
-from services.heat_action_service import HeatActionService
 from services.forecast_cards import build_forecast_cards
-from services.forecast_service import get_forecast_service
 from utils.parsers import safe_json_loads
-
-from ._common import HEAT_RISK_LABELS, _action_plan
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +38,20 @@ _REQUIRED_DASHBOARD_WEATHER_FIELDS = (
     'temperature_min',
     'humidity',
 )
+
+
+def get_bootstrap_payload(*args, **kwargs):
+    """延迟导入快照服务，避免 services.user 包初始化时形成循环依赖。"""
+    from services.miniprogram_service import get_bootstrap_payload as load_payload
+
+    return load_payload(*args, **kwargs)
+
+
+def snapshot_display_time(value):
+    """延迟导入快照时间格式化函数。"""
+    from services.miniprogram_service import snapshot_display_time as format_time
+
+    return format_time(value)
 
 
 def _clamp(value, lower=0.0, upper=1.0):
@@ -169,18 +175,6 @@ def _dashboard_weather_available(weather_data):
     return True
 
 
-def _forecast_weather_context(weather_data):
-    """提取真实和风实况中的有限空气质量值，供未来日代理链使用。"""
-    if not is_qweather_online_weather(weather_data):
-        return {}
-    context = {}
-    for field in ('pm25', 'aqi'):
-        value = _parse_float((weather_data or {}).get(field))
-        if value is not None and math.isfinite(value):
-            context[field] = value
-    return context
-
-
 def _parse_systolic(value):
     """从画像指标里提取收缩压，支持 138/82 或单个数字。"""
     if isinstance(value, str) and '/' in value:
@@ -253,28 +247,41 @@ def _dashboard_metric_cards(user_id):
     return [cards[key] for key in ('sbp', 'heart_rate', 'blood_sugar') if key in cards]
 
 
-def _dashboard_forecast_days(location, start_date, current_weather=None):
-    """首页 7 日预测只使用和风实时预报，失败时不展示演示风险。"""
-    qweather_days, _, meta = get_qweather_forecast_with_cache(location, days=7)
-    if len(qweather_days or []) < 7:
-        logger.warning(
-            "首页和风7日预报不可用: location=%s meta=%s count=%s",
-            location,
-            meta,
-            len(qweather_days or []),
-        )
+def _dashboard_snapshot_forecast_days(snapshot, start_date):
+    """把已落库的逐日天气风险直接转换成首页卡片。"""
+    if snapshot.get('forecast_stale'):
         return []
-
-    health_forecasts = []
-    try:
-        health_forecasts, _ = get_forecast_service().generate_7day_forecast(
-            qweather_days,
-            start_date=start_date,
-            context=_forecast_weather_context(current_weather),
+    forecast = snapshot.get('forecast')
+    if not isinstance(forecast, list):
+        return []
+    cards = build_forecast_cards(forecast, [], start_date)
+    source_by_date = {
+        str(item.get('date') or item.get('forecast_date')): item
+        for item in forecast
+        if isinstance(item, dict) and (item.get('date') or item.get('forecast_date'))
+    }
+    for card in cards:
+        item = source_by_date.get(card.get('full_date')) or {}
+        score = _parse_float(item.get('risk_score'))
+        available = (
+            item.get('risk_available') is True
+            and score is not None
+            and math.isfinite(score)
         )
-    except Exception as exc:
-        logger.warning("首页7日健康预测生成失败，仅展示和风天气: %s", exc)
-    return build_forecast_cards(qweather_days, health_forecasts, start_date)
+        if not available:
+            continue
+        label = str(item.get('risk_level') or '待计算')
+        card.update({
+            'risk_available': True,
+            'risk_score': max(0, min(100, int(round(score)))),
+            'risk_label': label,
+            'risk_level': (
+                'high' if '高' in label or '极' in label
+                else 'mid' if '中' in label
+                else 'low'
+            ),
+        })
+    return cards
 
 
 def user_dashboard(force_elder=False):
@@ -285,12 +292,21 @@ def user_dashboard(force_elder=False):
     )
     is_guest = is_guest_user(current_user)
     demo_mode = is_demo_mode()
-    # 获取当前天气
+    # 首页和公开风险、小程序共用同一份只读快照；缺少快照时统一安全降级。
     today = today_local()
     user_location = ensure_user_location_valid()
     alert_locations = _dashboard_alert_locations(user_location)
-    weather_source_city = resolve_weather_city_label(user_location)
-    weather_data, used_cache = get_weather_with_cache(user_location)
+    snapshot = get_bootstrap_payload()
+    snapshot_id = snapshot.get('snapshot_id')
+    snapshot_mode = bool(snapshot_id)
+    snapshot_location = snapshot.get('location') or {}
+    weather_source_city = str(
+        snapshot_location.get('name')
+        or resolve_weather_city_label(user_location)
+    )
+    weather_data = snapshot.get('current') or {}
+    if not snapshot_mode or snapshot.get('current_stale'):
+        weather_data = {}
     weather_is_mock = bool(weather_data.get('is_mock'))
     weather_available = _dashboard_weather_available(weather_data)
 
@@ -305,75 +321,34 @@ def user_dashboard(force_elder=False):
             logger.warning("极端天气识别失败，已跳过: %s", exc)
             extreme_result = {'is_extreme': False, 'conditions': []}
 
-    weather = WeatherData.query.filter_by(
-        date=today,
-        location=user_location
-    ).order_by(WeatherData.id.desc()).first()
-
-    if weather_available and (not weather or not used_cache):
-        if not weather:
-            weather = WeatherData(date=today, location=user_location)
-            db.session.add(weather)
-        weather.temperature = weather_data.get('temperature')
-        weather.temperature_max = weather_data.get('temperature_max')
-        weather.temperature_min = weather_data.get('temperature_min')
-        weather.humidity = weather_data.get('humidity')
-        weather.pressure = weather_data.get('pressure')
-        weather.weather_condition = weather_data.get('weather_condition')
-        weather.wind_speed = weather_data.get('wind_speed')
-        weather.pm25 = weather_data.get('pm25')
-        weather.aqi = weather_data.get('aqi')
-        weather.is_extreme = extreme_result['is_extreme']
-        weather.extreme_type = '、'.join([c['type'] for c in extreme_result['conditions']]) if extreme_result['is_extreme'] else None
-        db.session.commit()
-
-    if weather_available and not weather:
+    weather = None
+    if weather_available:
         weather = SimpleNamespace(**weather_data)
         weather.is_extreme = extreme_result['is_extreme']
         weather.extreme_type = '、'.join([c['type'] for c in extreme_result['conditions']]) if extreme_result['is_extreme'] else None
 
-    heat_service = HeatActionService()
-    if not weather_available:
+    risk = snapshot.get('risk') or {} if snapshot_mode else {}
+    calculation = risk.get('calculation') if isinstance(risk, dict) else {}
+    stored_heat_result = calculation.get('heat_result') if isinstance(calculation, dict) else None
+    snapshot_risk_ready = (
+        snapshot_mode
+        and not snapshot.get('risk_stale')
+        and risk.get('available') is True
+        and isinstance(stored_heat_result, dict)
+    )
+    if snapshot_risk_ready:
+        heat_result = dict(stored_heat_result)
+        heat_risk_label = risk.get('level') or '暂不可用'
+        heat_actions = snapshot.get('actions') or []
+    else:
         heat_result = None
         heat_risk_label = '暂不可用'
         heat_actions = []
-    else:
-        consecutive_hot_days = get_consecutive_hot_days(
-            user_location,
-            today_max=weather_data.get('temperature_max')
-        )
-        heat_result = heat_service.calculate_heat_risk(
-            weather_data,
-            consecutive_hot_days=consecutive_hot_days
-        )
-        heat_risk_label = HEAT_RISK_LABELS.get(heat_result['risk_level'], '低风险')
-        heat_actions = _action_plan(heat_risk_label)
     dashboard_hero_theme = _dashboard_hero_theme(
         getattr(weather, 'temperature', None) if weather_available else None
     )
     dashboard_metric_cards = [] if is_guest else _dashboard_metric_cards(current_user.id)
-    forecast_days = _dashboard_forecast_days(user_location, today, weather_data)
-
-    # 如果是极端天气，生成预警（避免重复）
-    if weather_available and extreme_result['is_extreme'] and not used_cache:
-        recent_alert = WeatherAlert.query.filter(
-            WeatherAlert.location.in_(alert_locations),
-            WeatherAlert.alert_date >= utcnow() - timedelta(hours=6)
-        ).first()
-        if not recent_alert:
-            alert = weather_service.generate_weather_alert(user_location, weather_data)
-            if alert:
-                weather_alert = WeatherAlert(
-                    alert_date=utcnow(),
-                    location=alert['location'],
-                    alert_type=alert['alert_type'],
-                    alert_level=alert['alert_level'],
-                    description=alert['description'],
-                    affected_communities=json.dumps([user_location]),
-                    disease_correlation=json.dumps({})
-                )
-                db.session.add(weather_alert)
-                db.session.commit()
+    forecast_days = _dashboard_snapshot_forecast_days(snapshot, today) if snapshot_mode else []
 
     # 获取最新风险评估
     if is_guest:
@@ -392,38 +367,6 @@ def user_dashboard(force_elder=False):
         WeatherAlert.alert_date >= utcnow() - timedelta(days=1),
         WeatherAlert.location.in_(alert_locations)
     ).order_by(WeatherAlert.alert_date.desc()).limit(5).all()
-
-    # 如果没有预警但有极端天气，创建预警
-    if weather_available and not alerts and weather and weather.is_extreme:
-        from services.weather_service import WeatherService
-        weather_service = WeatherService()
-        weather_data = {
-            'temperature': weather.temperature,
-            'temperature_max': weather.temperature_max,
-            'temperature_min': weather.temperature_min,
-            'humidity': weather.humidity,
-            'aqi': weather.aqi,
-            'wind_speed': weather.wind_speed,
-        }
-        recent_alert = WeatherAlert.query.filter(
-            WeatherAlert.location.in_(alert_locations),
-            WeatherAlert.alert_date >= utcnow() - timedelta(hours=6)
-        ).first()
-        if not recent_alert:
-            alert = weather_service.generate_weather_alert(user_location, weather_data)
-            if alert:
-                weather_alert = WeatherAlert(
-                    alert_date=utcnow(),
-                    location=alert['location'],
-                    alert_type=alert['alert_type'],
-                    alert_level=alert['alert_level'],
-                    description=alert['description'],
-                    affected_communities=json.dumps([user_location]),
-                    disease_correlation=json.dumps({})
-                )
-                db.session.add(weather_alert)
-                db.session.commit()
-                alerts = [weather_alert]
 
     # 用药提醒（根据天气触发）
     reminders = []
@@ -501,7 +444,11 @@ def user_dashboard(force_elder=False):
             heat_result=heat_result,
             heat_risk_label=heat_risk_label,
             heat_actions=heat_actions,
-            is_guest=is_guest
+            is_guest=is_guest,
+            weather_snapshot_id=snapshot_id,
+            weather_snapshot_fetched_at=snapshot.get('fetched_at'),
+            weather_snapshot_display_time=snapshot_display_time(snapshot.get('fetched_at')),
+            weather_source_status=snapshot.get('source_status') or {},
         )
 
     alert_cards = [_dashboard_alert_card(alert) for alert in alerts]
@@ -523,7 +470,11 @@ def user_dashboard(force_elder=False):
                          alerts=alert_cards,
                          reminders=reminders,
                          notifications=notifications,
-                         is_guest=is_guest)
+                         is_guest=is_guest,
+                         weather_snapshot_id=snapshot_id,
+                         weather_snapshot_fetched_at=snapshot.get('fetched_at'),
+                         weather_snapshot_display_time=snapshot_display_time(snapshot.get('fetched_at')),
+                         weather_source_status=snapshot.get('source_status') or {})
 
 
 def elder_dashboard():

--- a/services/user/profile_service.py
+++ b/services/user/profile_service.py
@@ -320,10 +320,17 @@ def profile():
         if form_id == 'password':
             old_password = request.form.get('old_password', '')
             new_password = request.form.get('new_password')
+            confirm_password = request.form.get('confirm_password', '')
             if not old_password:
                 flash('请输入当前密码', 'error')
                 return redirect(url_for('user.profile'))
             if new_password:
+                if not confirm_password:
+                    flash('请再次输入新密码', 'error')
+                    return redirect(url_for('user.profile'))
+                if new_password != confirm_password:
+                    flash('两次输入的新密码不一致', 'error')
+                    return redirect(url_for('user.profile'))
                 valid, result = validate_password(new_password)
                 if not valid:
                     flash(result, 'error')

--- a/services/user/profile_service.py
+++ b/services/user/profile_service.py
@@ -2,13 +2,13 @@
 """Profile and assessment routes."""
 import json
 import logging
-import math
 from datetime import timedelta
 from urllib.parse import urlparse
 
-from flask import current_app, flash, redirect, render_template, request, session, url_for
+from flask import abort, current_app, flash, redirect, render_template, request, session, url_for
 from flask_login import current_user, login_user
 from sqlalchemy.exc import IntegrityError
+from werkzeug.exceptions import HTTPException
 
 from core.analytics import get_high_risk_streak
 from core.db_models import (
@@ -21,6 +21,7 @@ from core.db_models import (
 )
 from core.extensions import db
 from core.guest import build_guest_profile, get_guest_assessment, is_guest_user
+from core.location_resolution import resolve_user_location
 from core.notifications import create_notification
 from core.time_utils import utcnow
 from core.usage import create_api_token
@@ -28,8 +29,7 @@ from core.weather import (
     compact_assessment_weather_condition,
     ensure_user_location_valid,
     get_weather_with_cache,
-    is_qweather_online_weather,
-    normalize_location_name,
+    is_complete_qweather_weather,
 )
 from utils.parsers import json_or_none, safe_json_loads
 from utils.validators import (
@@ -92,14 +92,8 @@ def _wxpusher_consent_is_current(user, required_version):
 
 
 def _personal_weather_available(weather_data):
-    """个人评估只接受来源明确且温度可计算的真实和风天气。"""
-    if not is_qweather_online_weather(weather_data):
-        return False
-    try:
-        temperature = float(weather_data.get('temperature'))
-    except (AttributeError, TypeError, ValueError):
-        return False
-    return math.isfinite(temperature)
+    """个人评估只接受风险模型必需字段完整的真实和风天气。"""
+    return is_complete_qweather_weather(weather_data)
 
 
 def _safe_referrer_or_dashboard():
@@ -307,13 +301,25 @@ def profile():
         form_id = sanitize_input(request.form.get('form_id'), max_length=30) or 'basic'
 
         if form_id == 'api_token':
+            if current_user.role != 'admin':
+                abort(403)
             token_name = sanitize_input(request.form.get('token_name'), max_length=80)
             if request.form.get('miniprogram_privacy_consent') != '1':
                 flash('请先阅读并同意小程序隐私说明，再生成绑定凭证。', 'error')
                 return redirect(url_for('user.profile'))
+            current_password = request.form.get('current_password', '')
+            if not current_password:
+                flash('请输入当前密码，再生成旧版 API Token。', 'error')
+                return redirect(url_for('user.profile'))
             try:
                 owner_user_id = int(current_user.id)
-                with owner_write_guard(owner_user_id):
+                with owner_write_guard(owner_user_id) as locked_user:
+                    # 角色与密码都在 owner 锁内重新读取，阻断降权并发和陈旧会话。
+                    if locked_user.role != 'admin':
+                        abort(403)
+                    if not locked_user.check_password(current_password):
+                        flash('当前密码不正确，未生成旧版 API Token。', 'error')
+                        return redirect(url_for('user.profile'))
                     plain = create_api_token(
                         owner_user_id,
                         name=token_name,
@@ -332,6 +338,8 @@ def profile():
             except OwnerInactiveError:
                 flash('账号已失效，请重新登录。', 'error')
                 return redirect(url_for('public.login'))
+            except HTTPException:
+                raise
             except Exception:
                 logger.exception("API token create failed")
                 flash('生成失败，请稍后重试。', 'error')
@@ -434,9 +442,17 @@ def profile():
             return redirect(url_for('user.profile'))
         gender = result
 
-        # 清理社区输入并校验
-        community_value = sanitize_input(request.form.get('community'), max_length=100)
-        community = normalize_location_name(community_value)
+        # 个人档案只接受县内配置地点；旧县外值必须由用户明确重选。
+        communities = Community.query.all()
+        community_resolution = resolve_user_location(
+            request.form.get('community'),
+            extra_names=[community.name for community in communities],
+            default_if_blank=False,
+        )
+        if not community_resolution.valid:
+            flash(community_resolution.error, 'error')
+            return redirect(url_for('user.profile'))
+        community = community_resolution.value
 
         # 验证邮箱
         valid, result = validate_email(request.form.get('email'))
@@ -595,6 +611,11 @@ def profile():
         return redirect(url_for('user.profile'))
 
     communities = Community.query.all()
+    current_location_resolution = resolve_user_location(
+        current_user.community,
+        extra_names=[community.name for community in communities],
+        default_if_blank=False,
+    )
     chronic_diseases_list = safe_json_loads(current_user.chronic_diseases, [])
 
     last_api_token_plain = session.pop('last_api_token_plain', None)
@@ -621,6 +642,11 @@ def profile():
                 required_wxpusher_version,
             )
         ),
+        profile_location_error=(
+            current_location_resolution.error
+            if not current_location_resolution.valid
+            else None
+        ),
     )
 
 
@@ -631,9 +657,19 @@ def update_location():
         flash('请填写有效的地点', 'error')
         return redirect(_safe_referrer_or_dashboard())
 
-    normalized = normalize_location_name(location)
-    if normalized != location:
-        flash(f'未识别的地点，已自动调整为 {normalized}', 'error')
+    communities = Community.query.all()
+    location_resolution = resolve_user_location(
+        location,
+        extra_names=[community.name for community in communities],
+        default_if_blank=False,
+    )
+    if not location_resolution.valid or not location_resolution.value:
+        flash(
+            location_resolution.error or '请填写有效的地点',
+            'error',
+        )
+        return redirect(_safe_referrer_or_dashboard())
+    normalized = location_resolution.value
 
     if is_guest_user(current_user):
         profile = build_guest_profile()

--- a/services/user/profile_service.py
+++ b/services/user/profile_service.py
@@ -57,6 +57,14 @@ _ACADEMIC_MAPPING_FIELDS = (
     'rr_breakdown',
 )
 
+_HEALTH_SCREENING_OPTIONS = {
+    'outdoor_exposure': {'low', 'medium', 'high'},
+    'symptom_level': {'none', 'mild', 'moderate', 'severe'},
+    'hydration': {'good', 'normal', 'poor'},
+    'medication_adherence': {'good', 'partial', 'poor'},
+    'sleep_quality': {'good', 'fair', 'poor'},
+}
+
 
 def _normalize_academic_profile(raw_profile):
     """把历史评估中的不可信 JSON 形状收敛到模板可安全读取的结构。"""
@@ -112,24 +120,66 @@ def _safe_referrer_or_dashboard():
     return referrer
 
 
+def _render_health_assessment_page(*, form_state=None, form_errors=None, status=200):
+    """渲染健康评估页，并在校验失败时保留已完成选项。"""
+    normalized_form_errors = form_errors or {}
+    first_form_error = next(
+        (name for name in _HEALTH_SCREENING_OPTIONS if name in normalized_form_errors),
+        None,
+    )
+    latest_assessment = None
+    if is_guest_user(current_user):
+        latest_assessment = get_guest_assessment()
+    else:
+        latest_assessment = HealthRiskAssessment.query.filter_by(
+            user_id=current_user.id
+        ).order_by(HealthRiskAssessment.assessment_date.desc()).first()
+    explain_data = {}
+    disease_risks_data = {}
+    if latest_assessment and getattr(latest_assessment, 'explain', None):
+        explain_data = safe_json_loads(latest_assessment.explain, {})
+    if latest_assessment and getattr(latest_assessment, 'disease_risks', None):
+        disease_risks_data = safe_json_loads(latest_assessment.disease_risks, {})
+    if not isinstance(explain_data, dict):
+        explain_data = {}
+    academic_profile = _normalize_academic_profile(
+        explain_data.get('academic_profile')
+    )
+    explain_data = dict(explain_data)
+    explain_data['academic_profile'] = academic_profile
+    if not isinstance(disease_risks_data, dict):
+        disease_risks_data = {}
+
+    return render_template(
+        'health_assessment.html',
+        assessment=latest_assessment,
+        assessment_explain=explain_data,
+        assessment_disease_risks=disease_risks_data,
+        assessment_academic=academic_profile,
+        form_state=form_state or {},
+        form_errors=normalized_form_errors,
+        first_form_error=first_form_error,
+    ), status
+
+
 def health_assessment():
     """健康风险评估"""
     if request.method == 'POST':
-        screening_options = {
-            'outdoor_exposure': {'low', 'medium', 'high'},
-            'symptom_level': {'none', 'mild', 'moderate', 'severe'},
-            'hydration': {'good', 'normal', 'poor'},
-            'medication_adherence': {'good', 'partial', 'poor'},
-            'sleep_quality': {'good', 'fair', 'poor'},
-        }
         screening = {}
-        for name, allowed in screening_options.items():
+        form_errors = {}
+        for name, allowed in _HEALTH_SCREENING_OPTIONS.items():
             value = sanitize_input(request.form.get(name), max_length=20)
             value = value.strip().lower() if isinstance(value, str) else ''
             if value not in allowed:
-                flash('请完整选择全部 5 项健康筛查后再提交。', 'error')
-                return redirect(url_for('user.health_assessment'))
-            screening[name] = value
+                form_errors[name] = '请选择这一项后再提交。'
+            else:
+                screening[name] = value
+        if form_errors:
+            return _render_health_assessment_page(
+                form_state=screening,
+                form_errors=form_errors,
+                status=422,
+            )
 
         try:
             # 执行风险评估（多路径融合版）
@@ -245,37 +295,7 @@ def health_assessment():
 
         return redirect(url_for('user.health_assessment'))
 
-    latest_assessment = None
-    if is_guest_user(current_user):
-        latest_assessment = get_guest_assessment()
-    else:
-        latest_assessment = HealthRiskAssessment.query.filter_by(
-            user_id=current_user.id
-        ).order_by(HealthRiskAssessment.assessment_date.desc()).first()
-    explain_data = {}
-    disease_risks_data = {}
-    academic_profile = {}
-    if latest_assessment and getattr(latest_assessment, 'explain', None):
-        explain_data = safe_json_loads(latest_assessment.explain, {})
-    if latest_assessment and getattr(latest_assessment, 'disease_risks', None):
-        disease_risks_data = safe_json_loads(latest_assessment.disease_risks, {})
-    if not isinstance(explain_data, dict):
-        explain_data = {}
-    academic_profile = _normalize_academic_profile(
-        explain_data.get('academic_profile')
-    )
-    explain_data = dict(explain_data)
-    explain_data['academic_profile'] = academic_profile
-    if not isinstance(disease_risks_data, dict):
-        disease_risks_data = {}
-
-    return render_template(
-        'health_assessment.html',
-        assessment=latest_assessment,
-        assessment_explain=explain_data,
-        assessment_disease_risks=disease_risks_data,
-        assessment_academic=academic_profile
-    )
+    return _render_health_assessment_page()
 
 
 def profile():

--- a/static/js/cooling-map.js
+++ b/static/js/cooling-map.js
@@ -72,7 +72,7 @@
             [point.type, point.community].filter(Boolean).join(' · ') || '避暑资源'
         ));
         content.appendChild(textRow(point.address || '地址未标注'));
-        content.appendChild(textRow(point.open_hours || '开放时间未标注'));
+        content.appendChild(textRow(point.open_hours || '开放时间未核验，请出发前确认'));
         return content;
     }
 

--- a/static/js/heat-exposure-gis.js
+++ b/static/js/heat-exposure-gis.js
@@ -131,8 +131,8 @@
         geometryMode: 'rectified',
         renderFrame: null,
         resizeFrame: null,
-        mapMoving: false,
-        mapZooming: false
+        cameraInMotion: false,
+        cameraSettleFrame: null
     };
 
     const GCJ_PI = Math.PI;
@@ -818,8 +818,7 @@
         state.renderFrame = null;
         if (
             !state.map
-            || state.mapMoving
-            || state.mapZooming
+            || state.cameraInMotion
             || !ui.gridCanvas
             || !resizeGridCanvas()
         ) return;
@@ -851,7 +850,7 @@
     }
 
     function scheduleMapRender() {
-        if (!state.map || state.mapMoving || state.mapZooming || state.renderFrame) return;
+        if (!state.map || state.cameraInMotion || state.renderFrame) return;
         state.renderFrame = window.requestAnimationFrame(renderMapCanvas);
     }
 
@@ -878,8 +877,7 @@
 
     function cellAtPixel(point) {
         if (
-            state.mapMoving
-            || state.mapZooming
+            state.cameraInMotion
             || ui.gridCanvas.hidden
         ) return null;
         const key = hitBucketKey(
@@ -1013,8 +1011,12 @@
         if (error) console.error('高德热暴露地图初始化失败', error);
     }
 
-    function suspendMapCanvas(motionType) {
-        state[motionType] = true;
+    function beginCameraTransaction() {
+        if (state.cameraSettleFrame !== null) {
+            window.cancelAnimationFrame(state.cameraSettleFrame);
+            state.cameraSettleFrame = null;
+        }
+        state.cameraInMotion = true;
         state.hoverIndex = null;
         // 手势结束后的下一帧之前禁用旧像素索引，避免点击命中移动前的网格。
         state.drawCache = [];
@@ -1023,10 +1025,16 @@
         ui.gridCanvas.hidden = true;
     }
 
-    function resumeMapCanvas(motionType) {
-        state[motionType] = false;
-        if (state.mapMoving || state.mapZooming) return;
-        scheduleMapRender();
+    function settleCameraTransaction() {
+        if (state.cameraSettleFrame !== null) {
+            window.cancelAnimationFrame(state.cameraSettleFrame);
+        }
+        // 高德的缩放和移动事件可能交错或缺少配对 end；任一 end 都以相机稳定帧为准完成事务。
+        state.cameraSettleFrame = window.requestAnimationFrame(function () {
+            state.cameraSettleFrame = null;
+            state.cameraInMotion = false;
+            scheduleMapRender();
+        });
     }
 
     function initializeMap() {
@@ -1074,16 +1082,16 @@
         });
         // 手势期间只移动高德底图，结束后一次性重投影网格，避免低端手机逐帧计算全部顶点。
         state.map.on('movestart', function () {
-            suspendMapCanvas('mapMoving');
+            beginCameraTransaction();
         });
         state.map.on('moveend', function () {
-            resumeMapCanvas('mapMoving');
+            settleCameraTransaction();
         });
         state.map.on('zoomstart', function () {
-            suspendMapCanvas('mapZooming');
+            beginCameraTransaction();
         });
         state.map.on('zoomend', function () {
-            resumeMapCanvas('mapZooming');
+            settleCameraTransaction();
         });
         state.map.on('mousemove', function (event) {
             const longitude = Number(event.lnglat?.getLng?.());

--- a/static/js/yilao-data-fx-extra.js
+++ b/static/js/yilao-data-fx-extra.js
@@ -403,7 +403,10 @@
             }
         }
         if (bulb) bulb.dataset.zone = zone;
-        if (valEl) animateNumber(valEl, 0, t, { duration: 1500, decimals: 1 });
+        // 服务端首帧已给出正式数值时，只动画水银柱，避免数字先跳回 0。
+        if (valEl && el.dataset.staticValue !== '1') {
+            animateNumber(valEl, 0, t, { duration: 1500, decimals: 1 });
+        }
 
         if (zone === 'danger') el.classList.add('danger-active');
         else el.classList.remove('danger-active');

--- a/templates/account_link.html
+++ b/templates/account_link.html
@@ -9,22 +9,22 @@
         <span class="section-kicker">网页版与微信小程序</span>
         <h1 class="mt-2 mb-2">把两端串成同一个账号</h1>
         <p class="text-muted mb-0">
-            手机号当前只保存为待验证标识，不发送短信验证码，也不能用于登录。
+            生成一次性绑定码只需要确认当前密码并同意绑定说明，不需要填写手机号。
         </p>
     </header>
 
     <div class="alert alert-light border" role="note">
         <strong>推荐顺序：</strong>
-        先保存手机号，再到微信小程序完成微信登录，最后输入这里生成的 8 位码。绑定完成后，两端会读取同一份家庭照护数据。
+        先在这里生成 8 位码，再到微信小程序登录并输入。绑定完成后，两端会读取同一份家庭照护数据。
     </div>
 
     <div class="row g-4">
-        <div class="col-lg-6">
+        <div class="col-lg-6 order-2">
             <section class="card shadow-sm h-100">
                 <div class="card-body p-4">
                     <div class="d-flex align-items-center gap-2 mb-3">
-                        <span class="badge text-bg-primary">1</span>
-                        <h2 class="h5 mb-0">保存待验证手机号</h2>
+                        <span class="badge text-bg-secondary">可选</span>
+                        <h2 class="h5 mb-0">保存联系手机号</h2>
                     </div>
                     <form method="POST" action="{{ url_for('public.account_link_phone') }}">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -41,7 +41,7 @@
                                 placeholder="例如 13800138000"
                                 required
                             >
-                            <div class="form-text">保存后仍需使用用户名登录。状态：待验证。</div>
+                            <div class="form-text">当前仅保存为待验证联系信息，不用于登录，也不影响小程序绑定。</div>
                         </div>
                         <div class="mb-3">
                             <label class="form-label" for="phoneCurrentPassword">当前密码</label>
@@ -53,11 +53,11 @@
             </section>
         </div>
 
-        <div class="col-lg-6">
+        <div class="col-lg-6 order-1">
             <section class="card shadow-sm h-100">
                 <div class="card-body p-4">
                     <div class="d-flex align-items-center gap-2 mb-3">
-                        <span class="badge text-bg-primary">2</span>
+                        <span class="badge text-bg-primary">1</span>
                         <h2 class="h5 mb-0">生成一次性绑定码</h2>
                     </div>
 

--- a/templates/action_checkin.html
+++ b/templates/action_checkin.html
@@ -15,7 +15,7 @@
             <h2><i class="bi bi-clipboard-check"></i> 行动型热健康预警</h2>
             {% if web_actions_read_only %}
                 <p class="text-muted mb-0">网页提供今日公共行动清单，并把家庭确认安全地交接到“{{ mini_program_name }}”小程序。</p>
-                <p class="text-muted small mt-2 mb-0">网页不会读取短码、兑换安全链接或写入家庭记录。家庭确认、求助和复盘请在小程序中登录后完成。</p>
+                <p class="text-muted small mt-2 mb-0">微信正式版不会在网页读取短码或家庭安全链接；不会读取短码、兑换安全链接或写入家庭记录。家庭确认、求助和复盘请在小程序中登录后完成。</p>
             {% else %}
                 <p class="text-muted mb-0">输入短码即可完成今日确认或求助（不含医疗诊断/治疗建议）。</p>
                 <p class="text-muted small mt-2 mb-0">未登录者可使用照护人提供的有效短码或有时效家庭行动安全链接。只有主动提交时，行动确认、求助需求或复盘才会写入对应照护账号；该入口不等于登录，不能查看账号内其他资料。</p>

--- a/templates/action_checkin.html
+++ b/templates/action_checkin.html
@@ -2,8 +2,11 @@
 {% from "partials/metric_info.html" import metric_info with context %}
 {% set needs_chartjs = true %}
 {% set web_actions_read_only = web_actions_read_only|default(config.get('WECHAT_FORMAL_RUNTIME', false)) %}
+{% set mini_program_name = config.get('WX_MINIPROGRAM_NAME', '宜老平安') %}
+{% set mini_program_action_path = config.get('WX_MINIPROGRAM_ACTION_PATH', 'pages/actions/index') %}
+{% set mini_program_code_image = config.get('WX_MINIPROGRAM_ACTION_CODE_IMAGE', '') %}
 
-{% block title %}行动打卡 - 天气健康风险预测系统{% endblock %}
+{% block title %}今日行动入口 · 宜老天气通{% endblock %}
 
 {% block content %}
 <div class="container my-4">
@@ -11,8 +14,8 @@
         <div class="col-12">
             <h2><i class="bi bi-clipboard-check"></i> 行动型热健康预警</h2>
             {% if web_actions_read_only %}
-                <p class="text-muted mb-0">当前网页仅显示家庭行动入口的停用说明（不含医疗诊断/治疗建议）。</p>
-                <p class="text-muted small mt-2 mb-0">微信正式版不会在网页读取短码或家庭安全链接。确认、求助和复盘请在微信小程序中登录并完成健康资料单独同意后操作。</p>
+                <p class="text-muted mb-0">网页提供今日公共行动清单，并把家庭确认安全地交接到“{{ mini_program_name }}”小程序。</p>
+                <p class="text-muted small mt-2 mb-0">网页不会读取短码、兑换安全链接或写入家庭记录。家庭确认、求助和复盘请在小程序中登录后完成。</p>
             {% else %}
                 <p class="text-muted mb-0">输入短码即可完成今日确认或求助（不含医疗诊断/治疗建议）。</p>
                 <p class="text-muted small mt-2 mb-0">未登录者可使用照护人提供的有效短码或有时效家庭行动安全链接。只有主动提交时，行动确认、求助需求或复盘才会写入对应照护账号；该入口不等于登录，不能查看账号内其他资料。</p>
@@ -25,13 +28,52 @@
             <div class="col-lg-6">
                 <div class="card shadow-sm">
                     <div class="card-header bg-light">
+                        {% if web_actions_read_only %}
+                        <h5 class="mb-0"><i class="bi bi-wechat"></i> 去“{{ mini_program_name }}”完成家庭打卡</h5>
+                        {% else %}
                         <h5 class="mb-0"><i class="bi bi-key"></i> 短码确认</h5>
+                        {% endif %}
                     </div>
                     <div class="card-body">
                         {% if web_actions_read_only %}
-                        <div class="alert alert-info mb-0" role="status" data-testid="web-actions-read-only">
-                            <strong>当前网页仅供查看停用说明。</strong>
-                            为保护家庭资料，首发不会读取短码、兑换安全链接或写入家庭记录。请打开微信小程序并登录后操作。
+                        <div data-testid="miniprogram-action-handoff"
+                             data-miniprogram-path="{{ mini_program_action_path }}">
+                            {% if mini_program_code_image %}
+                            <div class="text-center mb-3">
+                                <img src="{% if mini_program_code_image.startswith('https://') %}{{ mini_program_code_image }}{% else %}{{ url_for('static', filename=mini_program_code_image) }}{% endif %}"
+                                     alt="{{ mini_program_name }}官方小程序码，进入今日行动页"
+                                     width="220"
+                                     height="220"
+                                     loading="eager"
+                                     referrerpolicy="no-referrer"
+                                     class="img-fluid rounded border">
+                                <div class="text-muted small mt-2">微信扫码后进入“今日行动”页。</div>
+                            </div>
+                            {% else %}
+                            <div class="alert alert-info" role="status" data-testid="miniprogram-code-fallback">
+                                <strong>当前没有可展示的官方小程序码。</strong>
+                                请打开微信，搜索小程序“{{ mini_program_name }}”，进入后点“今日行动”。页面不会显示占位码或未经核验的二维码。
+                            </div>
+                            {% endif %}
+
+                            <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+                                <span>小程序名称：<strong id="miniProgramName">{{ mini_program_name }}</strong></span>
+                                <button type="button" class="btn btn-sm btn-outline-primary" id="copyMiniProgramName" data-copy-value="{{ mini_program_name }}">
+                                    <i class="bi bi-copy me-1" aria-hidden="true"></i>复制名称
+                                </button>
+                                <span class="small text-success" id="copyMiniProgramFeedback" role="status" aria-live="polite"></span>
+                            </div>
+
+                            <ol class="small ps-3 mb-3">
+                                <li class="mb-1">打开“{{ mini_program_name }}”，进入“今日行动”。</li>
+                                <li class="mb-1">公共行动可直接在本机勾选，无需先选择家人。</li>
+                                <li>需要保存家庭确认、求助或复盘时，从“照护”选择对应家人。</li>
+                            </ol>
+
+                            <div class="d-flex flex-wrap gap-2">
+                                <a class="btn btn-primary" href="{{ url_for('public.public_risk') }}"><i class="bi bi-shield-check me-1"></i>返回今日风险</a>
+                                <a class="btn btn-outline-secondary" href="{{ url_for('public.index') }}"><i class="bi bi-house me-1"></i>返回首页</a>
+                            </div>
                         </div>
                         {% else %}
                         <form method="POST" action="{{ entry_action or url_for('public.action_check') }}">
@@ -52,10 +94,23 @@
             <div class="col-lg-6 mt-4 mt-lg-0">
                 <div class="card shadow-sm">
                     <div class="card-header bg-light">
+                        {% if web_actions_read_only %}
+                        <h5 class="mb-0"><i class="bi bi-list-check"></i> 今天先做这 3 件事</h5>
+                        {% else %}
                         <h5 class="mb-0"><i class="bi bi-shield-check"></i> 统一免责声明</h5>
+                        {% endif %}
                     </div>
                     <div class="card-body">
+                        {% if web_actions_read_only %}
+                        <div class="d-grid gap-3" data-testid="public-action-fallback-list">
+                            <div><strong>1. 少量多次补水</strong><div class="text-muted small">根据自身饮水限制安排，别等明显口渴才喝。</div></div>
+                            <div><strong>2. 避开午后高温</strong><div class="text-muted small">尽量在室内休息，外出优先安排在上午或傍晚。</div></div>
+                            <div><strong>3. 主动联系家人</strong><div class="text-muted small">身体不适或需要帮助时直接电话、微信联系；紧急情况拨打 120。</div></div>
+                            <a class="btn btn-outline-primary" href="{{ url_for('public.cooling_resources') }}"><i class="bi bi-snow2 me-1"></i>查看已核验避暑资源</a>
+                        </div>
+                        {% else %}
                         {% include "partials/disclaimer_block.html" %}
+                        {% endif %}
                     </div>
                 </div>
             </div>
@@ -379,6 +434,20 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function () {
+    const copyMiniProgramButton = document.getElementById('copyMiniProgramName');
+    const copyMiniProgramFeedback = document.getElementById('copyMiniProgramFeedback');
+    if (copyMiniProgramButton && copyMiniProgramFeedback) {
+        copyMiniProgramButton.addEventListener('click', async function () {
+            const value = copyMiniProgramButton.dataset.copyValue || '';
+            try {
+                await navigator.clipboard.writeText(value);
+                copyMiniProgramFeedback.textContent = '已复制';
+            } catch (_error) {
+                copyMiniProgramFeedback.textContent = '复制失败，请长按名称复制';
+            }
+        });
+    }
+
     const nameInput = document.getElementById('localContactName');
     const phoneInput = document.getElementById('localContactPhone');
     const saveBtn = document.getElementById('saveLocalContact');

--- a/templates/base.html
+++ b/templates/base.html
@@ -240,7 +240,14 @@
             {% endif %}
 
             <div class="d-flex align-items-center gap-2 ms-auto">
-                {% if current_user.is_authenticated %}
+                {% if nav_is_guest %}
+                    <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('public.login') }}">登录正式账号</a>
+                    <a class="btn btn-sm btn-primary nav-auth-register" data-nav-auth="register" href="{{ url_for('public.register') }}">注册</a>
+                    <form method="POST" action="{{ url_for('public.logout') }}" class="d-none d-md-inline m-0">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button class="btn btn-sm btn-outline-secondary" type="submit">结束体验</button>
+                    </form>
+                {% elif current_user.is_authenticated %}
                     {% if current_user.role == 'admin' %}
                         <a class="btn btn-sm btn-outline-secondary d-none d-md-inline-flex" href="{{ url_for('admin.admin_dashboard') }}">
                             <i class="bi bi-speedometer2 me-1"></i>后台
@@ -278,7 +285,7 @@
 
             {% if current_user.is_authenticated %}
                 <div class="mb-3 p-3" style="background:var(--yl-orange-50); border-radius:12px;">
-                    <div class="small text-muted">当前账号</div>
+                    <div class="small text-muted">{% if nav_is_guest %}当前为游客体验{% else %}当前账号{% endif %}</div>
                     <div class="fw-semibold"><i class="bi bi-person-circle me-1"></i>{{ current_user.username }}</div>
                     <div class="small text-muted mt-1">
                         <i class="bi bi-geo-alt"></i> {{ current_location or '未设置定位' }}
@@ -400,11 +407,12 @@
                         </div>
                     {% endif %}
                 {% else %}
+                    <a class="nav-link" href="{{ url_for('public.login') }}"><i class="bi bi-box-arrow-in-right me-2"></i>登录正式账号</a>
                     <a class="nav-link" href="{{ url_for('public.register') }}"><i class="bi bi-person-plus me-2"></i>注册账号</a>
                 {% endif %}
                 <form method="POST" action="{{ url_for('public.logout') }}" class="mt-2">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <button class="btn btn-outline-secondary btn-sm w-100" type="submit"><i class="bi bi-box-arrow-right me-1"></i>退出登录</button>
+                    <button class="btn btn-outline-secondary btn-sm w-100" type="submit"><i class="bi bi-box-arrow-right me-1"></i>{% if nav_is_guest %}结束游客体验{% else %}退出登录{% endif %}</button>
                 </form>
             </nav>
             {% else %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -97,7 +97,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/yilao-data-fx.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/yilao-data-fx-extra.css') }}">
 
-    <noscript><style>.page-loader{display:none !important;}[data-motion] .yl-fade-up,[data-motion] .yl-section,[data-motion] .narrative-step,[data-motion] [data-animate-in]{opacity:1 !important;transform:none !important;}</style></noscript>
+    <noscript><style>[data-motion] .yl-fade-up,[data-motion] .yl-section,[data-motion] .narrative-step,[data-motion] [data-animate-in]{opacity:1 !important;transform:none !important;}</style></noscript>
     {% block extra_css %}{% endblock %}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/apple-polish.css') }}">
 </head>
@@ -134,11 +134,6 @@
     {% set nav_care_active = nav_care_primary_active or nav_family_active %}
 
     <a class="visually-hidden-focusable skip-link" href="#main-content">跳到主要内容</a>
-
-    <div class="page-loader" id="pageLoader">
-        <div class="loader-spinner"></div>
-        <div class="loader-text">加载中…</div>
-    </div>
 
     {# ===================== 顶部导航 ===================== #}
     <nav class="navbar sticky-top" aria-label="主导航">
@@ -469,14 +464,6 @@
     {% endif %}
 
     <script>
-        function hideLoader() {
-            const loader = document.getElementById('pageLoader');
-            if (loader) loader.classList.add('hidden');
-        }
-        document.addEventListener('DOMContentLoaded', function() { setTimeout(hideLoader, 100); });
-        window.addEventListener('load', function() { setTimeout(hideLoader, 100); });
-        setTimeout(hideLoader, 3000);
-
         document.addEventListener('DOMContentLoaded', function() {
             document.querySelectorAll('form').forEach(form => {
                 form.addEventListener('submit', function() {
@@ -490,7 +477,6 @@
                 });
             });
         });
-        window.addEventListener('error', function() { hideLoader(); });
     </script>
 
     <script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -384,7 +384,7 @@
                             <option value="{{ loc }}"></option>
                         {% endfor %}
                     </datalist>
-                    <div class="text-muted small mt-2">输入城市或社区名</div>
+                    <div class="text-muted small mt-2">输入都昌县或已配置的乡镇、社区</div>
                     <button class="btn btn-primary btn-sm w-100 mt-2">更新定位</button>
                 </form>
             </div>

--- a/templates/chronic_risk.html
+++ b/templates/chronic_risk.html
@@ -10,7 +10,7 @@
         <p>填写近 7 天血压、血糖和当前状态，结合天气查看今天需要留意的事项。结果只用于日常照护参考。</p>
     </section>
 
-    <form method="POST" action="{{ url_for('tools.chronic_risk') }}" class="yl-section mb-4 yl-fade-up yl-fade-up-d1">
+    <form method="POST" action="{{ url_for('tools.chronic_risk') }}" class="yl-section mb-4 yl-fade-up yl-fade-up-d1" novalidate>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
         <div class="row g-3">
@@ -25,11 +25,15 @@
             </div>
             <div class="col-md-4">
                 <label class="form-label">近 7 天最高血压(mmHg)</label>
-                <input type="number" class="form-control" name="sbp" value="{{ form_state.sbp if form_state else '' }}" placeholder="例:142">
+                <input type="text" inputmode="decimal" class="form-control{% if vital_errors and vital_errors.sbp %} is-invalid{% endif %}" name="sbp" value="{{ form_state.sbp if form_state else '' }}" placeholder="例:142" maxlength="20" aria-describedby="sbpHelp{% if vital_errors and vital_errors.sbp %} sbpError{% endif %}">
+                <div class="form-text" id="sbpHelp">可不填；填写时接受 60 至 260 mmHg。</div>
+                {% if vital_errors and vital_errors.sbp %}<div class="invalid-feedback" id="sbpError">{{ vital_errors.sbp }}</div>{% endif %}
             </div>
             <div class="col-md-4">
                 <label class="form-label">近 7 天空腹血糖(mmol/L)</label>
-                <input type="number" step="0.1" class="form-control" name="fbg" value="{{ form_state.fbg if form_state else '' }}" placeholder="例:7.8">
+                <input type="text" inputmode="decimal" class="form-control{% if vital_errors and vital_errors.fbg %} is-invalid{% endif %}" name="fbg" value="{{ form_state.fbg if form_state else '' }}" placeholder="例:7.8" maxlength="20" aria-describedby="fbgHelp{% if vital_errors and vital_errors.fbg %} fbgError{% endif %}">
+                <div class="form-text" id="fbgHelp">可不填；填写时接受 2 至 30 mmol/L。</div>
+                {% if vital_errors and vital_errors.fbg %}<div class="invalid-feedback" id="fbgError">{{ vital_errors.fbg }}</div>{% endif %}
             </div>
             <div class="col-md-4">
                 <label class="form-label">用药依从</label>
@@ -50,8 +54,8 @@
     </form>
 
     {% if risk_error %}
-    <div class="alert alert-warning yl-fade-up yl-fade-up-d2" role="status">
-        <i class="bi bi-cloud-slash me-1"></i>天气正在更新，本次提醒暂未生成。请稍后再试。
+    <div class="alert alert-warning yl-fade-up yl-fade-up-d2" role="alert">
+        <i class="bi bi-exclamation-triangle me-1"></i>{{ risk_error }}
     </div>
     {% endif %}
 

--- a/templates/cooling.html
+++ b/templates/cooling.html
@@ -18,14 +18,17 @@
         <div class="row g-4 align-items-center">
             <div class="col-md-auto">
                 <div class="fx-thermometer" data-fx="thermometer"
-                     data-temp="{{ outdoor_temp }}" data-min="-5" data-max="45">
+                     data-temp="{{ outdoor_temp }}" data-min="-5" data-max="45" data-static-value="1">
                     <div class="fx-thermometer-tube">
                         <div class="fx-thermometer-mercury"></div>
                         <div class="fx-thermometer-bulb"></div>
                     </div>
                     <div class="fx-thermometer-info">
-                        <div class="v"><span class="num">0</span><span class="unit">°C</span></div>
+                        <div class="v"><span class="num">{{ outdoor_temp }}</span><span class="unit">°C</span></div>
                         <div class="k">{{ cooling_weather_location or current_location or '当前位置' }} · 当前室外</div>
+                        {% if cooling_snapshot_meta and cooling_snapshot_meta.id_short %}
+                        <div class="text-muted small mt-1">天气快照 {{ cooling_snapshot_meta.id_short }}{% if cooling_snapshot_meta.fetched_at %} · {{ cooling_snapshot_meta.fetched_at[:16]|replace('T', ' ') }}{% endif %}</div>
+                        {% endif %}
                     </div>
                 </div>
             </div>
@@ -52,8 +55,10 @@
         <div class="row g-3 align-items-end">
             <div class="col-md-5">
                 <label class="form-label">所在地</label>
-                <input type="text" class="form-control" name="community" value="{{ selected_community or current_location or '' }}" list="locOpts">
-                <datalist id="locOpts">{% for loc in (communities or location_options or []) %}<option value="{{ loc }}"></option>{% endfor %}</datalist>
+                <input type="text" class="form-control{% if cooling_location_error %} is-invalid{% endif %}" name="community" value="{{ selected_community or '' }}" list="locOpts" aria-describedby="coolingLocationHelp{% if cooling_location_error %} coolingLocationError{% endif %}">
+                <datalist id="locOpts">{% for loc in (cooling_location_options or []) %}<option value="{{ loc }}"></option>{% endfor %}</datalist>
+                <div class="form-text" id="coolingLocationHelp">目前仅支持都昌县及列表中的乡镇、社区。</div>
+                {% if cooling_location_error %}<div class="invalid-feedback" id="coolingLocationError">{{ cooling_location_error }}</div>{% endif %}
             </div>
             <div class="col-md-4">
                 <label class="form-label">类型</label>
@@ -70,6 +75,12 @@
         </div>
     </form>
 
+    {% if cooling_location_error %}
+    <div class="alert alert-warning mb-4 yl-fade-up yl-fade-up-d2" role="alert" data-error-code="invalid_location">
+        <i class="bi bi-geo-alt me-1"></i>{{ cooling_location_error }} 原输入已保留，请修改后重新查找。
+    </div>
+    {% endif %}
+
     <section class="yl-section mb-4 yl-fade-up yl-fade-up-d2 cooling-map-panel"
              id="coolingMapPanel"
              data-has-map-key="{{ '1' if amap_key else '0' }}">
@@ -78,13 +89,21 @@
                 <h2 class="cooling-map-title">地图查看避暑资源</h2>
                 <p class="cooling-map-copy mb-0">地图只接收已核验的公开资源点。只有你点击按钮后，浏览器才会申请一次位置权限；精确位置仅在本页内存计算距离，不上传至本项目服务器或保存，也不会用于地图打点。</p>
             </div>
-            <button type="button"
-                    class="btn btn-outline-primary cooling-locate-button"
-                    id="coolingLocateButton"
-                    {% if not map_points or not amap_key %}disabled{% endif %}>
-                <i class="bi bi-crosshair me-1" aria-hidden="true"></i>
-                按当前位置找附近
-            </button>
+            <div class="text-lg-end">
+                <button type="button"
+                        class="btn btn-outline-primary cooling-locate-button"
+                        id="coolingLocateButton"
+                    {% if not map_points or not amap_key %}disabled
+                        aria-describedby="coolingLocateAvailability"{% endif %}>
+                    <i class="bi bi-crosshair me-1" aria-hidden="true"></i>
+                    按当前位置找附近
+                </button>
+                {% if not map_points %}
+                <div class="text-muted small mt-1" id="coolingLocateAvailability">当前没有已核验地图点位，暂不能按位置查找。</div>
+                {% elif not amap_key %}
+                <div class="text-muted small mt-1" id="coolingLocateAvailability">地图服务尚未配置，暂不能读取位置。</div>
+                {% endif %}
+            </div>
         </div>
         <div class="cooling-map-canvas" id="coolingMap" role="region" aria-label="都昌县避暑资源地图">
             <div class="cooling-map-fallback">
@@ -127,7 +146,7 @@
                     <div class="text-muted" style="font-size:.85rem;">{{ r.resource_type or '避暑资源' }} · {{ community }}</div>
 
                     <div class="mt-3" style="font-size:.88rem; color:var(--yl-ink-soft);">
-                        <div class="mb-1"><i class="bi bi-clock me-1 text-muted"></i>{{ r.open_hours or '开放时间未标注' }}</div>
+                        <div class="mb-1"><i class="bi bi-clock me-1 text-muted"></i>{{ r.open_hours or '开放时间未核验，请出发前确认' }}</div>
                         <div><i class="bi bi-geo-alt me-1 text-muted"></i>{{ r.address_hint or '地址未标注' }}</div>
                         {% if r.is_accessible %}
                         <div class="mt-1"><i class="bi bi-universal-access me-1 text-muted"></i>适合行动不便老人</div>
@@ -176,7 +195,7 @@
             <div>
                 <span class="section-kicker">预览资料</span>
                 <h2 class="h4 mb-1" id="coolingCandidateTitle">待核验场所预览</h2>
-                <p class="text-muted mb-0">这些信息来自高德公开 POI，仅帮助后续人工核验和联系确认。</p>
+                <p class="text-muted mb-0">这些信息来自高德公开 POI，仅帮助后续人工核验和联系确认。候选资料不参与上方地点、类型或开放条件筛选。</p>
             </div>
             <span class="badge bg-warning-subtle text-warning-emphasis align-self-start">全部待人工核验</span>
         </div>

--- a/templates/cooling.html
+++ b/templates/cooling.html
@@ -27,7 +27,7 @@
                         <div class="v"><span class="num">{{ outdoor_temp }}</span><span class="unit">°C</span></div>
                         <div class="k">{{ cooling_weather_location or current_location or '当前位置' }} · 当前室外</div>
                         {% if cooling_snapshot_meta and cooling_snapshot_meta.id_short %}
-                        <div class="text-muted small mt-1">天气快照 {{ cooling_snapshot_meta.id_short }}{% if cooling_snapshot_meta.fetched_at %} · {{ cooling_snapshot_meta.fetched_at[:16]|replace('T', ' ') }}{% endif %}</div>
+                        <div class="text-muted small mt-1">天气快照 {{ cooling_snapshot_meta.id_short }}{% if cooling_snapshot_meta.display_time %} · 北京时间 {{ cooling_snapshot_meta.display_time }}{% endif %}</div>
                         {% endif %}
                     </div>
                 </div>

--- a/templates/forecast_7day.html
+++ b/templates/forecast_7day.html
@@ -15,8 +15,10 @@
         <div class="row g-3 align-items-end">
             <div class="col-md-8">
                 <label class="form-label">所在地</label>
-                <input type="text" class="form-control" name="location" value="{{ request.args.get('location', current_location) }}" list="locOpts">
+                <input type="text" class="form-control{% if location_error %} is-invalid{% endif %}" name="location" value="{{ location_input if location_input is defined else current_location }}" list="locOpts" aria-describedby="forecastLocationHelp{% if location_error %} forecastLocationError{% endif %}">
                 <datalist id="locOpts">{% for loc in (location_options or []) %}<option value="{{ loc }}"></option>{% endfor %}</datalist>
+                <div class="form-text" id="forecastLocationHelp">目前仅支持都昌县及列表中的乡镇、社区。</div>
+                {% if location_error %}<div class="invalid-feedback" id="forecastLocationError">{{ location_error }}</div>{% endif %}
             </div>
             <div class="col-md-4 d-grid">
                 <button class="btn btn-primary" type="submit"><i class="bi bi-graph-up me-1"></i>生成预测</button>
@@ -24,6 +26,7 @@
         </div>
     </form>
 
+    {% if not location_error %}
     <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3 yl-fade-up yl-fade-up-d2">
         <div class="text-muted" style="font-size:.9rem;">
             来源：{{ forecast_meta.source_label or '和风天气' }}
@@ -31,6 +34,11 @@
             {% if forecast_meta.from_cache %} · 最近一次有效数据{% endif %}
         </div>
     </div>
+    {% else %}
+    <div class="alert alert-warning yl-fade-up yl-fade-up-d2" role="alert" data-error-code="invalid_location">
+        <i class="bi bi-geo-alt me-1"></i>{{ location_error }}
+    </div>
+    {% endif %}
 
     {% if forecast_error %}
     <div class="alert alert-warning yl-fade-up yl-fade-up-d2" role="alert">
@@ -114,7 +122,7 @@
         </div>
         {% endfor %}
     </div>
-    {% else %}
+    {% elif not location_error %}
     <section class="yl-section text-center yl-fade-up yl-fade-up-d2">
         <div style="font-size:2rem; color:var(--yl-orange-500);"><i class="bi bi-cloud-slash"></i></div>
         <h4 class="mt-2" style="font-size:1.05rem;">7 天预报正在更新</h4>
@@ -122,6 +130,7 @@
     </section>
     {% endif %}
 
+    {% if not location_error %}
     <div class="row g-4 mb-4">
         <div class="col-lg-8">
             <section class="yl-section yl-fade-up yl-fade-up-d3">
@@ -176,6 +185,7 @@
             {% endfor %}
         </div>
     </section>
+    {% endif %}
 </div>
 
 <script>

--- a/templates/health_assessment.html
+++ b/templates/health_assessment.html
@@ -1,6 +1,13 @@
 {% extends "base.html" %}
 {% from "partials/metric_info.html" import metric_info with context %}
 {% block title %}健康评估 · 宜老天气通{% endblock %}
+{% set questions = questions or [
+    {'id':'outdoor_exposure','text':'今日户外暴露情况','options':[('low','低,主要在室内'),('medium','中,约 1 到 3 小时'),('high','高,超过 3 小时')]},
+    {'id':'symptom_level','text':'当前不适症状','options':[('none','无明显不适'),('mild','轻微'),('moderate','中等'),('severe','明显或严重')]},
+    {'id':'hydration','text':'今天的饮水情况','options':[('good','充足'),('normal','一般'),('poor','不足')]},
+    {'id':'medication_adherence','text':'近期服药规律性','options':[('good','规律'),('partial','偶尔漏服'),('poor','经常漏服')]},
+    {'id':'sleep_quality','text':'最近睡眠质量','options':[('good','较好'),('fair','一般'),('poor','较差')]}
+] %}
 
 {% block content %}
 <div class="container" style="max-width:900px;">
@@ -19,7 +26,7 @@
         <div class="progress"><div class="progress-bar" id="progressBar" style="width:0%"></div></div>
     </div>
 
-    <form method="POST" action="{{ url_for('user.health_assessment') }}" id="assessForm" class="yl-fade-up yl-fade-up-d2">
+    <form method="POST" action="{{ url_for('user.health_assessment') }}" id="assessForm" class="yl-fade-up yl-fade-up-d2" novalidate>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
         <div class="alert alert-light border small" role="note">
@@ -36,6 +43,10 @@
                 border-color: var(--yl-orange-500);
                 color: #fff;
             }
+            .assessment-question.is-invalid {
+                border-color: var(--bs-danger);
+                box-shadow: 0 0 0 .15rem rgba(220, 53, 69, .12);
+            }
         </style>
 
         <div class="section-heading mb-3">
@@ -43,16 +54,22 @@
             <p>根据你今天的状态与近几天感受,快速完成这份筛查。</p>
         </div>
 
-        {% set questions = questions or [
-            {'id':'outdoor_exposure','text':'今日户外暴露情况','options':[('low','低,主要在室内'),('medium','中,约 1 到 3 小时'),('high','高,超过 3 小时')]},
-            {'id':'symptom_level','text':'当前不适症状','options':[('none','无明显不适'),('mild','轻微'),('moderate','中等'),('severe','明显或严重')]},
-            {'id':'hydration','text':'今天的饮水情况','options':[('good','充足'),('normal','一般'),('poor','不足')]},
-            {'id':'medication_adherence','text':'近期服药规律性','options':[('good','规律'),('partial','偶尔漏服'),('poor','经常漏服')]},
-            {'id':'sleep_quality','text':'最近睡眠质量','options':[('good','较好'),('fair','一般'),('poor','较差')]}
-        ] %}
+        <div class="alert alert-danger{% if not form_errors %} d-none{% endif %}"
+             id="assessmentErrorSummary"
+             role="alert"
+             tabindex="-1"
+             aria-live="assertive">
+            <strong>还差 <span id="assessmentMissingCount">{{ form_errors|length }}</span> 项。</strong>
+            请完成标红的问题后再提交，已选择的答案会保留。
+        </div>
 
         {% for q in questions %}
-        <div class="card mb-3">
+        <div class="card mb-3 assessment-question{% if form_errors.get(q.id) %} is-invalid{% endif %}"
+             id="assessmentQuestion-{{ q.id }}"
+             data-assessment-question="{{ q.id }}"
+             tabindex="-1"
+             {% if first_form_error == q.id %}autofocus{% endif %}
+             {% if form_errors.get(q.id) %}aria-invalid="true"{% endif %}>
             <div class="card-body">
                 <div class="d-flex gap-3">
                     <div class="fw-bold" style="color:var(--yl-orange-500); font-size:1.1rem;">{{ loop.index }}.</div>
@@ -61,10 +78,13 @@
                         <div class="d-flex flex-wrap gap-2">
                             {% for val, label in q.options %}
                             <label class="btn btn-outline-secondary assess-choice">
-                                <input type="radio" name="{{ q.id }}" value="{{ val }}" class="visually-hidden assess-opt" required>
+                                <input type="radio" name="{{ q.id }}" value="{{ val }}" class="visually-hidden assess-opt" {% if form_state.get(q.id) == val %}checked{% endif %}>
                                 {{ label }}
                             </label>
                             {% endfor %}
+                        </div>
+                        <div class="text-danger small mt-2{% if not form_errors.get(q.id) %} d-none{% endif %}" data-assessment-error="{{ q.id }}">
+                            {{ form_errors.get(q.id) or '请选择这一项后再提交。' }}
                         </div>
                     </div>
                 </div>
@@ -293,13 +313,63 @@
         document.getElementById('progressTxt').textContent = n + ' / ' + total;
         document.getElementById('progressBar').style.width = (n / total * 100) + '%';
     }
+    function setQuestionError(name, hasError) {
+        const card = document.querySelector(`[data-assessment-question="${name}"]`);
+        const message = document.querySelector(`[data-assessment-error="${name}"]`);
+        if (card) {
+            card.classList.toggle('is-invalid', hasError);
+            if (hasError) card.setAttribute('aria-invalid', 'true');
+            else card.removeAttribute('aria-invalid');
+        }
+        if (message) message.classList.toggle('d-none', !hasError);
+    }
+    function validateAssessment() {
+        return Array.from(document.querySelectorAll('[data-assessment-question]'))
+            .map(card => card.dataset.assessmentQuestion)
+            .filter(name => !document.querySelector(`.assess-opt[name="${name}"]:checked`));
+    }
     document.querySelectorAll('.assess-opt').forEach(input => {
         input.addEventListener('change', () => {
             syncGroup(input.name);
+            setQuestionError(input.name, false);
             update();
+            const missing = validateAssessment();
+            document.getElementById('assessmentMissingCount').textContent = String(missing.length);
+            summary.classList.toggle('d-none', missing.length === 0);
         });
         syncGroup(input.name);
     });
+    update();
+
+    const form = document.getElementById('assessForm');
+    const summary = document.getElementById('assessmentErrorSummary');
+    if (form && summary) {
+        form.addEventListener('submit', event => {
+            const missing = validateAssessment();
+            document.querySelectorAll('[data-assessment-question]').forEach(card => {
+                setQuestionError(card.dataset.assessmentQuestion, missing.includes(card.dataset.assessmentQuestion));
+            });
+            if (!missing.length) return;
+            event.preventDefault();
+            document.getElementById('assessmentMissingCount').textContent = String(missing.length);
+            summary.classList.remove('d-none');
+            summary.focus({ preventScroll: true });
+            const firstCard = document.querySelector(`[data-assessment-question="${missing[0]}"]`);
+            if (firstCard) {
+                firstCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                firstCard.focus({ preventScroll: true });
+            }
+        });
+    }
+
+    const serverMissing = validateAssessment().filter(name => {
+        const card = document.querySelector(`[data-assessment-question="${name}"]`);
+        return card && card.classList.contains('is-invalid');
+    });
+    if (serverMissing.length) {
+        const firstCard = document.querySelector(`[data-assessment-question="${serverMissing[0]}"]`);
+        if (firstCard) firstCard.focus();
+    }
 })();
 </script>
 {% endblock %}

--- a/templates/heat_vulnerability_preview.html
+++ b/templates/heat_vulnerability_preview.html
@@ -78,6 +78,8 @@
 {% endblock %}
 
 {% block content %}
+{% set full_gis_url = url_for('user.heat_exposure_gis') %}
+{% set has_full_gis_access = current_user.is_authenticated and current_user.role != 'guest' %}
 <div class="hv-shell">
     <section class="hv-hero yl-fade-up" aria-labelledby="heat-preview-title">
         <div class="hv-hero-copy">
@@ -91,6 +93,13 @@
             </p>
             <div class="hv-actions">
                 <a class="btn btn-primary" href="#heat-map">查看聚合地图</a>
+                {% if heat_summary.available and gis_data_url %}
+                {% if has_full_gis_access %}
+                <a class="btn btn-outline-primary" href="{{ full_gis_url }}">打开完整 GIS</a>
+                {% else %}
+                <a class="btn btn-outline-primary" href="{{ url_for('public.login', next=full_gis_url) }}">完整 GIS（需登录）</a>
+                {% endif %}
+                {% endif %}
                 <a class="btn btn-outline-secondary" href="{{ url_for('public.cooling_resources') }}">查看已核验避暑资源</a>
                 {% if heat_summary.available and gis_data_url %}
                 <a class="btn btn-link" href="{{ gis_data_url }}" download="duchang_heat_exposure_cells.geojson">下载公开 GeoJSON</a>
@@ -294,7 +303,13 @@
         </p>
         <div class="hv-actions">
             <a class="btn btn-outline-secondary" href="{{ url_for('public.transparency') }}">查看指标透明度</a>
-            <a class="btn btn-primary" href="{{ url_for('public.login', next=url_for('user.heat_exposure_gis')) }}">登录使用完整 GIS</a>
+            {% if heat_summary.available and gis_data_url %}
+            {% if has_full_gis_access %}
+            <a class="btn btn-primary" href="{{ full_gis_url }}">打开完整 GIS</a>
+            {% else %}
+            <a class="btn btn-primary" href="{{ url_for('public.login', next=full_gis_url) }}">登录使用完整 GIS</a>
+            {% endif %}
+            {% endif %}
         </div>
     </section>
 </div>

--- a/templates/heat_vulnerability_preview.html
+++ b/templates/heat_vulnerability_preview.html
@@ -79,7 +79,7 @@
 
 {% block content %}
 {% set full_gis_url = url_for('user.heat_exposure_gis') %}
-{% set has_full_gis_access = current_user.is_authenticated and current_user.role != 'guest' %}
+{% set has_full_gis_access = current_user.is_authenticated and not (current_user.is_guest|default(false)) %}
 <div class="hv-shell">
     <section class="hv-hero yl-fade-up" aria-labelledby="heat-preview-title">
         <div class="hv-hero-copy">

--- a/templates/http_error.html
+++ b/templates/http_error.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+
+{% block title %}{{ error_title }} · 宜老天气通{% endblock %}
+{% block body_class %}http-error-page{% endblock %}
+
+{% block content %}
+<div class="container py-5" style="max-width: 720px;">
+    <section class="card border-0 shadow-sm text-center">
+        <div class="card-body p-4 p-md-5">
+            <div class="display-5 fw-bold text-primary mb-2">{{ status_code }}</div>
+            <h1 class="h3 mb-3">{{ error_title }}</h1>
+            <p class="text-muted mb-3">{{ error_message }}</p>
+
+            {% if retry_after_seconds is not none %}
+            <p class="mb-4" role="status" aria-live="polite">
+                可在 <strong id="retryCountdown" data-retry-seconds="{{ retry_after_seconds }}">{{ retry_after_seconds }}</strong> 秒后重试。
+            </p>
+            {% endif %}
+
+            <div class="d-flex flex-wrap justify-content-center gap-2">
+                <a class="btn btn-primary" href="{{ url_for('public.index') }}">返回首页</a>
+                <button class="btn btn-outline-secondary" type="button" onclick="history.back()">返回上一页</button>
+            </div>
+
+            {% if request_id %}
+            <div class="small text-muted mt-4">请求编号：{{ request_id }}</div>
+            {% endif %}
+        </div>
+    </section>
+</div>
+
+{% if retry_after_seconds is not none %}
+<script>
+(function () {
+    const counter = document.getElementById('retryCountdown');
+    if (!counter) return;
+    let remaining = Number.parseInt(counter.dataset.retrySeconds || '0', 10);
+    const timer = window.setInterval(function () {
+        remaining = Math.max(0, remaining - 1);
+        counter.textContent = String(remaining);
+        if (remaining === 0) window.clearInterval(timer);
+    }, 1000);
+})();
+</script>
+{% endif %}
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -71,23 +71,22 @@
 
                 <div class="card auth-form-card">
                     <div class="card-body p-4">
-                        <form method="POST" action="{{ url_for('public.login') }}">
+                        <form method="POST" action="{{ url_for('public.login') }}" novalidate>
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             {% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
 
                             <div class="mb-3">
-                                <label for="username" class="form-label">用户名或已验证手机号</label>
-                                <input type="text" class="form-control" id="username" name="username" placeholder="请输入用户名" autocomplete="username" required autofocus>
-                                <small class="text-muted">手机号尚未接入短信验证，保存后仍需使用用户名登录。</small>
+                                <label for="username" class="form-label">用户名</label>
+                                <input type="text" class="form-control" id="username" name="username" value="{{ login_form.get('username', '') }}" placeholder="请输入用户名" autocomplete="username" autofocus>
                             </div>
                             <div class="mb-3">
                                 <label for="password" class="form-label">密码</label>
-                                <input type="password" class="form-control" id="password" name="password" placeholder="请输入密码" required>
+                                <input type="password" class="form-control" id="password" name="password" placeholder="请输入密码" autocomplete="current-password">
                             </div>
 
                             <div class="mb-3 d-flex justify-content-between align-items-center">
                                 <div class="form-check">
-                                    <input type="checkbox" class="form-check-input" id="remember" name="remember" value="1">
+                                    <input type="checkbox" class="form-check-input" id="remember" name="remember" value="1" {% if login_form.get('remember') %}checked{% endif %}>
                                     <label class="form-check-label" for="remember" style="font-size:.9rem;">记住我(30 天)</label>
                                 </div>
                             </div>

--- a/templates/ml_prediction.html
+++ b/templates/ml_prediction.html
@@ -42,8 +42,12 @@
                     {% endif %}
                 </div>
                 <div class="mb-3">
-                    <label class="form-label">年龄</label>
-                    <input type="number" class="form-control" name="age" value="{{ form_state.age if form_state else (age or 65) }}" min="1" max="120">
+                    <label class="form-label" for="mlAge">年龄</label>
+                    <input type="text" inputmode="numeric" pattern="[0-9]*" class="form-control{% if prediction_error and prediction_error.code == 'invalid_age' %} is-invalid{% endif %}" id="mlAge" name="age" value="{{ form_state.age if form_state else (age or 65) }}" aria-describedby="mlAgeHelp{% if prediction_error and prediction_error.code == 'invalid_age' %} mlAgeError{% endif %}" {% if prediction_error and prediction_error.code == 'invalid_age' %}aria-invalid="true"{% endif %}>
+                    <div class="form-text" id="mlAgeHelp">请填写 1 到 120 之间的整数。</div>
+                    {% if prediction_error and prediction_error.code == 'invalid_age' %}
+                    <div class="invalid-feedback" id="mlAgeError">{{ prediction_error.message }}</div>
+                    {% endif %}
                 </div>
                 <div class="alert alert-light border small" role="note">
                     慢病档案不会参与这项类别排序。需要查看慢病与天气的关系，请使用“慢病风险评估”。

--- a/templates/ml_prediction.html
+++ b/templates/ml_prediction.html
@@ -10,9 +10,16 @@
         <p>根据年龄、性别和当前天气，整理需要优先关注的健康类别。分数用于安排日常观察，不代表发病概率，也不能用于诊断。</p>
     </section>
 
+    {% if is_guest %}
+    <div class="alert alert-info yl-fade-up" role="status" data-testid="ml-guest-requirement">
+        <strong>游客可以先浏览这项功能说明。</strong>
+        生成个人类别线索需要<a href="{{ url_for('public.login', next=request.path) }}" class="alert-link">登录正式账号</a>或<a href="{{ url_for('public.register') }}" class="alert-link">注册账号</a>。
+    </div>
+    {% endif %}
+
     <div class="row g-4">
         <div class="col-lg-4">
-            <form method="POST" action="{{ url_for('tools.ml_prediction') }}" class="yl-section yl-fade-up yl-fade-up-d1">
+            <form method="POST" action="{{ url_for('tools.ml_prediction') }}" class="yl-section yl-fade-up yl-fade-up-d1" novalidate>
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <h4 style="font-size:1.05rem;">输入信息</h4>
 
@@ -27,8 +34,12 @@
                 </div>
                 <div class="mb-3">
                     <label class="form-label">所在地</label>
-                    <input type="text" class="form-control" name="location" value="{{ form_state.location if form_state else (current_location or '') }}" list="locOpts">
+                    <input type="text" class="form-control{% if prediction_error and prediction_error.code == 'invalid_location' %} is-invalid{% endif %}" name="location" value="{{ form_state.location if form_state else (current_location or '') }}" list="locOpts" aria-describedby="mlLocationHelp{% if prediction_error and prediction_error.code == 'invalid_location' %} mlLocationError{% endif %}">
                     <datalist id="locOpts">{% for loc in (location_options or []) %}<option value="{{ loc }}"></option>{% endfor %}</datalist>
+                    <div class="form-text" id="mlLocationHelp">目前仅支持都昌县及列表中的乡镇、社区。</div>
+                    {% if prediction_error and prediction_error.code == 'invalid_location' %}
+                    <div class="invalid-feedback" id="mlLocationError">{{ prediction_error.message }}</div>
+                    {% endif %}
                 </div>
                 <div class="mb-3">
                     <label class="form-label">年龄</label>
@@ -37,14 +48,18 @@
                 <div class="alert alert-light border small" role="note">
                     慢病档案不会参与这项类别排序。需要查看慢病与天气的关系，请使用“慢病风险评估”。
                 </div>
+                {% if is_guest %}
+                <a class="btn btn-primary w-100" href="{{ url_for('public.login', next=request.path) }}"><i class="bi bi-box-arrow-in-right me-1"></i>登录后生成</a>
+                {% else %}
                 <button type="submit" class="btn btn-primary w-100"><i class="bi bi-magic me-1"></i>生成类别线索</button>
+                {% endif %}
             </form>
         </div>
 
         <div class="col-lg-8">
             {% if prediction_error %}
             <section class="yl-section yl-fade-up yl-fade-up-d2 mb-3">
-                <div class="alert alert-warning mb-0">健康关注线索暂时无法生成，请稍后再试。</div>
+                <div class="alert alert-warning mb-0" role="alert" data-error-code="{{ prediction_error.code }}">{{ prediction_error.message }}</div>
             </section>
             {% endif %}
             {% if prediction %}

--- a/templates/pair_management.html
+++ b/templates/pair_management.html
@@ -12,6 +12,17 @@
                 为家中老人设置所在地，高温或寒潮来临时及时收到提醒。慢病类别可选填，用于提供更贴合的日常建议。
                 所在地和关联档案仅用于天气查询与提醒，请勿填写精确门牌信息。
             </p>
+            {% if request.args.get('welcome') == '1' and not pair_cards %}
+            <div class="alert alert-success mt-3 mb-0" role="status">
+                <div class="fw-semibold">账号已准备好，按这 3 步开始照护</div>
+                <ol class="mb-0 mt-2 ps-3">
+                    <li>在下方添加需要关注的家人。</li>
+                    <li>核对家人所在县、市或乡镇，无需填写门牌地址。</li>
+                    <li>查看今日风险，再复制提醒发给家人。</li>
+                </ol>
+                <div class="small mt-2">绑定微信小程序是可选步骤，可稍后在个人设置中完成。</div>
+            </div>
+            {% endif %}
             {% if wxpusher_feature_enabled %}
             {% if not current_user.push_enabled or not current_user.wxpusher_uid %}
                 <div class="alert alert-warning mt-3 mb-0">
@@ -256,6 +267,11 @@
                         <div class="text-muted small mt-3">升级链仅记录状态，请结合实际情况与社区沟通。</div>
                     {% else %}
                         <div class="text-muted">暂无监测对象，请先在左侧添加老人并设置所在地。</div>
+                        <ol class="small text-muted mt-3 mb-0 ps-3">
+                            <li>添加家人</li>
+                            <li>核对所在地</li>
+                            <li>查看风险并发送提醒</li>
+                        </ol>
                     {% endif %}
                 </div>
             </div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -178,7 +178,7 @@
                         </div>
                         <div class="mb-3">
                             <label for="confirm_password" class="form-label">确认新密码</label>
-                            <input type="password" class="form-control" id="confirm_password">
+                            <input type="password" class="form-control" id="confirm_password" name="confirm_password" autocomplete="new-password">
                         </div>
                         <button type="submit" class="btn btn-warning">修改密码</button>
                     </form>
@@ -193,12 +193,13 @@
                 </div>
                 <div class="card-body">
                     <p class="text-muted small mb-2">
-                        使用独立的跨端账号页保存手机号，并在复验当前密码后生成 8 位一次性绑定码。
+                        在跨端账号页复验当前密码后生成 8 位一次性绑定码。绑定不需要手机号。
                     </p>
                     <a class="btn btn-primary w-100" href="{{ url_for('public.account_link') }}">
                         <i class="bi bi-link-45deg"></i> 打开跨端账号页
                     </a>
 
+                    {% if current_user.role == 'admin' %}
                     <details class="mt-3">
                         <summary class="small text-muted">旧版 API Token 兼容入口</summary>
                         {% if last_api_token_plain %}
@@ -218,6 +219,7 @@
                             <button type="submit" class="btn btn-outline-secondary btn-sm w-100">生成旧版 Token</button>
                         </form>
                     </details>
+                    {% endif %}
                 </div>
             </div>
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -48,12 +48,19 @@
                             </div>
                             <div class="col-md-4 mb-3">
                                 <label for="community" class="form-label">所属社区</label>
-                                <select class="form-select" id="community" name="community">
+                                <select class="form-select{% if profile_location_error %} is-invalid{% endif %}" id="community" name="community" aria-describedby="profileCommunityHelp{% if profile_location_error %} profileCommunityError{% endif %}" {% if profile_location_error %}aria-invalid="true"{% endif %}>
                                     <option value="">请选择</option>
+                                    {% if profile_location_error and current_user.community %}
+                                        <option value="{{ current_user.community }}" selected>{{ current_user.community }}（不再支持，请重选）</option>
+                                    {% endif %}
                                     {% for comm in communities %}
                                         <option value="{{ comm.name }}" {% if current_user.community == comm.name %}selected{% endif %}>{{ comm.name }}</option>
                                     {% endfor %}
                                 </select>
+                                <div class="form-text" id="profileCommunityHelp">仅支持都昌县及已配置的乡镇、社区，也可以留空。</div>
+                                {% if profile_location_error %}
+                                <div class="invalid-feedback d-block" id="profileCommunityError">历史地点“{{ current_user.community }}”已无法继续使用，请重新选择县内地点或留空。</div>
+                                {% endif %}
                             </div>
                         </div>
 
@@ -212,6 +219,8 @@
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <input type="hidden" name="form_id" value="api_token">
                             <input class="form-control mb-2" name="token_name" placeholder="备注，例如：旧版设备">
+                            <label class="form-label small" for="legacyTokenCurrentPassword">当前密码</label>
+                            <input class="form-control mb-2" type="password" id="legacyTokenCurrentPassword" name="current_password" autocomplete="current-password" required>
                             <div class="form-check mb-2">
                                 <input class="form-check-input" type="checkbox" value="1" name="miniprogram_privacy_consent" id="legacyTokenConsent" required>
                                 <label class="form-check-label small" for="legacyTokenConsent">我确认仅在自己的旧版设备上使用。</label>

--- a/templates/register.html
+++ b/templates/register.html
@@ -92,12 +92,16 @@
                                 </div>
                                 <div class="col-md-4">
                                     <label for="community" class="form-label"><i class="bi bi-geo-alt me-1"></i>所属社区</label>
-                                    <select class="form-select" id="community" name="community">
+                                    <select class="form-select{% if form_errors.get('community') %} is-invalid{% endif %}" id="community" name="community" aria-describedby="communityError" {% if form_errors.get('community') %}aria-invalid="true"{% endif %}>
                                         <option value="">请选择</option>
+                                        {% if form_errors.get('community') and form_data.get('community') %}
+                                            <option value="{{ form_data.get('community') }}" selected>{{ form_data.get('community') }}（无效，请重选）</option>
+                                        {% endif %}
                                         {% for comm in communities %}
                                             <option value="{{ comm.name }}" {% if form_data.get('community') == comm.name %}selected{% endif %}>{{ comm.name }}</option>
                                         {% endfor %}
                                     </select>
+                                    <div class="invalid-feedback" id="communityError">{{ form_errors.get('community', '') }}</div>
                                 </div>
                             </div>
 

--- a/templates/register.html
+++ b/templates/register.html
@@ -19,8 +19,19 @@
 
                 <div class="card auth-form-card">
                     <div class="card-body p-4 p-md-5">
-                        <form method="POST" action="{{ url_for('public.register') }}">
+                        <form method="POST" action="{{ url_for('public.register') }}" novalidate>
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+                            {% if form_errors.get('account') %}
+                            <div class="alert alert-danger" role="alert">
+                                {{ form_errors.get('account') }}
+                            </div>
+                            {% endif %}
+                            {% if form_errors %}
+                            <div class="alert alert-warning" role="status">
+                                请检查下方标出的内容。密码不会被保留，请重新输入。
+                            </div>
+                            {% endif %}
 
                             {# 基础 #}
                             <div class="mb-3" style="font-size:.8rem; color:var(--yl-muted); text-transform:uppercase; letter-spacing:.05em; font-weight:600;">
@@ -32,32 +43,30 @@
                                     <label for="username" class="form-label">
                                         <i class="bi bi-person me-1"></i>用户名 <span style="color:var(--yl-danger);">*</span>
                                     </label>
-                                    <input type="text" class="form-control" id="username" name="username" required>
+                                    <input type="text" class="form-control{% if form_errors.get('username') %} is-invalid{% endif %}" id="username" name="username" value="{{ form_data.get('username', '') }}" autocomplete="username" aria-describedby="usernameError" {% if form_errors.get('username') %}aria-invalid="true"{% endif %}>
+                                    <div class="invalid-feedback" id="usernameError">{{ form_errors.get('username', '') }}</div>
                                 </div>
                                 <div class="col-md-6">
                                     <label for="email" class="form-label">
                                         <i class="bi bi-envelope me-1"></i>邮箱
                                     </label>
-                                    <input type="email" class="form-control" id="email" name="email" placeholder="可选">
-                                </div>
-                                <div class="col-md-6">
-                                    <label for="phone" class="form-label">
-                                        <i class="bi bi-phone me-1"></i>手机号
-                                    </label>
-                                    <input type="tel" class="form-control" id="phone" name="phone" inputmode="tel" autocomplete="tel" placeholder="可选，例如 13800138000">
-                                    <small class="text-muted">当前不发送短信验证码，仅保存为待验证标识，不能用于登录。</small>
+                                    <input type="email" class="form-control{% if form_errors.get('email') %} is-invalid{% endif %}" id="email" name="email" value="{{ form_data.get('email', '') }}" placeholder="可选" autocomplete="email" aria-describedby="emailError" {% if form_errors.get('email') %}aria-invalid="true"{% endif %}>
+                                    <div class="invalid-feedback" id="emailError">{{ form_errors.get('email', '') }}</div>
                                 </div>
                                 <div class="col-md-6">
                                     <label for="password" class="form-label">
                                         <i class="bi bi-lock me-1"></i>密码 <span style="color:var(--yl-danger);">*</span>
                                     </label>
-                                    <input type="password" class="form-control" id="password" name="password" required>
+                                    <input type="password" class="form-control{% if form_errors.get('password') %} is-invalid{% endif %}" id="password" name="password" autocomplete="new-password" aria-describedby="passwordHelp passwordError" {% if form_errors.get('password') %}aria-invalid="true"{% endif %}>
+                                    <div class="form-text" id="passwordHelp">至少 12 位；提交失败后需要重新输入。</div>
+                                    <div class="invalid-feedback" id="passwordError">{{ form_errors.get('password', '') }}</div>
                                 </div>
                                 <div class="col-md-6">
                                     <label for="confirm_password" class="form-label">
                                         <i class="bi bi-lock-fill me-1"></i>确认密码 <span style="color:var(--yl-danger);">*</span>
                                     </label>
-                                    <input type="password" class="form-control" id="confirm_password" name="confirm_password" required>
+                                    <input type="password" class="form-control{% if form_errors.get('confirm_password') %} is-invalid{% endif %}" id="confirm_password" name="confirm_password" autocomplete="new-password" aria-describedby="confirmPasswordError" {% if form_errors.get('confirm_password') %}aria-invalid="true"{% endif %}>
+                                    <div class="invalid-feedback" id="confirmPasswordError">{{ form_errors.get('confirm_password', '') }}</div>
                                 </div>
                             </div>
 
@@ -69,22 +78,24 @@
                             <div class="row g-3">
                                 <div class="col-md-4">
                                     <label for="age" class="form-label"><i class="bi bi-calendar me-1"></i>年龄</label>
-                                    <input type="number" class="form-control" id="age" name="age" min="1" max="120" placeholder="可选">
+                                    <input type="number" class="form-control{% if form_errors.get('age') %} is-invalid{% endif %}" id="age" name="age" value="{{ form_data.get('age', '') }}" min="1" max="150" placeholder="可选" aria-describedby="ageError" {% if form_errors.get('age') %}aria-invalid="true"{% endif %}>
+                                    <div class="invalid-feedback" id="ageError">{{ form_errors.get('age', '') }}</div>
                                 </div>
                                 <div class="col-md-4">
                                     <label for="gender" class="form-label"><i class="bi bi-gender-ambiguous me-1"></i>性别</label>
-                                    <select class="form-select" id="gender" name="gender">
+                                    <select class="form-select{% if form_errors.get('gender') %} is-invalid{% endif %}" id="gender" name="gender" aria-describedby="genderError" {% if form_errors.get('gender') %}aria-invalid="true"{% endif %}>
                                         <option value="">请选择</option>
-                                        <option value="男性">男性</option>
-                                        <option value="女性">女性</option>
+                                        <option value="男性" {% if form_data.get('gender') == '男性' %}selected{% endif %}>男性</option>
+                                        <option value="女性" {% if form_data.get('gender') == '女性' %}selected{% endif %}>女性</option>
                                     </select>
+                                    <div class="invalid-feedback" id="genderError">{{ form_errors.get('gender', '') }}</div>
                                 </div>
                                 <div class="col-md-4">
                                     <label for="community" class="form-label"><i class="bi bi-geo-alt me-1"></i>所属社区</label>
                                     <select class="form-select" id="community" name="community">
                                         <option value="">请选择</option>
                                         {% for comm in communities %}
-                                            <option value="{{ comm.name }}">{{ comm.name }}</option>
+                                            <option value="{{ comm.name }}" {% if form_data.get('community') == comm.name %}selected{% endif %}>{{ comm.name }}</option>
                                         {% endfor %}
                                     </select>
                                 </div>

--- a/templates/risk.html
+++ b/templates/risk.html
@@ -133,10 +133,10 @@
             {% endif %}
             <div class="card shadow-sm mb-3">
                 <div class="card-body">
-                    <h6 class="mb-2"><i class="bi bi-clipboard-check"></i> 去宜老平安小程序打卡</h6>
-                    <p class="text-muted small">网页会先说明交接方式；实际确认和求助在微信小程序完成。</p>
+                    <h6 class="mb-2"><i class="bi bi-clipboard-check"></i> {% if config.get('WECHAT_FORMAL_RUNTIME') %}正式行动交接{% else %}在网页记录今天{% endif %}</h6>
+                    <p class="text-muted small">{% if config.get('WECHAT_FORMAL_RUNTIME') %}网页会先说明交接方式；实际确认和求助在微信小程序完成。{% else %}打开网页行动入口，使用短码完成今日确认或求助。{% endif %}</p>
                     <a class="btn btn-primary w-100" href="{{ url_for('public.elder_entry') }}">
-                        查看小程序交接方式
+                        {% if config.get('WECHAT_FORMAL_RUNTIME') %}查看正式行动交接{% else %}打开网页行动入口{% endif %}
                     </a>
                 </div>
             </div>

--- a/templates/risk.html
+++ b/templates/risk.html
@@ -10,6 +10,15 @@
         <div class="col-12">
             <h1 class="h2"><i class="bi bi-thermometer-sun"></i> 都昌高温风险与老人防护行动</h1>
             <p class="text-muted mb-0">基于都昌县当前天气的通用行动提示（不提供医疗诊断或治疗建议）。</p>
+            <p class="small text-muted mt-2 mb-0"
+               {% if weather_snapshot_id %}data-weather-snapshot-id="{{ weather_snapshot_id }}"{% endif %}>
+                {% if weather_snapshot_id %}
+                    数据更新时间：<time datetime="{{ weather_snapshot_fetched_at }}">{{ weather_snapshot_display_time }}</time>
+                    · 数据编号 {{ weather_snapshot_id[:8] }}
+                {% else %}
+                    暂无可用的公开天气快照
+                {% endif %}
+            </p>
         </div>
     </div>
 
@@ -38,13 +47,13 @@
                     <div class="mb-3" id="heatRiskAdjust" data-heat-risk-score="{{ heat_result.risk_score if heat_result and heat_result.risk_score is not none else 0 }}">
                         <div class="d-flex flex-wrap align-items-center gap-2">
                             <span class="text-muted small">个人阈值 {{ metric_info('personal_threshold') }}</span>
-                            <div class="btn-group btn-group-sm" role="group" aria-label="Heat threshold adjust">
+                            <div class="btn-group" role="group" aria-label="调整个人高温阈值">
                                 <input type="radio" class="btn-check" name="heatAdjustRisk" id="heatAdjustRiskLow" value="-0.1" data-heat-adjust>
-                                <label class="btn btn-outline-secondary" for="heatAdjustRiskLow">-0.1</label>
+                                <label class="btn btn-outline-secondary px-3 py-2" for="heatAdjustRiskLow">-0.1</label>
                                 <input type="radio" class="btn-check" name="heatAdjustRisk" id="heatAdjustRiskMid" value="0" data-heat-adjust>
-                                <label class="btn btn-outline-secondary" for="heatAdjustRiskMid">0</label>
+                                <label class="btn btn-outline-secondary px-3 py-2" for="heatAdjustRiskMid">0</label>
                                 <input type="radio" class="btn-check" name="heatAdjustRisk" id="heatAdjustRiskHigh" value="0.1" data-heat-adjust>
-                                <label class="btn btn-outline-secondary" for="heatAdjustRiskHigh">+0.1</label>
+                                <label class="btn btn-outline-secondary px-3 py-2" for="heatAdjustRiskHigh">+0.1</label>
                             </div>
                             <span class="badge bg-secondary" id="heatAdjustedBadge">--</span>
                             <span class="text-muted small">仅保存在本机</span>
@@ -77,11 +86,12 @@
             {% else %}
             <div class="card shadow-sm border-warning">
                 <div class="card-header bg-warning-subtle text-warning-emphasis">
-                    <h5 class="mb-0"><i class="bi bi-cloud-slash"></i> 天气更新中</h5>
+                    <h5 class="mb-0"><i class="bi bi-cloud-slash"></i> 公开天气快照暂未就绪，天气更新中</h5>
                 </div>
                 <div class="card-body">
                     <div class="mb-2 text-muted">地区：{{ location }}</div>
-                    <p class="mb-0">风险等级暂不显示。你可以先查看通用防护和附近避暑资源。</p>
+                    <p class="mb-2">风险等级暂不显示。此页为公开数据，登录不会改变当前快照状态。</p>
+                    <p class="mb-0 text-muted small">系统完成下一次县级天气同步后会自动恢复；现在可先查看通用防护和附近避暑资源。</p>
                 </div>
             </div>
             {% endif %}
@@ -123,10 +133,10 @@
             {% endif %}
             <div class="card shadow-sm mb-3">
                 <div class="card-body">
-                    <h6 class="mb-2"><i class="bi bi-clipboard-check"></i> 去行动打卡</h6>
-                    <p class="text-muted small">使用短码完成今日确认或求助。</p>
+                    <h6 class="mb-2"><i class="bi bi-clipboard-check"></i> 去宜老平安小程序打卡</h6>
+                    <p class="text-muted small">网页会先说明交接方式；实际确认和求助在微信小程序完成。</p>
                     <a class="btn btn-primary w-100" href="{{ url_for('public.elder_entry') }}">
-                        进入行动入口
+                        查看小程序交接方式
                     </a>
                 </div>
             </div>

--- a/templates/user_dashboard.html
+++ b/templates/user_dashboard.html
@@ -87,7 +87,7 @@
                 </p>
 
                 <div class="yl-academic-actions">
-                    <a class="btn btn-primary" href="{{ url_for('public.elder_entry') }}">去宜老平安小程序打卡</a>
+                    <a class="btn btn-primary" href="{{ url_for('public.elder_entry') }}">{% if config.get('WECHAT_FORMAL_RUNTIME') %}查看正式行动交接{% else %}在网页记录今天{% endif %}</a>
                     <a class="btn btn-outline-secondary" href="{{ url_for('tools.forecast_7day') }}">看 7 天趋势</a>
                 </div>
 
@@ -182,7 +182,7 @@
             <strong>{{ heat_actions[0].title }}</strong>
             <p>{{ heat_actions[0].detail }}</p>
         </div>
-        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('public.elder_entry') }}">查看小程序交接方式 <i class="bi bi-arrow-right"></i></a>
+        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('public.elder_entry') }}">{% if config.get('WECHAT_FORMAL_RUNTIME') %}查看正式行动交接{% else %}在网页记录今天{% endif %} <i class="bi bi-arrow-right"></i></a>
     </section>
     {% endif %}
 
@@ -224,7 +224,7 @@
                         <img src="{{ url_for('static', filename='illustrations/dashboard/today-actions.png') }}" alt="" width="1254" height="1254" loading="lazy" decoding="async">
                     </div>
                 </div>
-                <a class="btn btn-sm btn-outline-primary" href="{{ url_for('public.elder_entry') }}">去宜老平安小程序打卡 <i class="bi bi-arrow-right"></i></a>
+                <a class="btn btn-sm btn-outline-primary" href="{{ url_for('public.elder_entry') }}">{% if config.get('WECHAT_FORMAL_RUNTIME') %}查看正式行动交接{% else %}打开网页行动入口{% endif %} <i class="bi bi-arrow-right"></i></a>
             </div>
             <div class="yl-action-list mt-3">
                 {% if not weather_available %}

--- a/templates/user_dashboard.html
+++ b/templates/user_dashboard.html
@@ -60,6 +60,11 @@
                     <span>家庭照护今日页</span>
                     <span>{{ today_date or '今天' }}</span>
                     <span><i class="bi bi-geo-alt"></i> {{ current_location or '未设置' }}</span>
+                    {% if weather_snapshot_id %}
+                    <span data-weather-snapshot-id="{{ weather_snapshot_id }}">
+                        数据 {{ weather_snapshot_id[:8] }} · {{ weather_snapshot_display_time }}
+                    </span>
+                    {% endif %}
                 </div>
                 <h1>
                     {% if risk_level in ['high', 'extreme'] %}
@@ -82,7 +87,7 @@
                 </p>
 
                 <div class="yl-academic-actions">
-                    <a class="btn btn-primary" href="{{ url_for('public.action_check') }}">记录今天是否做到</a>
+                    <a class="btn btn-primary" href="{{ url_for('public.elder_entry') }}">去宜老平安小程序打卡</a>
                     <a class="btn btn-outline-secondary" href="{{ url_for('tools.forecast_7day') }}">看 7 天趋势</a>
                 </div>
 
@@ -113,7 +118,7 @@
                     <span>当前温度</span>
                     <strong>
                     {% if weather_available and weather.temperature is not none %}
-                        <span class="yl-count" data-target="{{ weather.temperature }}" data-decimals="0">{{ weather.temperature }}</span>
+                        <span>{{ weather.temperature }}</span>
                     {% else %}
                         --
                     {% endif %}<small>°C</small>
@@ -135,7 +140,7 @@
                         <span>健康风险 {{ metric_info('heat_risk_score', heat_context) }}</span>
                         <strong class="{{ risk_score_class }}">
                             {% if risk_score is not none %}
-                                <span class="yl-count" data-target="{{ risk_score }}" data-decimals="0">{{ risk_score }}</span>
+                                <span>{{ risk_score }}</span>
                             {% else %}
                                 --
                             {% endif %}
@@ -177,7 +182,7 @@
             <strong>{{ heat_actions[0].title }}</strong>
             <p>{{ heat_actions[0].detail }}</p>
         </div>
-        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('public.action_check') }}">去打卡 <i class="bi bi-arrow-right"></i></a>
+        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('public.elder_entry') }}">查看小程序交接方式 <i class="bi bi-arrow-right"></i></a>
     </section>
     {% endif %}
 

--- a/templates/user_dashboard.html
+++ b/templates/user_dashboard.html
@@ -224,7 +224,7 @@
                         <img src="{{ url_for('static', filename='illustrations/dashboard/today-actions.png') }}" alt="" width="1254" height="1254" loading="lazy" decoding="async">
                     </div>
                 </div>
-                <a class="btn btn-sm btn-outline-primary" href="{{ url_for('public.action_check') }}">打卡 <i class="bi bi-arrow-right"></i></a>
+                <a class="btn btn-sm btn-outline-primary" href="{{ url_for('public.elder_entry') }}">去宜老平安小程序打卡 <i class="bi bi-arrow-right"></i></a>
             </div>
             <div class="yl-action-list mt-3">
                 {% if not weather_available %}

--- a/tests/heat_exposure_gis_amap.test.js
+++ b/tests/heat_exposure_gis_amap.test.js
@@ -67,6 +67,72 @@ function loadPercentileText() {
   return Function(source)();
 }
 
+function loadCameraTransactionHarness() {
+  const frames = new Map();
+  let nextFrameId = 1;
+  const state = {
+    map: {},
+    renderFrame: null,
+    cameraInMotion: false,
+    cameraSettleFrame: null,
+    hoverIndex: 8,
+    drawCache: [{polygons: []}],
+    hitBuckets: new Map([['0:0', [0]]]),
+    renderCalls: 0,
+  };
+  const ui = {gridCanvas: {hidden: false}};
+  const window = {
+    requestAnimationFrame(callback) {
+      const frameId = nextFrameId;
+      nextFrameId += 1;
+      frames.set(frameId, callback);
+      return frameId;
+    },
+    cancelAnimationFrame(frameId) {
+      frames.delete(frameId);
+    },
+  };
+  let tooltipHides = 0;
+  const hideMapTooltip = () => {
+    tooltipHides += 1;
+  };
+  const factory = Function(
+    'state',
+    'ui',
+    'window',
+    'hideMapTooltip',
+    [
+      'function renderMapCanvas() {',
+      '  state.renderFrame = null;',
+      '  state.renderCalls += 1;',
+      '  ui.gridCanvas.hidden = false;',
+      '}',
+      functionSource('scheduleMapRender'),
+      functionSource('beginCameraTransaction'),
+      functionSource('settleCameraTransaction'),
+      'return {beginCameraTransaction, settleCameraTransaction};',
+    ].join('\n'),
+  );
+  const camera = factory(state, ui, window, hideMapTooltip);
+
+  function flushNextFrame() {
+    const next = frames.entries().next();
+    assert.equal(next.done, false, '预期存在待执行的动画帧');
+    const [frameId, callback] = next.value;
+    frames.delete(frameId);
+    callback();
+  }
+
+  return {
+    ...camera,
+    state,
+    ui,
+    frames,
+    flushNextFrame,
+    tooltipHides: () => tooltipHides,
+  };
+}
+
 test('高德显示转换只生成 GCJ-02 副本，不修改科研 WGS84 几何', () => {
   const { wgs84ToGcj02, displayShape } = loadDisplayTransform();
   const feature = {
@@ -132,13 +198,81 @@ test('地图手势结束后才重绘，命中索引不会逐次扫描全部网�
   assert.match(script, /map\.on\('moveend'/);
   assert.match(script, /map\.on\('zoomstart'/);
   assert.match(script, /map\.on\('zoomend'/);
-  assert.match(functionSource('suspendMapCanvas'), /state\.drawCache = \[\]/);
-  assert.match(functionSource('suspendMapCanvas'), /state\.hitBuckets = new Map\(\)/);
+  assert.match(functionSource('beginCameraTransaction'), /state\.drawCache = \[\]/);
+  assert.match(functionSource('beginCameraTransaction'), /state\.hitBuckets = new Map\(\)/);
   assert.match(functionSource('cellAtPixel'), /ui\.gridCanvas\.hidden/);
   assert.doesNotMatch(functionSource('updateMapHover'), /scheduleMapRender/);
   assert.doesNotMatch(functionSource('renderMapCanvas'), /hoverIndex/);
   assert.doesNotMatch(script, /map\.on\('mapmove'/);
   assert.doesNotMatch(script, /map\.on\('zoomchange'/);
+});
+
+test('zoomstart 后交错 movestart，即使缺少 moveend 也会恢复 Canvas', () => {
+  const harness = loadCameraTransactionHarness();
+
+  harness.beginCameraTransaction();
+  harness.beginCameraTransaction();
+  harness.settleCameraTransaction();
+
+  assert.equal(harness.state.cameraInMotion, true);
+  assert.equal(harness.ui.gridCanvas.hidden, true);
+  assert.deepEqual(harness.state.drawCache, []);
+  assert.equal(harness.state.hitBuckets.size, 0);
+  assert.equal(harness.tooltipHides(), 2);
+  harness.flushNextFrame();
+  assert.equal(harness.state.cameraInMotion, false);
+  assert.notEqual(harness.state.renderFrame, null, '结束事务后应安排重绘');
+  harness.flushNextFrame();
+  assert.equal(harness.ui.gridCanvas.hidden, false);
+  assert.equal(harness.state.renderCalls, 1);
+});
+
+test('movestart 后交错 zoomstart，即使缺少 zoomend 也会恢复 Canvas', () => {
+  const harness = loadCameraTransactionHarness();
+
+  harness.beginCameraTransaction();
+  harness.beginCameraTransaction();
+  harness.settleCameraTransaction();
+  harness.flushNextFrame();
+
+  assert.equal(harness.state.cameraInMotion, false);
+  assert.notEqual(harness.state.renderFrame, null, '结束事务后应安排重绘');
+  harness.flushNextFrame();
+  assert.equal(harness.ui.gridCanvas.hidden, false);
+  assert.equal(harness.state.renderCalls, 1);
+});
+
+test('新的 start 会取消待结算帧，长拖拽期间不会提前重绘', () => {
+  const harness = loadCameraTransactionHarness();
+
+  harness.beginCameraTransaction();
+  harness.settleCameraTransaction();
+  assert.equal(harness.frames.size, 1);
+  harness.beginCameraTransaction();
+
+  assert.equal(harness.frames.size, 0);
+  assert.equal(harness.state.cameraInMotion, true);
+  assert.equal(harness.ui.gridCanvas.hidden, true);
+  assert.equal(harness.state.renderCalls, 0);
+  assert.doesNotMatch(functionSource('settleCameraTransaction'), /setTimeout/);
+});
+
+test('后续 end 会重新校准稳定帧并再次重绘', () => {
+  const harness = loadCameraTransactionHarness();
+
+  harness.beginCameraTransaction();
+  harness.settleCameraTransaction();
+  harness.settleCameraTransaction();
+  assert.equal(harness.frames.size, 1);
+  harness.flushNextFrame();
+  harness.flushNextFrame();
+  assert.equal(harness.state.renderCalls, 1);
+
+  harness.settleCameraTransaction();
+  harness.flushNextFrame();
+  harness.flushNextFrame();
+  assert.equal(harness.ui.gridCanvas.hidden, false);
+  assert.equal(harness.state.renderCalls, 2);
 });
 
 test('温差图层的对称中性色带包含正负边界值', () => {

--- a/tests/test_auth_onboarding.py
+++ b/tests/test_auth_onboarding.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """账号首登、表单重试和导航三态回归。"""
 
+import pytest
+
 
 def _set_csrf(client, token):
     with client.session_transaction() as flask_session:
@@ -28,6 +30,17 @@ def _login(client, username, csrf='auth-onboarding-login-csrf'):
         },
         follow_redirects=False,
     )
+
+
+def _register_payload(username, csrf, *, community=''):
+    return {
+        'username': username,
+        'email': f'{username}@example.com',
+        'password': 'RegistrationPassword1!',
+        'confirm_password': 'RegistrationPassword1!',
+        'community': community,
+        'csrf_token': csrf,
+    }
 
 
 def test_register_aggregates_errors_and_preserves_only_safe_fields(
@@ -100,6 +113,149 @@ def test_register_clears_guest_identity_and_starts_non_persistent_session(
     assert welcome.status_code == 200
     assert '账号已准备好，按这 3 步开始照护' in body
     assert '添加需要关注的家人' in body
+
+
+@pytest.mark.parametrize(
+    'invalid_location',
+    ('北京', '116.20,29.27', '101240201'),
+)
+def test_register_rejects_external_coordinate_and_qweather_locations_inline(
+    client,
+    db_session,
+    invalid_location,
+):
+    from core.db_models import User
+
+    csrf = 'register-invalid-location-csrf'
+    _set_csrf(client, csrf)
+    response = client.post(
+        '/register',
+        data=_register_payload(
+            f'location_case_{len(invalid_location)}_{ord(invalid_location[0])}',
+            csrf,
+            community=invalid_location,
+        ),
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 422
+    assert '目前仅支持都昌县及已配置的乡镇、社区' in body
+    assert f'value="{invalid_location}" selected' in body
+    assert User.query.count() == 0
+
+
+@pytest.mark.parametrize(
+    ('username', 'submitted_location', 'expected_location'),
+    (
+        ('register_blank_location', '', None),
+        ('register_county_community', '县内测试社区', '县内测试社区'),
+    ),
+)
+def test_register_accepts_blank_or_configured_county_community(
+    client,
+    db_session,
+    username,
+    submitted_location,
+    expected_location,
+):
+    from core.db_models import Community, User
+
+    if submitted_location:
+        db_session.add(Community(name=submitted_location, location='都昌县'))
+        db_session.commit()
+    csrf = f'{username}-csrf'
+    _set_csrf(client, csrf)
+    response = client.post(
+        '/register',
+        data=_register_payload(
+            username,
+            csrf,
+            community=submitted_location,
+        ),
+        follow_redirects=False,
+    )
+
+    assert response.status_code in (302, 303)
+    user = User.query.filter_by(username=username).one()
+    assert user.community == expected_location
+    assert user.last_login is not None
+
+
+def test_register_commits_once_before_replacing_guest_identity(
+    app,
+    client,
+    db_session,
+    monkeypatch,
+):
+    from core.db_models import User
+    from core.extensions import db
+
+    app.config['WECHAT_FORMAL_RUNTIME'] = False
+    app.config['WEB_PRIVATE_FEATURES_ENABLED'] = True
+    client.get('/guest', follow_redirects=False)
+    csrf = 'register-single-commit-csrf'
+    _set_csrf(client, csrf)
+    real_commit = db.session.commit
+    commit_calls = 0
+
+    def commit_once():
+        nonlocal commit_calls
+        commit_calls += 1
+        if commit_calls > 1:
+            raise AssertionError('注册成功路径不得执行第二次提交')
+        return real_commit()
+
+    monkeypatch.setattr(db.session, 'commit', commit_once)
+    response = client.post(
+        '/register',
+        data=_register_payload('single_commit_register', csrf),
+        follow_redirects=False,
+    )
+    monkeypatch.setattr(db.session, 'commit', real_commit)
+
+    assert response.status_code in (302, 303)
+    assert commit_calls == 1
+    user = User.query.filter_by(username='single_commit_register').one()
+    assert user.last_login is not None
+    with client.session_transaction() as flask_session:
+        assert flask_session.get('_user_id') == user.get_id()
+        assert 'guest_id' not in flask_session
+        assert 'guest_profile' not in flask_session
+
+
+def test_register_transaction_failure_keeps_guest_identity_and_rolls_back(
+    client,
+    db_session,
+    monkeypatch,
+):
+    from core.db_models import User
+    from core.extensions import db
+    from sqlalchemy.exc import OperationalError
+
+    client.get('/guest', follow_redirects=False)
+    with client.session_transaction() as flask_session:
+        guest_user_id = flask_session.get('_user_id')
+        guest_id = flask_session.get('guest_id')
+    csrf = 'register-transaction-failure-csrf'
+    _set_csrf(client, csrf)
+    real_commit = db.session.commit
+
+    def fail_commit():
+        raise OperationalError('INSERT users', {}, RuntimeError('database unavailable'))
+
+    monkeypatch.setattr(db.session, 'commit', fail_commit)
+    response = client.post(
+        '/register',
+        data=_register_payload('failed_reg_txn', csrf),
+    )
+    monkeypatch.setattr(db.session, 'commit', real_commit)
+
+    assert response.status_code == 503
+    assert '注册暂时无法完成，请稍后重试' in response.get_data(as_text=True)
+    assert User.query.filter_by(username='failed_reg_txn').first() is None
+    with client.session_transaction() as flask_session:
+        assert flask_session.get('_user_id') == guest_user_id
+        assert flask_session.get('guest_id') == guest_id
 
 
 def test_register_miniprogram_only_runtime_keeps_account_link_landing(
@@ -221,3 +377,95 @@ def test_ordinary_profile_hides_legacy_token_and_password_needs_confirmation(
     db_session.refresh(user)
     assert user.check_password('ExistingPassword1!')
     assert not user.check_password('ChangedPassword1!')
+
+
+def test_profile_rejects_external_location_and_prompts_for_legacy_value(
+    client,
+    db_session,
+):
+    user = _create_user(db_session, username='profile-location-user')
+    user.community = '北京'
+    db_session.commit()
+    _login(client, 'profile-location-user')
+
+    page = client.get('/profile')
+    body = page.get_data(as_text=True)
+    assert page.status_code == 200
+    assert '历史地点“北京”已无法继续使用' in body
+    assert '北京（不再支持，请重选）' in body
+
+    _set_csrf(client, 'profile-invalid-location-csrf')
+    response = client.post(
+        '/profile',
+        data={
+            'form_id': 'basic',
+            'age': '66',
+            'gender': '男性',
+            'community': '101240201',
+            'email': '',
+            'csrf_token': 'profile-invalid-location-csrf',
+        },
+        follow_redirects=True,
+    )
+    assert '目前仅支持都昌县及已配置的乡镇、社区' in response.get_data(as_text=True)
+    db_session.refresh(user)
+    assert user.community == '北京'
+
+
+def test_location_write_uses_same_county_resolver_for_user_and_guest(
+    client,
+    db_session,
+):
+    from core.db_models import Community
+
+    db_session.add(Community(name='县内定位社区', location='都昌县'))
+    db_session.commit()
+    user = _create_user(db_session, username='location-write-user')
+    _login(client, 'location-write-user')
+
+    _set_csrf(client, 'location-user-invalid-csrf')
+    invalid = client.post(
+        '/location',
+        data={'location': '116.20,29.27', 'csrf_token': 'location-user-invalid-csrf'},
+        follow_redirects=True,
+    )
+    assert '目前仅支持都昌县及已配置的乡镇、社区' in invalid.get_data(as_text=True)
+    db_session.refresh(user)
+    assert user.community == '朝阳社区'
+
+    _set_csrf(client, 'location-user-valid-csrf')
+    valid = client.post(
+        '/location',
+        data={'location': '县内定位社区', 'csrf_token': 'location-user-valid-csrf'},
+        follow_redirects=False,
+    )
+    assert valid.status_code in (302, 303)
+    db_session.refresh(user)
+    assert user.community == '县内定位社区'
+
+    _set_csrf(client, 'location-user-logout-csrf')
+    client.post(
+        '/logout',
+        data={'csrf_token': 'location-user-logout-csrf'},
+        follow_redirects=False,
+    )
+    client.get('/guest', follow_redirects=False)
+    _set_csrf(client, 'location-guest-valid-csrf')
+    guest_valid = client.post(
+        '/location',
+        data={'location': '县内定位社区', 'csrf_token': 'location-guest-valid-csrf'},
+        follow_redirects=False,
+    )
+    assert guest_valid.status_code in (302, 303)
+    with client.session_transaction() as flask_session:
+        assert flask_session['guest_profile']['community'] == '县内定位社区'
+
+    _set_csrf(client, 'location-guest-invalid-csrf')
+    guest_invalid = client.post(
+        '/location',
+        data={'location': '北京', 'csrf_token': 'location-guest-invalid-csrf'},
+        follow_redirects=False,
+    )
+    assert guest_invalid.status_code in (302, 303)
+    with client.session_transaction() as flask_session:
+        assert flask_session['guest_profile']['community'] == '县内定位社区'

--- a/tests/test_auth_onboarding.py
+++ b/tests/test_auth_onboarding.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+"""账号首登、表单重试和导航三态回归。"""
+
+
+def _set_csrf(client, token):
+    with client.session_transaction() as flask_session:
+        flask_session['_csrf_token'] = token
+
+
+def _create_user(db_session, username='auth-onboarding-user', role='user'):
+    from core.db_models import User
+
+    user = User(username=username, role=role, community='朝阳社区')
+    user.set_password('ExistingPassword1!')
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+def _login(client, username, csrf='auth-onboarding-login-csrf'):
+    _set_csrf(client, csrf)
+    return client.post(
+        '/login',
+        data={
+            'username': username,
+            'password': 'ExistingPassword1!',
+            'csrf_token': csrf,
+        },
+        follow_redirects=False,
+    )
+
+
+def test_register_aggregates_errors_and_preserves_only_safe_fields(
+    client,
+    db_session,
+):
+    _set_csrf(client, 'register-errors-csrf')
+    response = client.post(
+        '/register',
+        data={
+            'username': 'x',
+            'email': 'remember-me-invalid-email',
+            'password': 'short',
+            'confirm_password': 'secret-different',
+            'age': '999',
+            'gender': '任意值',
+            'community': '朝阳社区',
+            'csrf_token': 'register-errors-csrf',
+        },
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 422
+    assert '用户名长度需在3-25字符之间' in body
+    assert '密码长度至少12位' in body
+    assert '两次输入的密码不一致' in body
+    assert '邮箱格式不正确' in body
+    assert '年龄需在1-150之间' in body
+    assert '性别选择不正确' in body
+    assert 'value="x"' in body
+    assert 'remember-me-invalid-email' in body
+    assert 'value="short"' not in body
+    assert 'secret-different' not in body
+
+
+def test_register_clears_guest_identity_and_starts_non_persistent_session(
+    app,
+    client,
+    db_session,
+):
+    app.config['WECHAT_FORMAL_RUNTIME'] = False
+    app.config['WEB_PRIVATE_FEATURES_ENABLED'] = True
+    client.get('/guest', follow_redirects=False)
+    _set_csrf(client, 'register-success-csrf')
+
+    response = client.post(
+        '/register',
+        data={
+            'username': 'new_care_account',
+            'email': 'new-care@example.com',
+            'password': 'NewCarePassword1!',
+            'confirm_password': 'NewCarePassword1!',
+            'csrf_token': 'register-success-csrf',
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code in (302, 303)
+    assert response.headers['Location'].endswith('/pairs?welcome=1')
+    assert 'remember_token=' not in '\n'.join(
+        response.headers.getlist('Set-Cookie')
+    )
+    with client.session_transaction() as flask_session:
+        assert flask_session.get('_user_id')
+        assert 'guest_id' not in flask_session
+        assert 'guest_profile' not in flask_session
+
+    welcome = client.get('/pairs?welcome=1')
+    body = welcome.get_data(as_text=True)
+    assert welcome.status_code == 200
+    assert '账号已准备好，按这 3 步开始照护' in body
+    assert '添加需要关注的家人' in body
+
+
+def test_register_miniprogram_only_runtime_keeps_account_link_landing(
+    app,
+    client,
+    db_session,
+):
+    app.config['WECHAT_FORMAL_RUNTIME'] = True
+    app.config['WEB_PRIVATE_FEATURES_ENABLED'] = False
+    _set_csrf(client, 'register-mini-only-csrf')
+
+    response = client.post(
+        '/register',
+        data={
+            'username': 'mini_only_new_user',
+            'password': 'MiniOnlyPassword1!',
+            'confirm_password': 'MiniOnlyPassword1!',
+            'csrf_token': 'register-mini-only-csrf',
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code in (302, 303)
+    assert response.headers['Location'].endswith('/account-link')
+
+
+def test_login_retry_preserves_identifier_and_remember_without_password(
+    client,
+    db_session,
+):
+    _set_csrf(client, 'login-retry-csrf')
+    response = client.post(
+        '/login',
+        data={
+            'username': 'retry-name',
+            'password': 'NeverRenderThisPassword1!',
+            'remember': '1',
+            'csrf_token': 'login-retry-csrf',
+        },
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert 'value="retry-name"' in body
+    assert 'id="remember" name="remember" value="1" checked' in body
+    assert 'NeverRenderThisPassword1!' not in body
+    assert '用户名或密码错误' in body
+
+
+def test_register_and_login_copy_only_promises_username_login(client, db_session):
+    register_page = client.get('/register').get_data(as_text=True)
+    login_page = client.get('/login').get_data(as_text=True)
+
+    assert 'name="phone"' not in register_page
+    assert '>用户名<' in login_page
+    assert '用户名或已验证手机号' not in login_page
+
+
+def test_navigation_distinguishes_anonymous_guest_and_real_user(
+    client,
+    db_session,
+):
+    anonymous = client.get('/login').get_data(as_text=True)
+    assert '登录正式账号' not in anonymous
+    assert '结束游客体验' not in anonymous
+    assert '>退出<' not in anonymous
+
+    client.get('/guest', follow_redirects=False)
+    guest = client.get('/login').get_data(as_text=True)
+    assert '登录正式账号' in guest
+    assert '注册账号' in guest
+    assert '结束游客体验' in guest
+
+    logout_csrf = 'guest-finish-csrf'
+    _set_csrf(client, logout_csrf)
+    client.post(
+        '/logout',
+        data={'csrf_token': logout_csrf},
+        follow_redirects=False,
+    )
+    _create_user(db_session, username='real-nav-user')
+    _login(client, 'real-nav-user')
+    real = client.get('/login').get_data(as_text=True)
+    assert '>退出<' in real
+    assert '结束游客体验' not in real
+
+
+def test_account_link_says_phone_is_optional(client, db_session):
+    _create_user(db_session, username='link-copy-user')
+    _login(client, 'link-copy-user')
+
+    body = client.get('/account-link').get_data(as_text=True)
+    assert '不需要填写手机号' in body
+    assert '不影响小程序绑定' in body
+
+
+def test_ordinary_profile_hides_legacy_token_and_password_needs_confirmation(
+    client,
+    db_session,
+):
+    user = _create_user(db_session, username='profile-confirm-user')
+    _login(client, 'profile-confirm-user')
+    profile_page = client.get('/profile').get_data(as_text=True)
+    assert '旧版 API Token 兼容入口' not in profile_page
+
+    _set_csrf(client, 'password-confirm-csrf')
+    response = client.post(
+        '/profile',
+        data={
+            'form_id': 'password',
+            'old_password': 'ExistingPassword1!',
+            'new_password': 'ChangedPassword1!',
+            'confirm_password': 'DifferentPassword1!',
+            'csrf_token': 'password-confirm-csrf',
+        },
+        follow_redirects=True,
+    )
+    assert '两次输入的新密码不一致' in response.get_data(as_text=True)
+    db_session.refresh(user)
+    assert user.check_password('ExistingPassword1!')
+    assert not user.check_password('ChangedPassword1!')

--- a/tests/test_bugfix_batch1.py
+++ b/tests/test_bugfix_batch1.py
@@ -62,6 +62,7 @@ class TestPasswordChangeRequiresOldPassword:
                 'form_id': 'password',
                 'old_password': 'WrongOldPass!',
                 'new_password': 'NewPass456!x',
+                'confirm_password': 'NewPass456!x',
                 'csrf_token': csrf,
             }, follow_redirects=True)
 
@@ -81,6 +82,7 @@ class TestPasswordChangeRequiresOldPassword:
                 'form_id': 'password',
                 'old_password': 'OldPass123!',
                 'new_password': 'NewPass456!x',
+                'confirm_password': 'NewPass456!x',
                 'csrf_token': csrf,
             }, follow_redirects=True)
 
@@ -101,6 +103,7 @@ class TestPasswordChangeRequiresOldPassword:
                 'form_id': 'password',
                 'old_password': '',
                 'new_password': 'NewPass456!',
+                'confirm_password': 'NewPass456!',
                 'csrf_token': csrf,
             }, follow_redirects=True)
 
@@ -133,6 +136,7 @@ class TestPasswordChangeRequiresOldPassword:
                 'form_id': 'password',
                 'old_password': 'OldPass123!',
                 'new_password': 'ShortPass1!',
+                'confirm_password': 'ShortPass1!',
                 'csrf_token': csrf,
             }, follow_redirects=False)
             assert short_response.status_code in (301, 302)
@@ -145,6 +149,7 @@ class TestPasswordChangeRequiresOldPassword:
                 'form_id': 'password',
                 'old_password': 'OldPass123!',
                 'new_password': 'LongNewPass1!',
+                'confirm_password': 'LongNewPass1!',
                 'csrf_token': csrf,
             }, follow_redirects=False)
 

--- a/tests/test_cross_platform_identity.py
+++ b/tests/test_cross_platform_identity.py
@@ -816,6 +816,7 @@ def test_password_change_revokes_existing_link_code(
             "form_id": "password",
             "old_password": "long-web-password",
             "new_password": "new-long-web-password",
+            "confirm_password": "new-long-web-password",
         },
         follow_redirects=False,
     )
@@ -881,6 +882,7 @@ def test_password_change_detaches_wechat_until_fresh_relink(
             "form_id": "password",
             "old_password": "long-web-password",
             "new_password": "new-long-web-password",
+            "confirm_password": "new-long-web-password",
         },
         follow_redirects=False,
     )
@@ -977,6 +979,7 @@ def test_password_change_allows_different_wechat_to_replace_stale_identity(
             "form_id": "password",
             "old_password": "long-web-password",
             "new_password": "new-long-web-password",
+            "confirm_password": "new-long-web-password",
         },
         follow_redirects=False,
     )
@@ -1103,12 +1106,14 @@ def test_registration_rejects_phone_shaped_username(app, client, db_session):
         data={
             "username": "13800138000",
             "password": "long-registration-password",
+            "confirm_password": "long-registration-password",
             "csrf_token": csrf,
         },
         follow_redirects=False,
     )
 
-    assert response.status_code in (301, 302, 303)
+    assert response.status_code == 422
+    assert "用户名不能使用手机号格式" in response.get_data(as_text=True)
     assert User.query.filter_by(username="13800138000").first() is None
 
 
@@ -1130,103 +1135,37 @@ def test_registration_rejects_internal_username_namespaces(
             data={
                 "username": username,
                 "password": "long-registration-password",
+                "confirm_password": "long-registration-password",
                 "csrf_token": csrf,
             },
             follow_redirects=False,
         )
-        assert response.status_code in (301, 302, 303)
+        assert response.status_code == 422
         assert User.query.filter_by(username=username).first() is None
 
 
-def test_registration_hides_phone_occupancy_in_response(
-    app,
-    db_session,
-):
+def test_registration_ignores_legacy_phone_field(app, db_session):
     from core.db_models import User
 
-    occupied = User(
-        username="occupied_phone_owner",
-        phone_normalized="+8613900000001",
-    )
-    occupied.set_password("existing-password-long")
-    db_session.add(occupied)
-    db_session.commit()
-
-    def submit(username, phone):
-        test_client = app.test_client()
-        csrf = f"csrf-{username}"
-        with test_client.session_transaction() as flask_session:
-            flask_session["_csrf_token"] = csrf
-        response = test_client.post(
-            "/register",
-            data={
-                "username": username,
-                "password": "registration-password-long",
-                "phone": phone,
-                "csrf_token": csrf,
-            },
-            follow_redirects=False,
-        )
-        with test_client.session_transaction() as flask_session:
-            flashes = list(flask_session.get("_flashes") or [])
-        return response, flashes
-
-    occupied_response, occupied_flashes = submit(
-        "phone_probe_occupied",
-        "13900000001",
-    )
-    available_response, available_flashes = submit(
-        "phone_probe_available",
-        "13900000002",
+    test_client = app.test_client()
+    csrf = "legacy-register-phone-csrf"
+    with test_client.session_transaction() as flask_session:
+        flask_session["_csrf_token"] = csrf
+    response = test_client.post(
+        "/register",
+        data={
+            "username": "legacy_phone_field",
+            "password": "registration-password-long",
+            "confirm_password": "registration-password-long",
+            "phone": "13900000001",
+            "csrf_token": csrf,
+        },
+        follow_redirects=False,
     )
 
-    assert occupied_response.status_code == available_response.status_code
-    assert occupied_response.headers["Location"] == available_response.headers["Location"]
-    assert occupied_flashes == available_flashes
-    assert "手机号" not in occupied_flashes[0][1]
-    duplicate_user = User.query.filter_by(username="phone_probe_occupied").one()
-    assert duplicate_user.phone_normalized == "+8613900000001"
-    assert duplicate_user.phone_verified_at is None
-    assert User.query.filter_by(username="phone_probe_available").one()
-    assert User.query.filter_by(
-        phone_normalized="+8613900000001",
-    ).count() == 2
-
-    def attempt_pending_phone_login(phone, password):
-        test_client = app.test_client()
-        csrf = f"csrf-{phone}-{password}"
-        with test_client.session_transaction() as flask_session:
-            flask_session["_csrf_token"] = csrf
-        response = test_client.post(
-            "/login",
-            data={
-                "username": phone,
-                "password": password,
-                "csrf_token": csrf,
-            },
-            follow_redirects=False,
-        )
-        with test_client.session_transaction() as flask_session:
-            flashes = list(flask_session.get("_flashes") or [])
-            logged_in = "_user_id" in flask_session
-        return response.status_code, flashes, logged_in
-
-    occupied_phone_result = attempt_pending_phone_login(
-        "13900000001",
-        "registration-password-long",
-    )
-    available_phone_result = attempt_pending_phone_login(
-        "13900000002",
-        "registration-password-long",
-    )
-    existing_owner_result = attempt_pending_phone_login(
-        "13900000001",
-        "existing-password-long",
-    )
-    assert occupied_phone_result == available_phone_result
-    assert occupied_phone_result == existing_owner_result
-    assert occupied_phone_result[0] == 200
-    assert occupied_phone_result[2] is False
+    assert response.status_code in (301, 302, 303)
+    created = User.query.filter_by(username="legacy_phone_field").one()
+    assert created.phone_normalized is None
 
 
 def test_registration_post_has_dedicated_rate_limit(app, db_session):
@@ -1240,8 +1179,9 @@ def test_registration_post_has_dedicated_rate_limit(app, db_session):
         test_client.post(
             "/register",
             data={
-                "username": f"rate_limited_registration_{index}",
+                "username": f"rate_register_{index}",
                 "password": "registration-password-long",
+                "confirm_password": "registration-password-long",
                 "csrf_token": csrf,
             },
             follow_redirects=False,

--- a/tests/test_cross_platform_public_parity.py
+++ b/tests/test_cross_platform_public_parity.py
@@ -48,6 +48,76 @@ def _action_snapshot():
     }
 
 
+def test_snapshot_component_status_keeps_only_precise_independent_warning():
+    from services.miniprogram_service import snapshot_component_status
+
+    precise_warning = {
+        "available": False,
+        "stale": True,
+        "warnings_stale": False,
+        "source_status": {
+            "warnings": {"available": True, "stale": False},
+        },
+    }
+    incomplete_warning = {
+        "available": False,
+        "stale": False,
+        "source_status": {"warnings": {"available": True}},
+    }
+    contradictory_current = {
+        "available": False,
+        "stale": True,
+        "current_stale": False,
+        "source_status": {
+            "current": {"available": True, "stale": False},
+        },
+    }
+    malformed_current = {
+        "available": True,
+        "stale": False,
+        "current_stale": False,
+        "source_status": {
+            "current": {"available": "false", "stale": False},
+        },
+    }
+    malformed_warning_stale = {
+        "available": False,
+        "stale": True,
+        "warnings_stale": False,
+        "source_status": {
+            "warnings": {"available": True, "stale": "false"},
+        },
+    }
+
+    assert snapshot_component_status(precise_warning, "warnings")["usable"] is True
+    assert snapshot_component_status(incomplete_warning, "warnings")["usable"] is False
+    assert snapshot_component_status(contradictory_current, "current")["usable"] is False
+    assert snapshot_component_status(malformed_current, "current")["usable"] is False
+    assert snapshot_component_status(malformed_warning_stale, "warnings")["usable"] is False
+
+
+def test_public_risk_page_rejects_root_unavailable_contradictory_risk(
+    client,
+    monkeypatch,
+):
+    from services import public_service
+
+    payload = _action_snapshot()
+    payload.update({
+        'available': False,
+        'risk_stale': False,
+        'source_status': {
+            'risk': {'available': True, 'stale': False},
+        },
+    })
+    monkeypatch.setattr(public_service, 'get_bootstrap_payload', lambda: payload)
+
+    body = client.get('/risk').get_data(as_text=True)
+
+    assert '公开天气快照暂未就绪' in body
+    assert '当前风险：高风险' not in body
+
+
 def _forbid_weather_requests(monkeypatch):
     def forbidden(*_args, **_kwargs):
         pytest.fail("公开风险读取不得触发天气或预警请求")
@@ -390,3 +460,54 @@ def test_web_and_miniprogram_persist_the_same_valid_snapshot_risk(
         pair_id=pair.id,
         status_date=today_local(),
     ).count() == 1
+
+
+def test_forecast_only_stale_keeps_web_and_miniprogram_risk_actions(
+    app,
+    db_session,
+    monkeypatch,
+):
+    from blueprints import mp_api
+    from core.db_models import Pair, User
+    from core.security import hash_short_code
+    from core.time_utils import today_local
+    from services import public_service
+
+    snapshot = _action_snapshot()
+    snapshot.update({
+        'stale': True,
+        'forecast_stale': True,
+        'current_stale': False,
+        'risk_stale': False,
+        'source_status': {
+            'current': {'available': True, 'stale': False},
+            'risk': {'available': True, 'stale': False},
+            'forecast': {'available': True, 'stale': True},
+        },
+    })
+    monkeypatch.setattr(public_service, 'get_bootstrap_payload', lambda: snapshot)
+    monkeypatch.setattr(mp_api, 'get_bootstrap_payload', lambda: snapshot)
+    owner = User(username='forecast-stale-shared', role='caregiver')
+    owner.set_password('forecast-stale-password')
+    db_session.add(owner)
+    db_session.flush()
+    pair = Pair(
+        caregiver_id=owner.id,
+        community_code='都昌县',
+        location_query='都昌县',
+        elder_code='forecast-stale-shared',
+        short_code='76427642',
+        short_code_hash=hash_short_code('76427642'),
+        status='active',
+        created_at=FIXED_NOW,
+        last_active_at=FIXED_NOW,
+    )
+    db_session.add(pair)
+    db_session.flush()
+
+    web_context = public_service._build_action_context(pair, today_local())
+    mini_status = mp_api._daily_status_for_pair(pair)
+
+    assert web_context[1] == snapshot['actions']
+    assert web_context[5] == '高风险'
+    assert mini_status.risk_level == '高风险'

--- a/tests/test_dashboard_temperature_theme.py
+++ b/tests/test_dashboard_temperature_theme.py
@@ -56,31 +56,39 @@ def test_dashboard_renders_weather_alert_real_fields_with_local_date(
     db_session,
     monkeypatch,
 ):
-    from core.db_models import User, WeatherAlert
+    from core.db_models import User
 
     fixed_now = datetime(2026, 1, 1, 20, 0, tzinfo=timezone.utc)
     user = User.query.filter_by(username='testuser').one()
     user.community = '都昌'
     app.config['QWEATHER_CANONICAL_LOCATION'] = '116.20,29.27'
-    db_session.add(WeatherAlert(
-        alert_date=datetime(2026, 1, 1, 18, 0, tzinfo=timezone.utc),
-        location='116.20,29.27',
-        alert_type='高温预警',
-        alert_level='红色',
-        description='测试预警详情',
-    ))
     db_session.commit()
 
     monkeypatch.setattr('services.user.dashboard_service.utcnow', lambda: fixed_now)
     monkeypatch.setattr(
-        'services.user.dashboard_service.get_weather_with_cache',
-        lambda _location: ({'data_source': 'Demo', 'is_mock': True}, False),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        'services.user.dashboard_service.get_qweather_forecast_with_cache',
-        lambda _location, days=7: ([], False, {'error': 'qweather_unavailable'}),
-        raising=False,
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: {
+            'snapshot_id': 'dashboard-warning-snapshot',
+            'fetched_at': '2026-01-02T02:00:00+08:00',
+            'current_stale': True,
+            'forecast_stale': True,
+            'warnings_stale': False,
+            'risk_stale': True,
+            'location': {'name': '都昌县', 'code': '116.20,29.27'},
+            'current': {'is_mock': True},
+            'forecast': [],
+            'warnings': [{
+                'title': '高温预警',
+                'level': '红色',
+                'text': '测试预警详情',
+                'start_time': '2026-01-02T02:00:00+08:00',
+            }],
+            'risk': {'available': False},
+            'actions': [],
+            'source_status': {
+                'warnings': {'available': True, 'stale': False},
+            },
+        },
     )
 
     response = authenticated_client.get('/dashboard')

--- a/tests/test_dashboard_temperature_theme.py
+++ b/tests/test_dashboard_temperature_theme.py
@@ -75,10 +75,12 @@ def test_dashboard_renders_weather_alert_real_fields_with_local_date(
     monkeypatch.setattr(
         'services.user.dashboard_service.get_weather_with_cache',
         lambda _location: ({'data_source': 'Demo', 'is_mock': True}, False),
+        raising=False,
     )
     monkeypatch.setattr(
         'services.user.dashboard_service.get_qweather_forecast_with_cache',
         lambda _location, days=7: ([], False, {'error': 'qweather_unavailable'}),
+        raising=False,
     )
 
     response = authenticated_client.get('/dashboard')

--- a/tests/test_deploy_script.py
+++ b/tests/test_deploy_script.py
@@ -407,6 +407,44 @@ os.chmod(output, 0o600)
     return source
 
 
+def _run_prepare_release_source(source, deploy_temp_dir, verified_commit_file):
+    """在 pipefail 下执行冻结快照准备函数，覆盖 GNU 与 macOS 工具链。"""
+    function_source = _extract_shell_function(
+        _load_deploy_script(),
+        'prepare_release_source',
+    )
+    environment = os.environ.copy()
+    environment.update(
+        {
+            'DEPLOY_TEST_LOCAL_DIR': str(source),
+            'DEPLOY_TEST_TEMP_DIR': str(deploy_temp_dir),
+            'DEPLOY_TEST_COMMIT_FILE': str(verified_commit_file),
+        }
+    )
+    return subprocess.run(
+        [
+            'bash',
+            '-c',
+            'set -euo pipefail\n'
+            + function_source
+            + '\nLOCAL_DIR="$DEPLOY_TEST_LOCAL_DIR"\n'
+            + 'LOCAL_DEPLOY_TEMP_DIR="$DEPLOY_TEST_TEMP_DIR"\n'
+            + 'VERIFIED_COMMIT_FILE="$DEPLOY_TEST_COMMIT_FILE"\n'
+            + 'VERIFIED_COMMIT=""\n'
+            + 'VERIFIED_RELEASE_BRANCH=""\n'
+            + 'LOCAL_RELEASE_EXPORT_DIR=""\n'
+            + 'RELEASE_SOURCE_DIR="$LOCAL_DIR"\n'
+            + 'prepare_release_source\n',
+        ],
+        cwd=ROOT,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
 def _extract_shell_function(content, name):
     start = content.index(f'{name}() {{')
     end = content.index('\n}\n', start) + len('\n}\n')
@@ -1671,7 +1709,16 @@ def test_formal_deploy_uploads_verified_commit_snapshot_instead_of_live_tree():
         in content
     )
     assert 'IFS= read -r VERIFIED_COMMIT < "$VERIFIED_COMMIT_FILE"' in content
-    assert 'git -C "$LOCAL_DIR" archive --format=tar "$VERIFIED_COMMIT"' in content
+    assert 'local release_archive="$LOCAL_DEPLOY_TEMP_DIR/release-source.tar"' in content
+    assert (
+        'git -C "$LOCAL_DIR" archive \\\n'
+        '        --format=tar \\\n'
+        '        --output="$release_archive" \\\n'
+        '        "$VERIFIED_COMMIT"'
+    ) in content
+    assert 'chmod 0600 "$release_archive"' in content
+    assert 'tar -xf "$release_archive" -C "$LOCAL_RELEASE_EXPORT_DIR"' in content
+    assert '| tar -xf - -C "$LOCAL_RELEASE_EXPORT_DIR"' not in content
     assert 'RELEASE_SOURCE_DIR="$LOCAL_RELEASE_EXPORT_DIR"' in content
     assert '$NEW_RELEASE/private-metadata/source-commit.txt' in content
     assert (
@@ -1684,6 +1731,74 @@ def test_formal_deploy_uploads_verified_commit_snapshot_instead_of_live_tree():
     )
     assert content.count('"$RELEASE_SOURCE_DIR/" "$USER@$SERVER:$remote_target/"') == 2
     assert '"$LOCAL_DIR/" "$USER@$SERVER:$remote_target/"' not in content
+
+
+def test_prepare_release_source_uses_private_tar_and_frozen_commit(tmp_path):
+    source = _create_clean_git_source(tmp_path)
+    verified_commit = subprocess.check_output(
+        ['git', '-C', str(source), 'rev-parse', 'HEAD'],
+        text=True,
+    ).strip()
+    deploy_temp_dir = tmp_path / 'case-weather-deploy.test'
+    deploy_temp_dir.mkdir(mode=0o700)
+    verified_commit_file = deploy_temp_dir / 'verified-commit'
+    verified_commit_file.write_text(f'{verified_commit}\n', encoding='utf-8')
+    verified_commit_file.chmod(0o600)
+
+    # 票据生成后的工作树变化不得进入冻结发布快照。
+    (source / 'README.md').write_text('live tree changed\n', encoding='utf-8')
+    (source / 'live-only.txt').write_text('uncommitted\n', encoding='utf-8')
+
+    result = _run_prepare_release_source(
+        source,
+        deploy_temp_dir,
+        verified_commit_file,
+    )
+
+    assert result.returncode == 0, result.stderr
+    release_archive = deploy_temp_dir / 'release-source.tar'
+    release_source = deploy_temp_dir / 'release-source'
+    assert release_archive.is_file()
+    assert stat.S_IMODE(release_archive.stat().st_mode) == 0o600
+    assert stat.S_IMODE(release_source.stat().st_mode) == 0o700
+    assert (release_source / 'README.md').read_text(
+        encoding='utf-8'
+    ) == 'release fixture\n'
+    assert not (release_source / 'live-only.txt').exists()
+
+
+def test_deploy_exit_cleanup_removes_private_release_archive(tmp_path):
+    content = _load_deploy_script()
+    cleanup_source = _extract_shell_function(
+        content,
+        'cleanup_local_deploy_temp',
+    )
+    deploy_temp_dir = tmp_path / 'case-weather-deploy.cleanup'
+    deploy_temp_dir.mkdir(mode=0o700)
+    (deploy_temp_dir / 'release-source.tar').write_bytes(b'private archive')
+    environment = os.environ.copy()
+    environment['DEPLOY_TEST_TEMP_DIR'] = str(deploy_temp_dir)
+
+    result = subprocess.run(
+        [
+            'bash',
+            '-c',
+            'set -euo pipefail\n'
+            + cleanup_source
+            + '\nLOCAL_DEPLOY_TEMP_DIR="$DEPLOY_TEST_TEMP_DIR"\n'
+            + 'REMOTE_QWEATHER_PREACTIVATION_ACTIVE=0\n'
+            + 'trap cleanup_local_deploy_temp EXIT\n',
+        ],
+        cwd=ROOT,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not deploy_temp_dir.exists()
 
 
 def test_deploy_archive_target_comes_from_same_validation_ticket():

--- a/tests/test_formal_web_gate.py
+++ b/tests/test_formal_web_gate.py
@@ -142,7 +142,7 @@ def test_formal_web_registration_keeps_minimal_account_creation(
     client,
     db_session,
 ):
-    """正式态保留待验证手机号保存，并继续执行 CSRF 与输入校验。"""
+    """小程序独占正式态注册后建立会话并落到账号绑定页。"""
     from core.db_models import User
 
     app.config["WECHAT_FORMAL_RUNTIME"] = True
@@ -156,6 +156,7 @@ def test_formal_web_registration_keeps_minimal_account_creation(
         data={
             "username": "formal_link_user",
             "password": "formal-test-password",
+            "confirm_password": "formal-test-password",
             "phone": "13800138000",
             "csrf_token": csrf,
         },
@@ -163,10 +164,12 @@ def test_formal_web_registration_keeps_minimal_account_creation(
     )
 
     assert response.status_code in (301, 302, 303)
-    assert "/login" in response.headers["Location"]
+    assert response.headers["Location"].endswith("/account-link")
     user = User.query.filter_by(username="formal_link_user").one()
-    assert user.phone_normalized == "+8613800138000"
+    assert user.phone_normalized is None
     assert user.phone_verified_at is None
+    with client.session_transaction() as flask_session:
+        assert flask_session.get("_user_id")
 
 
 def test_formal_web_gate_preserves_public_aggregate_and_admin_inventory(app):

--- a/tests/test_health_profile_regressions.py
+++ b/tests/test_health_profile_regressions.py
@@ -53,8 +53,10 @@ def test_health_assessment_marks_every_screening_group_required(authenticated_cl
             continue
         assert f'name="{field_name}"' in html
         assert f'name="{field_name}" value=' in html
-    assert html.count('class="visually-hidden assess-opt" required') == 16
-    assert 'class="d-none assess-opt" required' not in html
+    assert html.count('class="visually-hidden assess-opt"') == 16
+    assert 'assess-opt" required' not in html
+    assert 'novalidate' in html
+    assert 'validateAssessment()' in html
 
 
 @pytest.mark.parametrize(
@@ -87,11 +89,44 @@ def test_health_assessment_rejects_missing_or_invalid_screening_without_side_eff
     response = authenticated_client.post(
         '/health-assessment',
         data=data,
+    )
+
+    assert response.status_code == 422
+    body = response.get_data(as_text=True)
+    assert '还差 <span id="assessmentMissingCount">1</span> 项' in body
+    assert 'assessment-question is-invalid' in body
+    assert HealthRiskAssessment.query.count() == 0
+
+
+def test_web_health_assessment_rejects_partial_weather_before_model_or_write(
+    authenticated_client,
+    monkeypatch,
+):
+    """Web 评估不能用模型默认值补齐缺失天气后生成正式结果。"""
+    monkeypatch.setattr(
+        'services.user.profile_service.get_weather_with_cache',
+        lambda _location: ({
+            'temperature': 39,
+            'data_source': 'QWeather',
+            'is_mock': False,
+        }, False),
+    )
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('不完整天气不得进入健康风险模型')
+
+    monkeypatch.setattr(
+        'services.health_risk_service.HealthRiskService.assess_personal_weather_health_risk',
+        unexpected,
+    )
+    response = authenticated_client.post(
+        '/health-assessment',
+        data=SCREENING_DATA,
         follow_redirects=True,
     )
 
     assert response.status_code == 200
-    assert '请完整选择全部 5 项健康筛查后再提交' in response.get_data(as_text=True)
+    assert '天气正在更新，本次评估暂未完成' in response.get_data(as_text=True)
     assert HealthRiskAssessment.query.count() == 0
 
 
@@ -100,7 +135,7 @@ def _profile_form(email):
         'form_id': 'basic',
         'age': '66',
         'gender': '男性',
-        'community': '新社区',
+        'community': '都昌县',
         'email': email,
         'csrf_token': 'test-csrf-token',
     }

--- a/tests/test_heat_exposure_gis.py
+++ b/tests/test_heat_exposure_gis.py
@@ -25,6 +25,22 @@ def test_heat_exposure_gis_requires_login(client):
     assert "/login" in response.headers["Location"]
 
 
+def test_heat_exposure_gis_rejects_authenticated_guest(client):
+    guest_entry = client.get(
+        "/guest?next=/heat-exposure-gis",
+        follow_redirects=False,
+    )
+    assert guest_entry.status_code == 302
+    assert guest_entry.headers["Location"].endswith("/heat-exposure-gis")
+
+    response = client.get("/heat-exposure-gis", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(
+        "/login?next=/heat-exposure-gis"
+    )
+
+
 def test_heat_exposure_gis_page_has_academic_contract(app, authenticated_client):
     app.config["AMAP_JS_API_KEY"] = "j" * 32
     app.config["AMAP_SECURITY_JS_CODE"] = "s" * 32

--- a/tests/test_http_errors.py
+++ b/tests/test_http_errors.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+"""中文错误页、限流响应和可信代理客户端键回归。"""
+from flask import abort
+
+
+def _set_csrf(client, token):
+    with client.session_transaction() as flask_session:
+        flask_session['_csrf_token'] = token
+
+
+def _register_payload(index, csrf):
+    return {
+        'username': f'error_rate_{index}',
+        'password': 'RegistrationPassword1!',
+        'confirm_password': 'RegistrationPassword1!',
+        'csrf_token': csrf,
+    }
+
+
+def test_html_rate_limit_is_branded_and_has_retry_contract(
+    app,
+    client,
+    db_session,
+):
+    app.config['RATE_LIMIT_REGISTER'] = '2 per hour'
+    csrf = 'html-rate-limit-csrf'
+    _set_csrf(client, csrf)
+    responses = [
+        client.post(
+            '/register',
+            data=_register_payload(index, csrf),
+            environ_base={'REMOTE_ADDR': '198.51.100.70'},
+            follow_redirects=False,
+        )
+        for index in range(3)
+    ]
+
+    response = responses[-1]
+    body = response.get_data(as_text=True)
+    assert [item.status_code for item in responses[:2]] == [302, 302]
+    assert response.status_code == 429
+    assert '操作太频繁' in body
+    assert '5 per 5 minute' not in body
+    assert 'data-retry-seconds=' in body
+    assert int(response.headers['Retry-After']) >= 1
+    assert response.headers['Cache-Control'] == 'no-store, private, max-age=0'
+    assert response.headers['X-Request-ID']
+    assert response.headers['X-Request-ID'] in body
+
+
+def test_json_rate_limit_keeps_structured_api_contract(
+    app,
+    client,
+    db_session,
+):
+    app.config['RATE_LIMIT_REGISTER'] = '1 per hour'
+    csrf = 'json-rate-limit-csrf'
+    _set_csrf(client, csrf)
+    first = client.post(
+        '/register',
+        data=_register_payload(20, csrf),
+        headers={'Accept': 'application/json'},
+        environ_base={'REMOTE_ADDR': '198.51.100.71'},
+        follow_redirects=False,
+    )
+    limited = client.post(
+        '/register',
+        data=_register_payload(21, csrf),
+        headers={'Accept': 'application/json'},
+        environ_base={'REMOTE_ADDR': '198.51.100.71'},
+        follow_redirects=False,
+    )
+
+    payload = limited.get_json()
+    assert first.status_code == 302
+    assert limited.status_code == 429
+    assert payload['success'] is False
+    assert payload['error'] == 'rate_limit_exceeded'
+    assert payload['retry_after_seconds'] == int(limited.headers['Retry-After'])
+    assert payload['request_id'] == limited.headers['X-Request-ID']
+
+
+def test_successful_logins_do_not_consume_failed_login_limit(
+    app,
+    client,
+    db_session,
+):
+    from core.db_models import User
+
+    app.config['RATE_LIMIT_LOGIN'] = '2 per 5 minutes'
+    user = User(username='deduct-login-user', role='user')
+    user.set_password('CorrectLoginPassword1!')
+    db_session.add(user)
+    db_session.commit()
+    csrf = 'deduct-login-csrf'
+    _set_csrf(client, csrf)
+    remote = {'REMOTE_ADDR': '198.51.100.72'}
+
+    for _index in range(3):
+        success = client.post(
+            '/login',
+            data={
+                'username': user.username,
+                'password': 'CorrectLoginPassword1!',
+                'csrf_token': csrf,
+            },
+            environ_base=remote,
+            follow_redirects=False,
+        )
+        assert success.status_code == 302
+        client.post(
+            '/logout',
+            data={'csrf_token': csrf},
+            environ_base=remote,
+            follow_redirects=False,
+        )
+
+    failures = [
+        client.post(
+            '/login',
+            data={
+                'username': user.username,
+                'password': 'WrongLoginPassword1!',
+                'csrf_token': csrf,
+            },
+            environ_base=remote,
+            follow_redirects=False,
+        )
+        for _index in range(3)
+    ]
+    assert [item.status_code for item in failures] == [200, 200, 429]
+
+
+def test_client_rate_limit_key_obeys_trusted_proxy_boundary(app):
+    from core.security import client_rate_limit_key
+
+    app.config['TRUSTED_PROXY_CIDRS'] = '127.0.0.1/32,::1/128'
+    with app.test_request_context(
+        '/',
+        headers={'X-Forwarded-For': '8.8.8.8'},
+        environ_base={'REMOTE_ADDR': '203.0.113.10'},
+    ):
+        untrusted_a = client_rate_limit_key()
+    with app.test_request_context(
+        '/',
+        headers={'X-Forwarded-For': '9.9.9.9'},
+        environ_base={'REMOTE_ADDR': '203.0.113.10'},
+    ):
+        untrusted_b = client_rate_limit_key()
+    with app.test_request_context(
+        '/',
+        headers={'X-Forwarded-For': '8.8.8.8'},
+        environ_base={'REMOTE_ADDR': '127.0.0.1'},
+    ):
+        trusted_a = client_rate_limit_key()
+    with app.test_request_context(
+        '/',
+        headers={'X-Forwarded-For': '9.9.9.9'},
+        environ_base={'REMOTE_ADDR': '127.0.0.1'},
+    ):
+        trusted_b = client_rate_limit_key()
+
+    assert untrusted_a == untrusted_b
+    assert trusted_a != trusted_b
+    assert all(
+        key.startswith('client:')
+        and '8.8.8.8' not in key
+        and '203.0.113.10' not in key
+        for key in (untrusted_a, trusted_a, trusted_b)
+    )
+
+
+def test_html_and_api_not_found_are_content_negotiated(client, db_session):
+    html_response = client.get('/settings')
+    api_response = client.get('/api/does-not-exist')
+
+    html_body = html_response.get_data(as_text=True)
+    assert html_response.status_code == 404
+    assert '页面没有找到' in html_body
+    assert 'Not Found' not in html_body
+    assert api_response.status_code == 404
+    assert api_response.get_json()['error'] == 'not_found'
+    assert api_response.get_json()['request_id']
+
+
+def test_forbidden_and_internal_errors_use_station_pages(app, client, db_session):
+    app.config['PROPAGATE_EXCEPTIONS'] = False
+
+    @app.get('/_test/forbidden')
+    def _test_forbidden():
+        abort(403)
+
+    @app.get('/_test/server-error')
+    def _test_server_error():
+        raise RuntimeError('raw-private-error-text')
+
+    forbidden = client.get('/_test/forbidden')
+    failed = client.get('/_test/server-error')
+    assert forbidden.status_code == 403
+    assert '没有访问权限' in forbidden.get_data(as_text=True)
+    assert failed.status_code == 500
+    assert '页面暂时不可用' in failed.get_data(as_text=True)
+    assert 'raw-private-error-text' not in failed.get_data(as_text=True)
+
+
+def test_community_permission_message_names_required_role(
+    client,
+    db_session,
+):
+    from core.db_models import User
+
+    user = User(username='ordinary-community-visitor', role='user')
+    user.set_password('CommunityVisitor1!')
+    db_session.add(user)
+    db_session.commit()
+    csrf = 'community-role-csrf'
+    _set_csrf(client, csrf)
+    client.post(
+        '/login',
+        data={
+            'username': user.username,
+            'password': 'CommunityVisitor1!',
+            'csrf_token': csrf,
+        },
+        follow_redirects=False,
+    )
+
+    response = client.get('/community', follow_redirects=False)
+    assert response.status_code == 302
+    with client.session_transaction() as flask_session:
+        messages = [message for _kind, message in flask_session.get('_flashes', [])]
+    assert '该页面仅限社区工作人员或管理员使用，请切换对应账号。' in messages
+
+
+def test_base_template_has_no_full_screen_page_loader(client, db_session):
+    body = client.get('/login').get_data(as_text=True)
+    assert 'id="pageLoader"' not in body
+    assert 'function hideLoader' not in body
+    assert '处理中…' in body

--- a/tests/test_http_errors.py
+++ b/tests/test_http_errors.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 """中文错误页、限流响应和可信代理客户端键回归。"""
+import importlib
+
 from flask import abort
+from flask_login import current_user
+from sqlalchemy import event, text
+from sqlalchemy.exc import OperationalError
 
 
 def _set_csrf(client, token):
@@ -170,6 +175,34 @@ def test_client_rate_limit_key_obeys_trusted_proxy_boundary(app):
     )
 
 
+def test_client_rate_limit_key_is_stable_across_worker_reload(app):
+    import core.security as security
+
+    app.config['PAIR_TOKEN_PEPPER'] = 'pair-pepper-stable-across-workers'
+    app.config['SECRET_KEY'] = 'different-session-secret'
+    request_kwargs = {
+        'headers': {'X-Forwarded-For': '8.8.4.4'},
+        'environ_base': {'REMOTE_ADDR': '127.0.0.1'},
+    }
+
+    with app.test_request_context('/', **request_kwargs):
+        first_worker = security.client_rate_limit_key()
+
+    importlib.reload(security)
+    app.config['SECRET_KEY'] = 'rotated-but-lower-priority-session-secret'
+    with app.test_request_context('/', **request_kwargs):
+        restarted_worker = security.client_rate_limit_key()
+
+    assert restarted_worker == first_worker
+    assert first_worker.startswith('client:')
+    assert '8.8.4.4' not in first_worker
+
+    app.config['PAIR_TOKEN_PEPPER'] = 'rotated-pair-pepper'
+    with app.test_request_context('/', **request_kwargs):
+        rotated_pepper = security.client_rate_limit_key()
+    assert rotated_pepper != first_worker
+
+
 def test_html_and_api_not_found_are_content_negotiated(client, db_session):
     html_response = client.get('/settings')
     api_response = client.get('/api/does-not-exist')
@@ -201,6 +234,68 @@ def test_forbidden_and_internal_errors_use_station_pages(app, client, db_session
     assert failed.status_code == 500
     assert '页面暂时不可用' in failed.get_data(as_text=True)
     assert 'raw-private-error-text' not in failed.get_data(as_text=True)
+
+
+def test_authenticated_database_failure_500_never_queries_database_again(
+    app,
+    authenticated_client,
+):
+    from core.extensions import db
+
+    app.config['PROPAGATE_EXCEPTIONS'] = False
+    app.config['FEATURE_STRUCTURED_LOGS'] = True
+    state = {'database_offline': False, 'query_count': 0}
+
+    with app.app_context():
+        engine = db.engine
+
+    def reject_queries_after_failure(
+        _connection,
+        _cursor,
+        statement,
+        parameters,
+        _context,
+        _executemany,
+    ):
+        if not state['database_offline']:
+            return
+        state['query_count'] += 1
+        raise OperationalError(
+            statement,
+            parameters,
+            RuntimeError('database unavailable'),
+        )
+
+    def _test_authenticated_db_failure():
+        assert current_user.is_authenticated
+        loaded_user = current_user._get_current_object()
+        db.session.expire(loaded_user)
+        state['database_offline'] = True
+        db.session.execute(text('SELECT 1'))
+        raise AssertionError('数据库故障必须在这里终止请求')
+
+    endpoint = 'user.user_dashboard'
+    original_view = app.view_functions[endpoint]
+    app.view_functions[endpoint] = _test_authenticated_db_failure
+    event.listen(engine, 'before_cursor_execute', reject_queries_after_failure)
+    try:
+        response = authenticated_client.get('/dashboard')
+    finally:
+        app.view_functions[endpoint] = original_view
+        event.remove(
+            engine,
+            'before_cursor_execute',
+            reject_queries_after_failure,
+        )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 500
+    assert state['query_count'] == 1
+    assert '页面暂时不可用' in body
+    assert response.headers['X-Request-ID']
+    assert response.headers['X-Request-ID'] in body
+    assert response.headers['Cache-Control'] == 'no-store, private, max-age=0'
+    assert 'database unavailable' not in body
 
 
 def test_community_permission_message_names_required_role(

--- a/tests/test_input_integrity_and_handoff.py
+++ b/tests/test_input_integrity_and_handoff.py
@@ -1,0 +1,553 @@
+# -*- coding: utf-8 -*-
+"""输入完整性、地点边界与小程序行动交接回归。"""
+from pathlib import Path
+
+import pytest
+
+
+def _login_as(client, user_id, csrf_token='test-csrf-token'):
+    with client.session_transaction() as session:
+        session['_user_id'] = f'{user_id}:1'
+        session['_fresh'] = True
+        session['_csrf_token'] = csrf_token
+
+
+def _create_user(db_session, username='input-integrity-user'):
+    from core.db_models import User
+
+    user = User(username=username, role='user', age=72, gender='男')
+    user.set_password('testpass')
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+def _online_weather(temperature=31.4):
+    return {
+        'temperature': temperature,
+        'humidity': 68,
+        'data_source': 'QWeather',
+        'is_mock': False,
+        'is_demo': False,
+    }
+
+
+@pytest.mark.parametrize('raw', ['北京', '101010100', '116.20,29.27', '完全不存在地点'])
+def test_strict_user_location_rejects_external_ids_coordinates_and_unknown(app, raw):
+    from core.location_resolution import resolve_user_location
+
+    with app.app_context():
+        result = resolve_user_location(raw)
+
+    assert result.valid is False
+    assert result.raw == raw
+    assert result.value is None
+    assert '目前仅支持都昌县' in result.error
+
+
+def test_strict_user_location_accepts_county_and_configured_village(app):
+    from core.location_resolution import resolve_user_location
+
+    with app.app_context():
+        county = resolve_user_location('都昌')
+        village = resolve_user_location('都昌县牛家垄周村')
+
+    assert county.valid is True
+    assert county.value == '都昌'
+    assert village.valid is True
+    assert village.value == '牛家垄周村'
+
+
+def test_strict_user_location_rejects_external_default_city_misconfiguration(
+    app,
+    monkeypatch,
+):
+    from core.location_resolution import resolve_user_location
+
+    with app.app_context():
+        monkeypatch.setitem(app.config, 'DEFAULT_CITY', '北京')
+        result = resolve_user_location('北京')
+
+    assert result.valid is False
+
+
+def test_tool_location_accepts_confirmed_dynamic_county_community_but_rejects_beijing(
+    client,
+    db_session,
+    monkeypatch,
+):
+    from core.db_models import Community
+
+    user = _create_user(db_session, username='dynamic-county-community')
+    db_session.add(Community(name='甲村', location='甲村'))
+    db_session.commit()
+    _login_as(client, user.id)
+    monkeypatch.setattr(
+        'blueprints.tools.get_qweather_forecast_with_cache',
+        lambda location, days: ([], False, {'source': 'QWeather'}),
+    )
+
+    accepted = client.get('/forecast-7day?location=甲村')
+    rejected = client.get('/forecast-7day?location=北京')
+
+    assert accepted.status_code == 200
+    assert 'value="甲村"' in accepted.get_data(as_text=True)
+    assert rejected.status_code == 422
+    assert '未找到这个地点' in rejected.get_data(as_text=True)
+
+
+@pytest.mark.parametrize('path', ['/ml-prediction', '/forecast-7day'])
+@pytest.mark.parametrize('invalid_location', ['火星一号社区', '北京'])
+def test_invalid_tool_location_returns_422_preserves_input_and_skips_services(
+    client,
+    db_session,
+    monkeypatch,
+    path,
+    invalid_location,
+):
+    user = _create_user(
+        db_session,
+        username=f"invalid-location-{path.rsplit('/', 1)[-1]}-{len(invalid_location)}",
+    )
+    _login_as(client, user.id)
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('非法地点不得调用天气或预测服务')
+
+    monkeypatch.setattr('blueprints.tools.get_weather_with_cache', unexpected)
+    monkeypatch.setattr('blueprints.tools.get_qweather_forecast_with_cache', unexpected)
+    monkeypatch.setattr('blueprints.tools.get_ml_service', unexpected)
+    monkeypatch.setattr('blueprints.tools.get_forecast_service', unexpected)
+
+    if path == '/ml-prediction':
+        response = client.post(
+            path,
+            data={
+                'location': invalid_location,
+                'age': '72',
+                'csrf_token': 'test-csrf-token',
+            },
+        )
+    else:
+        response = client.get(f'{path}?location={invalid_location}')
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 422
+    assert invalid_location in body
+    assert '未找到这个地点' in body
+    assert 'data-error-code="invalid_location"' in body
+
+
+def test_ml_guest_gets_explicit_auth_requirement_without_weather_call(
+    client,
+    db_session,
+    monkeypatch,
+):
+    del db_session
+    client.get('/guest', follow_redirects=False)
+    with client.session_transaction() as session:
+        session['_csrf_token'] = 'test-csrf-token'
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('游客身份要求应在天气和模型调用前返回')
+
+    monkeypatch.setattr('blueprints.tools.get_weather_with_cache', unexpected)
+    monkeypatch.setattr('blueprints.tools.get_ml_service', unexpected)
+
+    response = client.post(
+        '/ml-prediction',
+        data={
+            'location': '都昌',
+            'age': '72',
+            'csrf_token': 'test-csrf-token',
+        },
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 403
+    assert '生成个人类别线索需要注册或登录正式账号' in body
+    assert 'data-error-code="auth_required"' in body
+
+
+def test_ml_service_error_is_classified_without_leaking_raw_error(
+    client,
+    db_session,
+    monkeypatch,
+):
+    user = _create_user(db_session, username='ml-safe-error-user')
+    _login_as(client, user.id)
+    monkeypatch.setattr(
+        'blueprints.tools.get_weather_with_cache',
+        lambda _location: (_online_weather(), False),
+    )
+
+    class FailedService:
+        def predict_disease_risk(self, *_args, **_kwargs):
+            return {'success': False, 'error': 'secret stack /srv/private/model.pkl'}
+
+    monkeypatch.setattr('blueprints.tools.get_ml_service', lambda: FailedService())
+    response = client.post(
+        '/ml-prediction',
+        data={
+            'location': '都昌',
+            'age': '72',
+            'csrf_token': 'test-csrf-token',
+        },
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert '类别线索模型正在维护' in body
+    assert 'secret stack' not in body
+    assert '/srv/private' not in body
+
+
+@pytest.mark.parametrize(
+    ('field', 'value'),
+    [
+        ('sbp', '59'),
+        ('sbp', '261'),
+        ('sbp', 'nan'),
+        ('sbp', 'inf'),
+        ('sbp', '1e2'),
+        ('sbp', '9' * 64),
+        ('fbg', '1.9'),
+        ('fbg', '30.1'),
+        ('fbg', 'nan'),
+        ('fbg', 'inf'),
+        ('fbg', '-inf'),
+        ('fbg', '2e1'),
+        ('fbg', '9' * 64),
+    ],
+)
+def test_chronic_vital_rejection_is_422_and_stops_weather_and_risk(
+    client,
+    db_session,
+    monkeypatch,
+    field,
+    value,
+):
+    user = _create_user(db_session, username=f'chronic-{field}-{len(value)}-{value[:2]}')
+    _login_as(client, user.id)
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('无效生命体征不得调用天气或慢病风险服务')
+
+    monkeypatch.setattr('blueprints.tools.get_weather_with_cache', unexpected)
+    monkeypatch.setattr('blueprints.tools.get_chronic_service', unexpected)
+    response = client.post(
+        '/chronic-risk',
+        data={
+            'disease': 'hypertension',
+            'sbp': value if field == 'sbp' else '',
+            'fbg': value if field == 'fbg' else '',
+            'csrf_token': 'test-csrf-token',
+        },
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 422
+    assert '请先修正生命体征输入' in body
+    assert 'is-invalid' in body
+    assert '综合风险评分' not in body
+
+
+@pytest.mark.parametrize(
+    ('sbp', 'fbg', 'expected_vitals'),
+    [
+        ('60', '2', {'sbp': 60.0, 'fbg': 2.0}),
+        ('260', '30', {'sbp': 260.0, 'fbg': 30.0}),
+        ('', '', {}),
+    ],
+)
+def test_chronic_vital_boundaries_and_blank_values_are_accepted(
+    client,
+    db_session,
+    monkeypatch,
+    sbp,
+    fbg,
+    expected_vitals,
+):
+    user = _create_user(
+        db_session,
+        username=f'chronic-valid-{sbp or "blank"}-{fbg or "blank"}',
+    )
+    _login_as(client, user.id)
+    monkeypatch.setattr(
+        'blueprints.tools.get_weather_with_cache',
+        lambda _location: (_online_weather(), False),
+    )
+
+    captured = {}
+
+    class StubChronicService:
+        def predict_individual_risk(self, profile, _weather):
+            captured['vitals'] = profile['vitals']
+            return {
+                'overall_risk': {'score': 35, 'level': '低风险'},
+                'disease_risks': {},
+                'recommendations': [],
+            }
+
+    monkeypatch.setattr(
+        'blueprints.tools.get_chronic_service',
+        lambda: StubChronicService(),
+    )
+    response = client.post(
+        '/chronic-risk',
+        data={
+            'disease': 'hypertension',
+            'sbp': sbp,
+            'fbg': fbg,
+            'csrf_token': 'test-csrf-token',
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured['vitals'] == expected_vitals
+
+
+@pytest.mark.parametrize('answered_count', [0, 4])
+def test_incomplete_health_assessment_returns_422_preserves_answers_and_skips_weather(
+    authenticated_client,
+    db_session,
+    monkeypatch,
+    answered_count,
+):
+    answers = [
+        ('outdoor_exposure', 'low'),
+        ('symptom_level', 'none'),
+        ('hydration', 'good'),
+        ('medication_adherence', 'good'),
+        ('sleep_quality', 'good'),
+    ]
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('未完成问卷不得读取天气或调用风险服务')
+
+    monkeypatch.setattr(
+        'services.user.profile_service.get_weather_with_cache',
+        unexpected,
+    )
+    payload = dict(answers[:answered_count])
+    payload['csrf_token'] = 'test-csrf-token'
+    response = authenticated_client.post('/health-assessment', data=payload)
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 422
+    assert f'还差 <span id="assessmentMissingCount">{5 - answered_count}</span> 项' in body
+    assert 'assessment-question is-invalid' in body
+    assert 'validateAssessment()' in body
+    for name, value in answers[:answered_count]:
+        assert f'name="{name}" value="{value}" class="visually-hidden assess-opt" checked' in body
+    assert 'autofocus' in body
+    assert db_session.query(__import__('core.db_models', fromlist=['HealthRiskAssessment']).HealthRiskAssessment).count() == 0
+
+
+def test_formal_action_handoff_has_real_fallback_and_no_fake_code(app, client):
+    app.config['WECHAT_FORMAL_RUNTIME'] = True
+    app.config['WX_MINIPROGRAM_ACTION_CODE_IMAGE'] = ''
+
+    response = client.get('/elder')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'data-testid="miniprogram-action-handoff"' in body
+    assert 'data-miniprogram-path="pages/actions/index"' in body
+    assert '搜索小程序“宜老平安”' in body
+    assert 'data-testid="miniprogram-code-fallback"' in body
+    assert '复制名称' in body
+    assert '公共行动可直接在本机勾选' in body
+    assert '从“照护”选择对应家人' in body
+    assert '返回今日风险' in body
+    assert '今天先做这 3 件事' in body
+    assert 'alt="宜老平安官方小程序码' not in body
+
+
+def test_miniprogram_code_image_contract_rejects_missing_static_and_accepts_https(app):
+    from core.config import _validated_miniprogram_code_image
+
+    assert _validated_miniprogram_code_image(
+        'images/not-present-action-code.png',
+        app.static_folder,
+    ) == ''
+    assert _validated_miniprogram_code_image(
+        '../private/action-code.png',
+        app.static_folder,
+    ) == ''
+    assert _validated_miniprogram_code_image(
+        'https://cdn.example.org/yilao/action-code.png',
+        app.static_folder,
+    ) == 'https://cdn.example.org/yilao/action-code.png'
+    assert _validated_miniprogram_code_image(
+        'brand/yilao-avatar.png',
+        app.static_folder,
+    ) == 'brand/yilao-avatar.png'
+    assert _validated_miniprogram_code_image(
+        'HTTPS://cdn.example.org/yilao/action-code.png',
+        app.static_folder,
+    ) == 'https://cdn.example.org/yilao/action-code.png'
+
+
+def test_formal_action_handoff_renders_normalized_remote_code_without_referrer(app, client):
+    from core.config import _validated_miniprogram_code_image
+
+    app.config['WECHAT_FORMAL_RUNTIME'] = True
+    app.config['WX_MINIPROGRAM_ACTION_CODE_IMAGE'] = _validated_miniprogram_code_image(
+        'HTTPS://cdn.example.org/yilao/action-code.png',
+        app.static_folder,
+    )
+
+    response = client.get('/elder')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'src="https://cdn.example.org/yilao/action-code.png"' in body
+    assert 'referrerpolicy="no-referrer"' in body
+    assert 'data-testid="miniprogram-code-fallback"' not in body
+
+
+def test_invalid_cooling_location_is_422_and_never_reads_weather(
+    client,
+    db_session,
+    monkeypatch,
+):
+    del db_session
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('非法避暑地点不得读取天气快照或旧天气缓存')
+
+    monkeypatch.setattr('services.public_service.get_bootstrap_payload', unexpected)
+    monkeypatch.setattr('services.public_service.get_weather_with_cache', unexpected)
+    response = client.get('/cooling?community=不存在的火星社区')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 422
+    assert 'value="不存在的火星社区"' in body
+    assert '原输入已保留' in body
+    assert 'data-error-code="invalid_location"' in body
+    assert '都昌 · 当前室外' not in body
+
+
+def test_cooling_uses_fresh_bootstrap_snapshot_and_renders_final_temperature_first(
+    client,
+    db_session,
+    monkeypatch,
+):
+    del db_session
+    monkeypatch.setattr(
+        'services.public_service.get_bootstrap_payload',
+        lambda: {
+            'snapshot_id': 'snapshot-cooling-12345678',
+            'fetched_at': '2026-08-12T20:30:00+08:00',
+            'stale': False,
+            'current_stale': False,
+            'risk_stale': False,
+            'current': _online_weather(31.4),
+        },
+    )
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('已有快照时不得混读旧天气缓存')
+
+    monkeypatch.setattr('services.public_service.get_weather_with_cache', unexpected)
+    response = client.get('/cooling?location=都昌')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'data-temp="31.4"' in body
+    assert 'data-static-value="1"' in body
+    assert '<span class="num">31.4</span>' in body
+    assert '<span class="num">0</span>' not in body
+    assert '天气快照 snapshot' in body
+
+
+@pytest.mark.parametrize(
+    'snapshot_overrides',
+    [
+        {'current_stale': True, 'risk_stale': False},
+        {'current_stale': False, 'risk_stale': True},
+        {'current_stale': False, 'risk_stale': False, 'current': {'is_mock': True}},
+    ],
+)
+def test_cooling_existing_unusable_snapshot_never_shows_temperature_or_reads_legacy(
+    client,
+    db_session,
+    monkeypatch,
+    snapshot_overrides,
+):
+    del db_session
+    snapshot = {
+        'snapshot_id': 'snapshot-unusable-current',
+        'stale': False,
+        'current_stale': False,
+        'risk_stale': False,
+        'current': _online_weather(39.5),
+    }
+    snapshot.update(snapshot_overrides)
+    monkeypatch.setattr(
+        'services.public_service.get_bootstrap_payload',
+        lambda: snapshot,
+    )
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('已有快照时即使不可用也不得混读旧天气缓存')
+
+    monkeypatch.setattr('services.public_service.get_weather_with_cache', unexpected)
+    response = client.get('/cooling?location=都昌')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'data-fx="thermometer"' not in body
+    assert '<span class="num">39.5</span>' not in body
+
+
+def test_county_cooling_filter_keeps_all_configured_community_resources(
+    client,
+    db_session,
+    monkeypatch,
+):
+    from core.db_models import CoolingResource
+
+    db_session.add(CoolingResource(
+        community_code='牛家垄周村',
+        name='周村已核验纳凉点',
+        resource_type='社区服务场所',
+        is_active=True,
+    ))
+    db_session.commit()
+    monkeypatch.setattr(
+        'services.public_service.get_bootstrap_payload',
+        lambda: {
+            'snapshot_id': 'snapshot-county-filter',
+            'stale': True,
+            'current': {},
+        },
+    )
+
+    response = client.get('/cooling?community=都昌')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert '周村已核验纳凉点' in body
+    assert '<option value="都昌"></option>' in body
+    assert '<option value="北京"></option>' not in body
+
+
+def test_filtered_cooling_page_hides_unverified_candidate_preview(client, db_session):
+    del db_session
+    response = client.get('/cooling?community=牛家垄周村')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert '待核验场所预览' not in body
+
+
+def test_cooling_templates_explain_disabled_location_and_keep_server_value_static():
+    project_root = Path(__file__).resolve().parents[1]
+    template = (project_root / 'templates' / 'cooling.html').read_text(encoding='utf-8')
+    script = (project_root / 'static' / 'js' / 'yilao-data-fx-extra.js').read_text(encoding='utf-8')
+
+    assert '当前没有已核验地图点位，暂不能按位置查找' in template
+    assert '地图服务尚未配置，暂不能读取位置' in template
+    assert '开放时间未核验，请出发前确认' in template
+    assert "el.dataset.staticValue !== '1'" in script

--- a/tests/test_input_integrity_and_handoff.py
+++ b/tests/test_input_integrity_and_handoff.py
@@ -138,6 +138,84 @@ def test_invalid_tool_location_returns_422_preserves_input_and_skips_services(
     assert 'data-error-code="invalid_location"' in body
 
 
+@pytest.mark.parametrize('invalid_age', ['0', '121', '99999', 'abc'])
+def test_ml_invalid_age_returns_422_preserves_input_and_skips_services(
+    client,
+    db_session,
+    monkeypatch,
+    invalid_age,
+):
+    user = _create_user(
+        db_session,
+        username=f'ml-invalid-age-{len(invalid_age)}-{ord(invalid_age[0])}',
+    )
+    _login_as(client, user.id)
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('非法年龄不得调用天气或模型服务')
+
+    monkeypatch.setattr('blueprints.tools.get_weather_with_cache', unexpected)
+    monkeypatch.setattr('blueprints.tools.get_ml_service', unexpected)
+    response = client.post(
+        '/ml-prediction',
+        data={
+            'location': '都昌',
+            'age': invalid_age,
+            'csrf_token': 'test-csrf-token',
+        },
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 422
+    assert f'value="{invalid_age}"' in body
+    assert '年龄需填写 1 到 120 之间的整数' in body
+    assert 'data-error-code="invalid_age"' in body
+    assert 'id="mlAge"' in body
+    assert 'aria-invalid="true"' in body
+
+
+@pytest.mark.parametrize('valid_age', ['1', '120'])
+def test_ml_age_accepts_inclusive_boundaries(
+    client,
+    db_session,
+    monkeypatch,
+    valid_age,
+):
+    user = _create_user(
+        db_session,
+        username=f'ml-valid-age-{valid_age}',
+    )
+    _login_as(client, user.id)
+    captured = {}
+
+    monkeypatch.setattr(
+        'blueprints.tools.get_weather_with_cache',
+        lambda _location: (_online_weather(), False),
+    )
+
+    class BoundaryService:
+        def predict_disease_risk(self, user_info, _weather_info):
+            captured['age'] = user_info['age']
+            return {
+                'success': True,
+                'predictions': [{'disease': '健康观察', 'probability': 0.2}],
+            }
+
+    monkeypatch.setattr('blueprints.tools.get_ml_service', lambda: BoundaryService())
+    response = client.post(
+        '/ml-prediction',
+        data={
+            'location': '都昌',
+            'age': valid_age,
+            'csrf_token': 'test-csrf-token',
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured['age'] == int(valid_age)
+    assert f'value="{valid_age}"' in response.get_data(as_text=True)
+
+
 def test_ml_guest_gets_explicit_auth_requirement_without_weather_call(
     client,
     db_session,
@@ -438,7 +516,8 @@ def test_cooling_uses_fresh_bootstrap_snapshot_and_renders_final_temperature_fir
         'services.public_service.get_bootstrap_payload',
         lambda: {
             'snapshot_id': 'snapshot-cooling-12345678',
-            'fetched_at': '2026-08-12T20:30:00+08:00',
+            'fetched_at': '2026-08-12T12:30:00+00:00',
+            'available': True,
             'stale': False,
             'current_stale': False,
             'risk_stale': False,
@@ -459,6 +538,71 @@ def test_cooling_uses_fresh_bootstrap_snapshot_and_renders_final_temperature_fir
     assert '<span class="num">31.4</span>' in body
     assert '<span class="num">0</span>' not in body
     assert '天气快照 snapshot' in body
+    assert '北京时间 2026-08-12 20:30' in body
+
+
+def test_cooling_rejects_carried_current_marked_unavailable(
+    client,
+    db_session,
+    monkeypatch,
+):
+    """独立来源更新可携带旧实况做溯源，避暑页不得把它当当前温度。"""
+    del db_session
+    monkeypatch.setattr(
+        'services.public_service.get_bootstrap_payload',
+        lambda: {
+            'snapshot_id': 'snapshot-cooling-unavailable',
+            'fetched_at': '2026-08-12T12:30:00+00:00',
+            'available': False,
+            'stale': False,
+            'current_stale': False,
+            'risk_stale': False,
+            'current': _online_weather(39.5),
+            'source_status': {
+                'current': {'available': False, 'stale': False},
+            },
+        },
+    )
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError('已有快照时不得回退读取另一套天气缓存')
+
+    monkeypatch.setattr('services.public_service.get_weather_with_cache', unexpected)
+    response = client.get('/cooling?location=都昌')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'data-temp="39.5"' not in body
+    assert '<span class="num">39.5</span>' not in body
+
+
+def test_action_cta_matches_web_and_formal_runtime(app, client, monkeypatch):
+    monkeypatch.setattr(
+        'services.public_service.get_bootstrap_payload',
+        lambda: {
+            'snapshot_id': None,
+            'available': False,
+            'stale': True,
+            'risk_stale': True,
+            'location': {'name': '都昌县'},
+            'current': {},
+            'risk': {},
+            'actions': [],
+            'family_reminder': None,
+            'source_status': {},
+        },
+    )
+
+    app.config['WECHAT_FORMAL_RUNTIME'] = False
+    web_body = client.get('/risk').get_data(as_text=True)
+    assert '在网页记录今天' in web_body
+    assert '打开网页行动入口' in web_body
+    assert '实际确认和求助在微信小程序完成' not in web_body
+
+    app.config['WECHAT_FORMAL_RUNTIME'] = True
+    formal_body = client.get('/risk').get_data(as_text=True)
+    assert '正式行动交接' in formal_body
+    assert '实际确认和求助在微信小程序完成' in formal_body
 
 
 @pytest.mark.parametrize(

--- a/tests/test_miniprogram_runtime.py
+++ b/tests/test_miniprogram_runtime.py
@@ -121,6 +121,53 @@ def _adult_pair(db_session, user, code):
     return _pair(db_session, user, code, member=member)
 
 
+def test_alerts_api_hides_expired_warning_component(
+    client,
+    db_session,
+    monkeypatch,
+):
+    """私密预警接口也必须拒绝组件已过期的旧官方预警。"""
+    owner, token = _user_and_token(db_session, "alerts-expired-owner")
+    pair = _pair(db_session, owner, "70000010")
+    monkeypatch.setattr(
+        "blueprints.mp_api.get_bootstrap_payload",
+        lambda: {
+            "snapshot_id": "snapshot-alerts-expired",
+            "available": True,
+            "stale": False,
+            "current_stale": False,
+            "warnings_stale": False,
+            "location": {"name": "都昌县"},
+            "current": dict(CURRENT),
+            "warnings": [{
+                "title": "已过期红色预警",
+                "level": "红色",
+                "text": "这条旧预警正文不得返回",
+            }],
+            "source_status": {
+                "current": {"available": True, "stale": False},
+                "warnings": {
+                    "available": True,
+                    "stale": True,
+                    "expires_at": "2000-01-01T01:00:00+08:00",
+                },
+            },
+        },
+    )
+
+    response = client.get(
+        f"/mp/api/v1/alerts?pair_id={pair.id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()["data"]
+    assert data["warnings"] == []
+    assert data["warnings_available"] is False
+    assert data["warnings_stale"] is True
+    assert data["weather"]["weather_available"] is True
+
+
 def _grant_health_consent(db_session, user_id, app):
     """会话测试按当前版本显式准备独立健康同意回执。"""
     from core.db_models import User
@@ -1919,6 +1966,57 @@ def test_health_assessment_submit_latest_and_owner_scope(
         headers={"Authorization": f"Bearer {outsider_token}"},
         json=payload,
     ).status_code == 404
+
+
+def test_health_assessment_rejects_partial_current_before_model_or_write(
+    client,
+    db_session,
+    monkeypatch,
+):
+    """只有温度的快照不得靠模型默认值生成正式个人风险。"""
+    from core.db_models import HealthRiskAssessment
+
+    _owner, token = _user_and_token(db_session, "assessment-partial-current")
+    monkeypatch.setattr(
+        "blueprints.mp_api.get_bootstrap_payload",
+        lambda: {
+            "snapshot_id": "snapshot-partial-current",
+            "available": True,
+            "stale": False,
+            "current_stale": False,
+            "current": {
+                "temperature": 39,
+                "data_source": "QWeather",
+                "is_mock": False,
+            },
+            "source_status": {
+                "current": {"available": True, "stale": False},
+            },
+        },
+    )
+
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError("不完整天气不得进入健康风险模型")
+
+    monkeypatch.setattr(
+        "services.health_risk_service.HealthRiskService.assess_personal_weather_health_risk",
+        unexpected,
+    )
+    response = client.post(
+        "/mp/api/v1/health/assessment",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "outdoor_exposure": "medium",
+            "symptom_level": "none",
+            "hydration": "normal",
+            "medication_adherence": "good",
+            "sleep_quality": "fair",
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "weather_snapshot_incomplete"
+    assert HealthRiskAssessment.query.count() == 0
 
 
 def test_health_assessment_database_failure_does_not_log_sensitive_values(

--- a/tests/test_miniprogram_runtime.py
+++ b/tests/test_miniprogram_runtime.py
@@ -157,10 +157,13 @@ def test_snapshot_fresh_at_2959_and_stale_at_3001(app, db_session):
 
         record = MiniProgramSnapshot.query.filter_by(snapshot_id=snapshot_id).one()
         fresh = snapshot_payload(record, now=fetched_at + timedelta(minutes=29, seconds=59))
+        exact_expiry = snapshot_payload(record, now=fetched_at + timedelta(minutes=30))
         stale = snapshot_payload(record, now=fetched_at + timedelta(minutes=30, seconds=1))
 
     assert fresh["ttl_seconds"] == 1800
     assert fresh["stale"] is False
+    assert exact_expiry["stale"] is True
+    assert exact_expiry["current_stale"] is True
     assert stale["stale"] is True
     assert fresh["snapshot_id"] == stale["snapshot_id"]
     assert fresh["family_reminder"]["date"]

--- a/tests/test_motion_widgets.py
+++ b/tests/test_motion_widgets.py
@@ -39,6 +39,53 @@ def _login_as(client, user_id, csrf_token='test-csrf-token'):
         session['_csrf_token'] = csrf_token
 
 
+def _dashboard_snapshot(current=None, forecast=None, *, risk_available=True):
+    """构造 dashboard 契约使用的县级持久化快照。"""
+    weather = current or {
+        'temperature': 27.5,
+        'temperature_max': 30,
+        'temperature_min': 22,
+        'humidity': 64,
+        'pressure': 1008,
+        'weather_condition': '多云',
+        'wind_speed': 2.5,
+        'aqi': 42,
+        'is_mock': False,
+        'data_source': 'QWeather',
+    }
+    risk = {
+        'available': risk_available,
+        'level': '低风险' if risk_available else '未知',
+        'score': 28 if risk_available else None,
+        'calculation': {
+            'heat_result': {
+                'risk_level': 'low',
+                'risk_score': 28,
+                'heat_index': 28,
+                'night_min': weather.get('temperature_min'),
+                'consecutive_hot_days': 0,
+            },
+        } if risk_available else {},
+    }
+    return {
+        'snapshot_id': '87654321-1234-5678-1234-567812345678',
+        'fetched_at': '2026-08-12T01:02:03+00:00',
+        'expires_at': '2026-08-12T01:32:03+00:00',
+        'available': True,
+        'stale': False,
+        'current_stale': False,
+        'forecast_stale': False,
+        'warnings_stale': False,
+        'risk_stale': not risk_available,
+        'location': {'name': '都昌县', 'code': '116.20,29.27'},
+        'current': weather,
+        'forecast': forecast or [],
+        'risk': risk,
+        'actions': [{'title': '日常补水', 'detail': '少量多次喝水'}] if risk_available else [],
+        'source_status': {},
+    }
+
+
 def test_dashboard_renders_temperature_and_registered_metric_widgets(client, db_session, monkeypatch):
     from core.db_models import FamilyMember, FamilyMemberProfile, User
 
@@ -61,25 +108,8 @@ def test_dashboard_renders_temperature_and_registered_metric_widgets(client, db_
     db_session.commit()
     _login_as(client, user.id)
     monkeypatch.setattr(
-        'services.user.dashboard_service.get_weather_with_cache',
-        lambda location: ({
-            'temperature': 27.5,
-            'temperature_max': 30,
-            'temperature_min': 22,
-            'humidity': 64,
-            'pressure': 1008,
-            'weather_condition': '多云',
-            'wind_speed': 2.5,
-            'aqi': 42,
-            'is_mock': False,
-            'data_source': 'QWeather',
-        }, False),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        'services.user.dashboard_service.get_qweather_forecast_with_cache',
-        lambda location, days=7: ([], False, {'error': 'qweather_unavailable'}),
-        raising=False,
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: _dashboard_snapshot(),
     )
 
     response = client.get('/dashboard')
@@ -93,7 +123,126 @@ def test_dashboard_renders_temperature_and_registered_metric_widgets(client, db_
     assert '橙线 = 当前登记值定位' in body
 
 
-def test_dashboard_forecast_uses_qweather_cards(client, db_session, monkeypatch):
+def test_dashboard_uses_one_persisted_snapshot_without_cache_or_weather_write(
+    client,
+    db_session,
+    monkeypatch,
+):
+    """正式快照存在时，天气、风险和页面编号必须来自同一份只读记录。"""
+    from core.db_models import User, WeatherData
+
+    user = User(username='dashboard_snapshot_user', role='user', community='都昌')
+    user.set_password('testpass')
+    db_session.add(user)
+    db_session.commit()
+    _login_as(client, user.id)
+    snapshot = {
+        'snapshot_id': '12345678-1234-5678-1234-567812345678',
+        'fetched_at': '2026-08-12T01:02:03+00:00',
+        'expires_at': '2026-08-12T01:32:03+00:00',
+        'available': True,
+        'stale': False,
+        'current_stale': False,
+        'forecast_stale': False,
+        'warnings_stale': False,
+        'risk_stale': False,
+        'location': {'name': '都昌县', 'code': '116.20,29.27'},
+        'current': {
+            'temperature': 31.25,
+            'temperature_max': 35,
+            'temperature_min': 25,
+            'humidity': 66,
+            'pressure': 1005,
+            'weather_condition': '晴',
+            'wind_speed': 2,
+            'aqi': 40,
+            'data_source': 'QWeather',
+            'is_mock': False,
+        },
+        'forecast': [],
+        'risk': {
+            'available': True,
+            'level': '中风险',
+            'score': 66,
+            'calculation': {
+                'heat_result': {
+                    'risk_level': 'medium',
+                    'risk_score': 66,
+                    'heat_index': 35,
+                    'night_min': 25,
+                    'consecutive_hot_days': 1,
+                },
+            },
+        },
+        'actions': [{'title': '及时补水', 'detail': '少量多次喝水'}],
+        'source_status': {'current': {'available': True, 'stale': False}},
+    }
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: snapshot,
+    )
+    from services.user import dashboard_service
+    assert not hasattr(dashboard_service, 'get_weather_with_cache')
+    assert not hasattr(dashboard_service, 'get_qweather_forecast_with_cache')
+
+    response = client.get('/dashboard')
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert 'data-weather-snapshot-id="12345678-1234-5678-1234-567812345678"' in body
+    assert '2026-08-12 09:02' in body
+    assert '<span>31.25</span>' in body
+    assert '<span>66</span>' in body
+    assert 'data-target="31.25"' not in body
+    assert 'data-target="66"' not in body
+    assert '中风险' in body
+    assert WeatherData.query.count() == 0
+
+
+def test_dashboard_without_snapshot_fails_closed_without_weather_cache(
+    client,
+    db_session,
+    monkeypatch,
+):
+    """快照缺失或读取失败时，登录页不能私自切换到另一套天气来源。"""
+    from core.db_models import User, WeatherData
+
+    user = User(username='dashboard_missing_snapshot', role='user', community='都昌')
+    user.set_password('testpass')
+    db_session.add(user)
+    db_session.commit()
+    _login_as(client, user.id)
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: {
+            'snapshot_id': None,
+            'current_stale': True,
+            'risk_stale': True,
+            'forecast_stale': True,
+            'current': {'is_mock': True},
+            'risk': {'available': False},
+            'forecast': [],
+            'source_status': {'status': 'missing'},
+        },
+    )
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_weather_with_cache',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError('无快照时也不得切换到另一份天气缓存')
+        ),
+        raising=False,
+    )
+
+    response = client.get('/dashboard')
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert '天气正在更新，风险等级暂不显示' in body
+    assert 'data-weather-snapshot-id=' not in body
+    assert WeatherData.query.count() == 0
+
+
+def test_dashboard_forecast_uses_persisted_snapshot_cards(client, db_session, monkeypatch):
     from core.db_models import User
 
     user = User(username='dashboard_qweather_user', role='user', community='都昌')
@@ -118,62 +267,26 @@ def test_dashboard_forecast_uses_qweather_cards(client, db_session, monkeypatch)
         })
     qweather_days[1]['temperature_max'] = 26
     qweather_days[1]['temperature_min'] = 18
+    qweather_days[1]['risk_level'] = '中风险'
+    qweather_days[1]['risk_score'] = 43
 
-    captured = {}
-
-    def fake_qweather(location, days=7):
-        captured['location'] = location
-        captured['days'] = days
-        return qweather_days, False, {'source': 'QWeather'}
-
-    class FakeForecastService:
-        def generate_7day_forecast(self, forecast_temps, start_date=None, context=None):
-            captured['start_date'] = start_date
-            captured['context'] = context
-            forecasts = []
-            for idx, _entry in enumerate(forecast_temps):
-                day = start + timedelta(days=idx)
-                forecasts.append({
-                    'date': day.strftime('%Y-%m-%d'),
-                    'probability_high_visits': 10 + idx,
-                    'composite_exposure': {'score': 18 + idx, 'level': '低'},
-                })
-            return forecasts, {'recommendations': []}
-
+    for idx, item in enumerate(qweather_days):
+        item.setdefault('risk_score', 18 + idx)
+        item.setdefault('risk_level', '低风险')
+        item['risk_available'] = True
     monkeypatch.setattr(
-        'services.user.dashboard_service.get_qweather_forecast_with_cache',
-        fake_qweather,
-        raising=False,
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: _dashboard_snapshot(forecast=qweather_days),
     )
-    monkeypatch.setattr(
-        'services.user.dashboard_service.get_weather_with_cache',
-        lambda _location: ({
-            'temperature': 27,
-            'temperature_max': 30,
-            'temperature_min': 22,
-            'humidity': 64,
-            'pm25': 18,
-            'aqi': 42,
-            'data_source': 'QWeather',
-            'is_mock': False,
-        }, False),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        'services.user.dashboard_service.get_forecast_service',
-        lambda: FakeForecastService(),
-        raising=False,
-    )
+    from services.user import dashboard_service
+    assert not hasattr(dashboard_service, 'get_qweather_forecast_with_cache')
 
     response = client.get('/dashboard')
 
     assert response.status_code == 200
     body = response.get_data(as_text=True)
-    assert captured['location'] == '都昌'
-    assert captured['days'] == 7
-    assert captured['start_date'] == start
-    assert captured['context'] == {'pm25': 18.0, 'aqi': 42.0}
     assert '26° / 18°' in body
+    assert '中风险' in body
     assert '演示风险' not in body
     assert '34°/26°' not in body
 
@@ -202,7 +315,7 @@ def test_dashboard_forecast_failure_does_not_render_demo_heat(client, db_session
     assert '34°/26°' not in body
 
 
-def test_dashboard_forecast_generation_failure_marks_risk_unknown(client, db_session, monkeypatch):
+def test_dashboard_forecast_snapshot_marks_unavailable_risk_unknown(client, db_session, monkeypatch):
     from core.db_models import User
 
     user = User(username='dashboard_forecast_unknown_user', role='user', community='都昌')
@@ -226,19 +339,11 @@ def test_dashboard_forecast_generation_failure_marks_risk_unknown(client, db_ses
             'is_mock': False,
         })
 
-    class FailingForecastService:
-        def generate_7day_forecast(self, forecast_temps, start_date=None, context=None):
-            raise RuntimeError('forecast unavailable')
-
+    for item in qweather_days:
+        item.update(risk_available=False, risk_score=None, risk_level='未知')
     monkeypatch.setattr(
-        'services.user.dashboard_service.get_qweather_forecast_with_cache',
-        lambda location, days=7: (qweather_days, False, {'source': 'QWeather'}),
-        raising=False,
-    )
-    monkeypatch.setattr(
-        'services.user.dashboard_service.get_forecast_service',
-        lambda: FailingForecastService(),
-        raising=False,
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: _dashboard_snapshot(forecast=qweather_days),
     )
 
     response = client.get('/dashboard')

--- a/tests/test_motion_widgets.py
+++ b/tests/test_motion_widgets.py
@@ -118,6 +118,8 @@ def test_dashboard_renders_temperature_and_registered_metric_widgets(client, db_
     body = response.get_data(as_text=True)
     assert 'data-fx="thermo-bar"' in body
     assert '已登记健康指标' in body
+    assert '在网页记录今天' in body
+    assert '查看小程序交接方式' not in body
     assert 'data-fx="sparkline"' in body
     assert '父亲 · 当前登记' in body
     assert '橙线 = 当前登记值定位' in body
@@ -240,6 +242,221 @@ def test_dashboard_without_snapshot_fails_closed_without_weather_cache(
     assert '天气正在更新，风险等级暂不显示' in body
     assert 'data-weather-snapshot-id=' not in body
     assert WeatherData.query.count() == 0
+
+
+def test_dashboard_rejects_carried_current_marked_unavailable(
+    client,
+    db_session,
+    monkeypatch,
+):
+    """独立预警更新可携带旧实况做溯源，但首页不得继续显示它。"""
+    from core.db_models import User
+
+    user = User(username='dashboard_carried_current', role='user', community='都昌')
+    user.set_password('testpass')
+    db_session.add(user)
+    db_session.commit()
+    _login_as(client, user.id)
+    snapshot = _dashboard_snapshot()
+    snapshot.update({
+        'available': False,
+        'stale': False,
+        'current_stale': False,
+        'risk_stale': True,
+        'source_status': {
+            'current': {'available': False, 'stale': False},
+            'risk': {'available': False, 'stale': True},
+            'warnings': {'available': True, 'stale': False},
+        },
+    })
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: snapshot,
+    )
+
+    body = client.get('/dashboard').get_data(as_text=True)
+
+    assert '天气正在更新，风险等级暂不显示' in body
+    assert '<span>27.5</span>' not in body
+
+
+def test_dashboard_rejects_risk_when_root_snapshot_is_unavailable(
+    client,
+    db_session,
+    monkeypatch,
+):
+    """根快照不可用时，不得继续展示矛盾组件里的旧风险和行动。"""
+    from core.db_models import User
+
+    user = User(username='dashboard_unavailable_risk', role='user', community='都昌')
+    user.set_password('testpass')
+    db_session.add(user)
+    db_session.commit()
+    _login_as(client, user.id)
+    snapshot = _dashboard_snapshot()
+    snapshot.update({
+        'available': False,
+        'risk_stale': False,
+        'risk': {
+            'available': True,
+            'level': '高风险',
+            'score': 92,
+            'calculation': {
+                'heat_result': {
+                    'risk_level': 'high',
+                    'risk_score': 92,
+                },
+            },
+        },
+        'actions': [{'title': '旧高温行动', 'detail': '这条行动不得展示'}],
+        'source_status': {
+            'risk': {'available': True, 'stale': False},
+        },
+    })
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: snapshot,
+    )
+
+    body = client.get('/dashboard').get_data(as_text=True)
+
+    assert '<span>92</span>' not in body
+    assert '旧高温行动' not in body
+    assert '天气正在更新，风险等级暂不显示' in body
+
+
+def test_dashboard_rejects_expired_warning_component(
+    client,
+    db_session,
+    monkeypatch,
+):
+    """顶层标记与组件冲突时，以组件过期状态关闭旧官方预警。"""
+    from core.db_models import User
+
+    user = User(username='dashboard_expired_warning', role='user', community='都昌')
+    user.set_password('testpass')
+    db_session.add(user)
+    db_session.commit()
+    _login_as(client, user.id)
+    snapshot = _dashboard_snapshot()
+    snapshot.update({
+        'warnings_stale': False,
+        'warnings': [{
+            'title': '已过期红色预警',
+            'level': '红色',
+            'text': '这条旧预警正文不得展示',
+            'issued_at': '2000-01-01T00:00:00+08:00',
+        }],
+        'source_status': {
+            'warnings': {
+                'available': True,
+                'stale': True,
+                'expires_at': '2000-01-01T01:00:00+08:00',
+            },
+        },
+    })
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: snapshot,
+    )
+
+    body = client.get('/dashboard').get_data(as_text=True)
+
+    assert '已过期红色预警' not in body
+    assert '这条旧预警正文不得展示' not in body
+
+
+def test_dashboard_rejects_expired_forecast_component(
+    client,
+    db_session,
+    monkeypatch,
+):
+    """组件已过期时，顶层 fresh 标记不能继续放行旧逐日预报。"""
+    from core.db_models import User
+
+    user = User(username='dashboard_expired_forecast', role='user', community='都昌')
+    user.set_password('testpass')
+    db_session.add(user)
+    db_session.commit()
+    _login_as(client, user.id)
+    day = today_local() + timedelta(days=1)
+    snapshot = _dashboard_snapshot(forecast=[{
+        'date': day.strftime('%Y-%m-%d'),
+        'temperature_max': 49,
+        'temperature_min': 39,
+        'humidity': 80,
+        'condition': '旧预报标记',
+        'risk_available': True,
+        'risk_score': 99,
+        'risk_level': '极高风险',
+    }])
+    snapshot.update({
+        'available': False,
+        'stale': True,
+        'forecast_stale': False,
+        'source_status': {
+            'forecast': {
+                'available': True,
+                'stale': True,
+                'expires_at': '2000-01-01T01:00:00+08:00',
+            },
+        },
+    })
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: snapshot,
+    )
+
+    body = client.get('/dashboard').get_data(as_text=True)
+
+    assert '49° / 39°' not in body
+    assert '旧预报标记' not in body
+    assert '极高风险' not in body
+
+
+def test_dashboard_allows_independently_fresh_forecast_component(
+    client,
+    db_session,
+    monkeypatch,
+):
+    """当前天气失败时，明确新鲜的独立预报仍可展示。"""
+    from core.db_models import User
+
+    user = User(username='dashboard_fresh_forecast', role='user', community='都昌')
+    user.set_password('testpass')
+    db_session.add(user)
+    db_session.commit()
+    _login_as(client, user.id)
+    day = today_local() + timedelta(days=1)
+    snapshot = _dashboard_snapshot(forecast=[{
+        'date': day.strftime('%Y-%m-%d'),
+        'temperature_max': 25,
+        'temperature_min': 17,
+        'humidity': 60,
+        'condition': '独立新鲜预报',
+        'risk_available': True,
+        'risk_score': 20,
+        'risk_level': '低风险',
+    }])
+    snapshot.update({
+        'available': False,
+        'stale': True,
+        'current_stale': True,
+        'risk_stale': True,
+        'forecast_stale': False,
+        'source_status': {
+            'forecast': {'available': True, 'stale': False},
+        },
+    })
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_bootstrap_payload',
+        lambda: snapshot,
+    )
+
+    body = client.get('/dashboard').get_data(as_text=True)
+
+    assert '25° / 17°' in body
+    assert '独立新鲜预报' in body
 
 
 def test_dashboard_forecast_uses_persisted_snapshot_cards(client, db_session, monkeypatch):

--- a/tests/test_mp_api_auth.py
+++ b/tests/test_mp_api_auth.py
@@ -989,31 +989,62 @@ def test_elder_profiles_require_sensitive_scope_for_read_and_write(
         assert denied.get_json()["error"] == "insufficient_scope"
 
 
-def test_profile_requires_privacy_consent_before_generating_api_token(
+def test_admin_profile_requires_consent_and_current_password_for_legacy_token(
     app,
-    authenticated_client,
+    admin_client,
     db_session,
 ):
     from core.db_models import ApiToken
 
-    missing_consent = authenticated_client.post(
+    profile_html = admin_client.get("/profile").get_data(as_text=True)
+    assert 'name="current_password"' in profile_html
+    assert 'autocomplete="current-password"' in profile_html
+
+    missing_consent = admin_client.post(
         "/profile",
         data={
             "csrf_token": "test-csrf-token",
             "form_id": "api_token",
             "token_name": "未同意设备",
+            "current_password": "testpass",
         },
     )
     assert missing_consent.status_code == 302
     assert ApiToken.query.count() == 0
 
-    accepted = authenticated_client.post(
+    missing_password = admin_client.post(
+        "/profile",
+        data={
+            "csrf_token": "test-csrf-token",
+            "form_id": "api_token",
+            "token_name": "缺少密码设备",
+            "miniprogram_privacy_consent": "1",
+        },
+    )
+    assert missing_password.status_code == 302
+    assert ApiToken.query.count() == 0
+
+    wrong_password = admin_client.post(
+        "/profile",
+        data={
+            "csrf_token": "test-csrf-token",
+            "form_id": "api_token",
+            "token_name": "错密设备",
+            "miniprogram_privacy_consent": "1",
+            "current_password": "wrong-password",
+        },
+    )
+    assert wrong_password.status_code == 302
+    assert ApiToken.query.count() == 0
+
+    accepted = admin_client.post(
         "/profile",
         data={
             "csrf_token": "test-csrf-token",
             "form_id": "api_token",
             "token_name": "本人手机",
             "miniprogram_privacy_consent": "1",
+            "current_password": "testpass",
         },
     )
     assert accepted.status_code == 302
@@ -1021,6 +1052,70 @@ def test_profile_requires_privacy_consent_before_generating_api_token(
     assert record.expires_at is not None
     assert record.scopes
     assert record.privacy_consent_version == app.config["WX_MINIPROGRAM_PRIVACY_VERSION"]
+
+
+def test_non_admin_roles_cannot_post_legacy_api_token(
+    client,
+    db_session,
+):
+    from core.db_models import ApiToken, User
+
+    for index, role in enumerate(("user", "caregiver", "community"), start=1):
+        user = User(username=f"legacy-token-{role}", role=role)
+        user.set_password("RolePassword1!")
+        db_session.add(user)
+        db_session.commit()
+        with client.session_transaction() as flask_session:
+            flask_session.clear()
+            flask_session["_user_id"] = user.get_id()
+            flask_session["_fresh"] = True
+            flask_session["_csrf_token"] = f"legacy-token-role-{index}"
+
+        denied = client.post(
+            "/profile",
+            data={
+                "csrf_token": f"legacy-token-role-{index}",
+                "form_id": "api_token",
+                "token_name": "越权设备",
+                "miniprogram_privacy_consent": "1",
+                "current_password": "RolePassword1!",
+            },
+        )
+        assert denied.status_code == 403
+        assert ApiToken.query.count() == 0
+
+
+def test_legacy_api_token_rechecks_admin_role_inside_owner_guard(
+    admin_client,
+    db_session,
+    monkeypatch,
+):
+    from types import SimpleNamespace
+
+    from core.db_models import ApiToken
+    from services.user import profile_service
+
+    @contextmanager
+    def demoted_owner_guard(_owner_user_id):
+        yield SimpleNamespace(
+            role="user",
+            check_password=lambda _password: True,
+        )
+
+    monkeypatch.setattr(profile_service, "owner_write_guard", demoted_owner_guard)
+    response = admin_client.post(
+        "/profile",
+        data={
+            "csrf_token": "test-csrf-token",
+            "form_id": "api_token",
+            "token_name": "降权竞态设备",
+            "miniprogram_privacy_consent": "1",
+            "current_password": "testpass",
+        },
+    )
+
+    assert response.status_code == 403
+    assert ApiToken.query.count() == 0
 
 
 def test_mp_api_rate_limit_key_uses_stable_client_ip(app):

--- a/tests/test_public_heat_vulnerability_preview.py
+++ b/tests/test_public_heat_vulnerability_preview.py
@@ -81,6 +81,27 @@ def test_public_heat_preview_is_indexable_aggregate_dataset(client):
     assert "不含姓名、手机号、家庭关系、微信身份或用户精确位置" in body
 
 
+def test_public_heat_preview_hero_exposes_safe_full_gis_cta(client):
+    body = client.get("/duchang-heat-vulnerability-map").get_data(as_text=True)
+    hero = body.split('<section class="hv-hero', 1)[1].split("</section>", 1)[0]
+
+    assert "完整 GIS（需登录）" in hero
+    assert 'href="/login?next=/heat-exposure-gis"' in hero
+    assert 'href="/heat-exposure-gis"' not in hero
+
+
+def test_authenticated_heat_preview_hero_links_directly_to_full_gis(
+    authenticated_client,
+):
+    body = authenticated_client.get(
+        "/duchang-heat-vulnerability-map"
+    ).get_data(as_text=True)
+    hero = body.split('<section class="hv-hero', 1)[1].split("</section>", 1)[0]
+
+    assert 'href="/heat-exposure-gis"' in hero
+    assert "完整 GIS（需登录）" not in hero
+
+
 def test_public_heat_preview_has_machine_readable_dataset_contract(client):
     body = client.get(
         "/duchang-heat-vulnerability-map"
@@ -130,6 +151,7 @@ def test_public_heat_preview_feature_flag_removes_dead_data_links(app, client):
     assert response.status_code == 200
     assert "/data/duchang-heat-exposure.geojson" not in body
     assert "/static/js/heat-vulnerability-preview.js" not in body
+    assert "完整 GIS" not in body
     assert "distribution" not in dataset
     assert client.get("/data/duchang-heat-exposure.geojson").status_code == 404
 

--- a/tests/test_public_heat_vulnerability_preview.py
+++ b/tests/test_public_heat_vulnerability_preview.py
@@ -102,6 +102,19 @@ def test_authenticated_heat_preview_hero_links_directly_to_full_gis(
     assert "完整 GIS（需登录）" not in hero
 
 
+def test_guest_heat_preview_hero_requires_real_login(client):
+    client.get("/guest", follow_redirects=False)
+
+    body = client.get(
+        "/duchang-heat-vulnerability-map"
+    ).get_data(as_text=True)
+    hero = body.split('<section class="hv-hero', 1)[1].split("</section>", 1)[0]
+
+    assert "完整 GIS（需登录）" in hero
+    assert 'href="/login?next=/heat-exposure-gis"' in hero
+    assert 'href="/heat-exposure-gis"' not in hero
+
+
 def test_public_heat_preview_has_machine_readable_dataset_contract(client):
     body = client.get(
         "/duchang-heat-vulnerability-map"

--- a/tests/test_public_risk_service.py
+++ b/tests/test_public_risk_service.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""公开家庭提醒的数据依赖合同回归。"""
+
+from services.public_risk_service import build_public_family_reminder
+
+
+CURRENT = {
+    "temperature": 36,
+    "temperature_max": 38,
+    "temperature_min": 28,
+    "humidity": 70,
+    "data_source": "QWeather",
+    "is_mock": False,
+}
+WARNING = {"title": "都昌县高温橙色预警"}
+
+
+def test_family_reminder_declares_current_only_dependency():
+    reminder = build_public_family_reminder(
+        CURRENT,
+        [],
+        risk={"level": "高风险"},
+        available=True,
+        date_value="2026-08-12",
+    )
+
+    assert reminder["depends_on"] == ["current"]
+
+
+def test_family_reminder_declares_current_and_warning_dependencies():
+    reminder = build_public_family_reminder(
+        CURRENT,
+        [WARNING],
+        risk={"level": "高风险"},
+        available=True,
+        date_value="2026-08-12",
+    )
+
+    assert reminder["depends_on"] == ["current", "warnings"]
+
+
+def test_warning_only_reminder_keeps_warning_provenance():
+    reminder = build_public_family_reminder(
+        {},
+        [WARNING],
+        risk={"level": "未知"},
+        available=False,
+        date_value="2026-08-12",
+    )
+
+    assert reminder["depends_on"] == ["warnings"]
+    assert reminder["weather_tags"] == ["heat"]
+
+
+def test_generic_reminder_explicitly_declares_zero_dependencies():
+    reminder = build_public_family_reminder(
+        {},
+        [],
+        risk={"level": "未知"},
+        available=False,
+        date_value="2026-08-12",
+    )
+
+    assert reminder["depends_on"] == []
+    assert reminder["weather_tags"] == ["general"]

--- a/tests/test_public_token_flow.py
+++ b/tests/test_public_token_flow.py
@@ -243,7 +243,8 @@ def test_formal_wechat_runtime_stops_web_entry_before_reading_family_data(
     entry = client.get("/e/formal-readonly-page-token", follow_redirects=False)
     assert entry.status_code == 200
     entry_body = entry.get_data(as_text=True)
-    assert "当前网页仅供查看停用说明" in entry_body
+    assert "去“宜老平安”完成家庭打卡" in entry_body
+    assert "data-miniprogram-path=\"pages/actions/index\"" in entry_body
     assert 'name="short_code"' not in entry_body
     response = client.post(
         "/elder/enter",
@@ -253,7 +254,8 @@ def test_formal_wechat_runtime_stops_web_entry_before_reading_family_data(
 
     assert response.status_code == 200
     body = response.get_data(as_text=True)
-    assert "当前网页仅供查看停用说明" in body
+    assert "去“宜老平安”完成家庭打卡" in body
+    assert "data-miniprogram-path=\"pages/actions/index\"" in body
     assert "不会读取短码、兑换安全链接或写入家庭记录" in body
     assert 'name="short_code"' not in body
     assert 'action="/e/formal-readonly-page-token/checkin"' not in body
@@ -306,7 +308,8 @@ def test_formal_wechat_runtime_stops_debrief_get_before_family_lookup(
 
     assert response.status_code == 200
     body = response.get_data(as_text=True)
-    assert "当前网页仅供查看停用说明" in body
+    assert "去“宜老平安”完成家庭打卡" in body
+    assert "data-miniprogram-path=\"pages/actions/index\"" in body
     assert 'name="short_code"' not in body
 
 

--- a/tests/test_push_dispatch.py
+++ b/tests/test_push_dispatch.py
@@ -663,6 +663,110 @@ def test_dispatch_fails_closed_without_fresh_available_snapshot(
         assert AlertDelivery.query.count() == 0
 
 
+def test_dispatch_sends_fresh_official_warning_without_current_weather(
+    app,
+    db_session,
+    monkeypatch,
+):
+    from core.db_models import AlertDelivery, WeatherAlert
+    from core.time_utils import utcnow
+    from services.push import dispatch as dispatch_mod
+    from services.miniprogram_service import canonical_location
+
+    with app.app_context():
+        _create_push_recipient(
+            db_session,
+            username="warning-only-recipient",
+            short_code="91000004",
+        )
+        now = utcnow()
+        payload = {
+            "snapshot_id": "warning-only-dispatch",
+            "available": False,
+            "stale": True,
+            "current_stale": True,
+            "warnings_stale": False,
+            "location": canonical_location(),
+            # 旧实况故意保留高温值，派发层必须把它清空。
+            "current": dict(DISPATCH_CURRENT),
+            "warnings": [{
+                "type": "高温",
+                "level": "红色",
+                "title": "高温红色预警",
+                "text": "请减少户外活动。",
+            }],
+            "source_status": {
+                "current": {"available": False, "stale": True},
+                "warnings": {"available": True, "stale": False},
+            },
+        }
+        monkeypatch.setattr(
+            dispatch_mod,
+            "get_bootstrap_payload",
+            lambda **_kwargs: payload,
+        )
+        monkeypatch.setattr(
+            dispatch_mod,
+            "wxpusher_send",
+            lambda *_args, **_kwargs: {"ok": True, "msg_id": "warning-only"},
+        )
+        _forbid_weather_upstream(monkeypatch)
+
+        result = dispatch_mod.dispatch_alerts(now=now)
+
+        assert result["sent"] == 1
+        assert AlertDelivery.query.filter_by(status="sent").count() == 1
+        alert = WeatherAlert.query.one()
+        assert alert.alert_type == "高温"
+        assert alert.alert_level == "红色"
+
+
+def test_dispatch_stops_when_current_and_warnings_are_unusable(
+    app,
+    db_session,
+    monkeypatch,
+):
+    from core.time_utils import utcnow
+    from services.push import dispatch as dispatch_mod
+    from services.miniprogram_service import canonical_location
+
+    with app.app_context():
+        _create_push_recipient(
+            db_session,
+            username="double-unavailable-recipient",
+            short_code="91000005",
+        )
+        payload = {
+            "snapshot_id": "double-unavailable-dispatch",
+            "available": False,
+            "stale": True,
+            "current_stale": True,
+            "warnings_stale": True,
+            "location": canonical_location(),
+            "current": dict(DISPATCH_CURRENT),
+            "warnings": [{"type": "高温", "level": "红色"}],
+            "source_status": {
+                "current": {"available": False, "stale": True},
+                "warnings": {"available": False, "stale": True},
+            },
+        }
+        monkeypatch.setattr(
+            dispatch_mod,
+            "get_bootstrap_payload",
+            lambda **_kwargs: payload,
+        )
+        monkeypatch.setattr(
+            dispatch_mod,
+            "wxpusher_send",
+            lambda *_args, **_kwargs: pytest.fail("双组件不可用时不得推送"),
+        )
+
+        result = dispatch_mod.dispatch_alerts(now=utcnow())
+
+        assert result["status"] == "snapshot_unavailable"
+        assert result["alerts"] == 0
+
+
 def test_threshold_alert_rejects_mock_weather():
     from services.push.dispatch import _threshold_alert
 

--- a/tests/test_session_revocation.py
+++ b/tests/test_session_revocation.py
@@ -130,6 +130,7 @@ def test_password_change_revokes_all_other_sessions_and_refreshes_current_browse
             'form_id': 'password',
             'old_password': 'OldPassword1!',
             'new_password': 'NewPassword2!',
+            'confirm_password': 'NewPassword2!',
             'csrf_token': current_csrf,
         },
         follow_redirects=False,

--- a/tests/test_weather_cache_sync.py
+++ b/tests/test_weather_cache_sync.py
@@ -798,4 +798,5 @@ def test_unavailable_warnings_do_not_feed_family_reminder(app, db_session, monke
 
     assert payload["warnings_stale"] is False
     assert payload["source_status"]["warnings"]["available"] is False
+    assert payload["warnings"] == []
     assert captured["warnings"] == []

--- a/tests/test_weather_cache_sync.py
+++ b/tests/test_weather_cache_sync.py
@@ -644,3 +644,112 @@ def test_snapshot_expiry_uses_earliest_required_source(app, db_session):
     assert payload["expires_at"] == (forecast_time + timedelta(minutes=30)).isoformat()
     assert payload["source_status"]["forecast"]["fetched_at"] == forecast_time.isoformat()
     assert payload["source_status"]["budget_guard"] == "enabled"
+
+
+def test_stale_forecast_does_not_hide_fresh_current_risk(app, db_session):
+    """总快照过期时，各页面仍应按自己依赖的来源判断可用性。"""
+    from core.time_utils import utcnow
+    from services.miniprogram_service import persist_snapshot, snapshot_payload
+
+    cycle_time = utcnow().replace(microsecond=0)
+    forecast_time = cycle_time - timedelta(minutes=31)
+    current = {
+        "temperature": 35,
+        "temperature_max": 38,
+        "temperature_min": 27,
+        "humidity": 70,
+        "data_source": "QWeather",
+        "is_mock": False,
+    }
+    forecast = [{
+        "date": cycle_time.date().isoformat(),
+        "temperature_max": 38,
+        "temperature_min": 27,
+        "temperature_mean": 32.5,
+        "humidity": 70,
+        "data_source": "QWeather",
+        "is_mock": False,
+    }]
+    with app.app_context():
+        record = persist_snapshot(
+            current,
+            forecast,
+            [],
+            fetched_at=cycle_time,
+            forecast_meta={"source": "QWeather"},
+            warning_status={"available": True, "status": "ok"},
+            source_timing={
+                "current": {
+                    "fetched_at": cycle_time,
+                    "expires_at": cycle_time + timedelta(minutes=30),
+                },
+                "forecast": {
+                    "fetched_at": forecast_time,
+                    "expires_at": forecast_time + timedelta(minutes=30),
+                },
+                "warnings": {
+                    "fetched_at": cycle_time,
+                    "expires_at": cycle_time + timedelta(minutes=30),
+                },
+            },
+        )
+        payload = snapshot_payload(record, now=cycle_time)
+
+    assert payload["stale"] is True
+    assert payload["forecast_stale"] is True
+    assert payload["current_stale"] is False
+    assert payload["warnings_stale"] is False
+    assert payload["risk_stale"] is False
+    assert payload["risk"]["available"] is True
+    assert payload["source_status"]["forecast"]["stale"] is True
+    assert payload["source_status"]["risk"]["stale"] is False
+
+
+def test_stale_warnings_do_not_feed_family_reminder(app, db_session, monkeypatch):
+    """预警来源过期时，提醒只能继续使用新鲜的当前天气。"""
+    from core.time_utils import utcnow
+    from services import miniprogram_service
+
+    cycle_time = utcnow().replace(microsecond=0)
+    captured = {}
+
+    def fake_reminder(current, warnings, **_kwargs):
+        captured["warnings"] = warnings
+        return {"date": cycle_time.date().isoformat(), "message": "安全提醒"}
+
+    monkeypatch.setattr(
+        miniprogram_service,
+        "build_public_family_reminder",
+        fake_reminder,
+    )
+    with app.app_context():
+        record = miniprogram_service.persist_snapshot(
+            {
+                "temperature": 35,
+                "temperature_max": 38,
+                "temperature_min": 27,
+                "humidity": 70,
+                "data_source": "QWeather",
+                "is_mock": False,
+            },
+            [],
+            [{"title": "旧高温预警"}],
+            fetched_at=cycle_time,
+            warning_status={"available": True, "status": "ok"},
+            source_timing={
+                "current": {
+                    "fetched_at": cycle_time,
+                    "expires_at": cycle_time + timedelta(minutes=30),
+                },
+                "warnings": {
+                    "fetched_at": cycle_time - timedelta(minutes=31),
+                    "expires_at": cycle_time - timedelta(minutes=1),
+                },
+            },
+        )
+        captured.clear()
+        payload = miniprogram_service.snapshot_payload(record, now=cycle_time)
+
+    assert payload["warnings_stale"] is True
+    assert payload["risk_stale"] is False
+    assert captured["warnings"] == []

--- a/tests/test_weather_cache_sync.py
+++ b/tests/test_weather_cache_sync.py
@@ -519,6 +519,138 @@ def test_dispatch_accepts_complete_qweather_cycle():
     ) is True
 
 
+def test_dispatch_readiness_accepts_warning_only_snapshot():
+    from services.pipelines import sync_weather_cache as pipeline
+
+    payload = {
+        "snapshot_id": "warning-only",
+        "available": False,
+        "stale": True,
+        "current_stale": True,
+        "warnings_stale": False,
+        "current": {},
+        "warnings": [{"type": "高温", "level": "红色"}],
+        "source_status": {
+            "current": {"available": False, "stale": True},
+            "warnings": {"available": True, "stale": False},
+        },
+    }
+
+    assert pipeline._dispatch_ready_snapshot(
+        payload,
+        updated=0,
+        previous_snapshot_id="older",
+    ) is True
+
+
+def test_dispatch_readiness_rejects_double_unavailable_snapshot():
+    from services.pipelines import sync_weather_cache as pipeline
+
+    payload = {
+        "snapshot_id": "double-unavailable",
+        "available": False,
+        "stale": True,
+        "current_stale": True,
+        "warnings_stale": True,
+        "current": {},
+        "warnings": [],
+        "source_status": {
+            "current": {"available": False, "stale": True},
+            "warnings": {"available": False, "stale": True},
+        },
+    }
+
+    assert pipeline._dispatch_ready_snapshot(
+        payload,
+        updated=0,
+        previous_snapshot_id="older",
+    ) is False
+
+
+def test_refresh_persists_fresh_warning_with_expired_carried_current(
+    app,
+    db_session,
+    monkeypatch,
+):
+    from core.time_utils import utcnow
+    from services import miniprogram_service
+    from services import warning_service
+
+    cycle_time = utcnow().replace(microsecond=0)
+    current_fetched_at = cycle_time - timedelta(minutes=60)
+    current_expires_at = cycle_time - timedelta(minutes=30)
+    warning_expires_at = cycle_time + timedelta(minutes=30)
+    current = {
+        "temperature": 36,
+        "temperature_max": 38,
+        "temperature_min": 27,
+        "humidity": 70,
+        "data_source": "QWeather",
+        "is_mock": False,
+    }
+    warning = {
+        "type": "高温",
+        "level": "红色",
+        "title": "高温红色预警",
+        "text": "减少户外活动。",
+    }
+
+    with app.app_context():
+        previous = miniprogram_service.persist_snapshot(
+            current,
+            [],
+            [],
+            fetched_at=current_fetched_at,
+            warning_status={"available": False, "status": "fetch_failed"},
+            source_timing={
+                "current": {
+                    "fetched_at": current_fetched_at,
+                    "expires_at": current_expires_at,
+                },
+            },
+        )
+        previous_id = previous.snapshot_id
+        monkeypatch.setattr(
+            miniprogram_service,
+            "qweather_runtime_configured",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            miniprogram_service,
+            "get_qweather_forecast_with_cache",
+            lambda *_args, **_kwargs: ([], False, {"source": "QWeather"}),
+        )
+        monkeypatch.setattr(
+            warning_service,
+            "get_qweather_warnings_result",
+            lambda *_args, **_kwargs: {
+                "available": True,
+                "status": "success",
+                "warnings": [warning],
+                "fetched_at": cycle_time.isoformat(),
+                "expires_at": warning_expires_at.isoformat(),
+            },
+        )
+
+        record = miniprogram_service.refresh_snapshot_from_cycle(
+            {},
+            weather_service=object(),
+            fetched_at=cycle_time,
+        )
+        payload = miniprogram_service.snapshot_payload(record, now=cycle_time)
+
+    assert payload["snapshot_id"] != previous_id
+    assert payload["available"] is False
+    assert payload["current_stale"] is True
+    assert payload["warnings_stale"] is False
+    assert payload["warnings"] == [warning]
+    assert payload["source_status"]["current"]["expires_at"] == current_expires_at.isoformat()
+    assert payload["source_status"]["warnings"]["fetched_at"] == cycle_time.isoformat()
+    assert payload["source_status"]["warnings"]["expires_at"] == warning_expires_at.isoformat()
+    assert miniprogram_service.snapshot_component_status(payload, "current")["usable"] is False
+    assert miniprogram_service.snapshot_component_status(payload, "warnings")["usable"] is True
+
+
 def test_force_refresh_does_not_reuse_29_minute_forecast(
     app,
     db_session,
@@ -650,6 +782,7 @@ def test_stale_forecast_does_not_hide_fresh_current_risk(app, db_session):
     """总快照过期时，各页面仍应按自己依赖的来源判断可用性。"""
     from core.time_utils import utcnow
     from services.miniprogram_service import persist_snapshot, snapshot_payload
+    from services.pipelines.sync_weather_cache import _trusted_cycle_current
 
     cycle_time = utcnow().replace(microsecond=0)
     forecast_time = cycle_time - timedelta(minutes=31)
@@ -703,6 +836,11 @@ def test_stale_forecast_does_not_hide_fresh_current_risk(app, db_session):
     assert payload["risk"]["available"] is True
     assert payload["source_status"]["forecast"]["stale"] is True
     assert payload["source_status"]["risk"]["stale"] is False
+    assert _trusted_cycle_current(
+        payload,
+        fetched_at=cycle_time,
+        previous_snapshot_id="older-snapshot",
+    ) == current
 
 
 def test_stale_warnings_do_not_feed_family_reminder(app, db_session, monkeypatch):

--- a/tests/test_weather_cache_sync.py
+++ b/tests/test_weather_cache_sync.py
@@ -753,3 +753,49 @@ def test_stale_warnings_do_not_feed_family_reminder(app, db_session, monkeypatch
     assert payload["warnings_stale"] is True
     assert payload["risk_stale"] is False
     assert captured["warnings"] == []
+
+
+def test_unavailable_warnings_do_not_feed_family_reminder(app, db_session, monkeypatch):
+    """来源失败但记录尚未总过期时，也不能把旧预警继续用于提醒。"""
+    from core.time_utils import utcnow
+    from services import miniprogram_service
+
+    cycle_time = utcnow().replace(microsecond=0)
+    captured = {}
+
+    def fake_reminder(current, warnings, **_kwargs):
+        captured["warnings"] = warnings
+        return {"date": cycle_time.date().isoformat(), "message": "安全提醒"}
+
+    monkeypatch.setattr(
+        miniprogram_service,
+        "build_public_family_reminder",
+        fake_reminder,
+    )
+    with app.app_context():
+        record = miniprogram_service.persist_snapshot(
+            {
+                "temperature": 35,
+                "temperature_max": 38,
+                "temperature_min": 27,
+                "humidity": 70,
+                "data_source": "QWeather",
+                "is_mock": False,
+            },
+            [],
+            [{"title": "来源失败前的旧预警"}],
+            fetched_at=cycle_time,
+            warning_status={"available": False, "status": "fetch_failed"},
+            source_timing={
+                "current": {
+                    "fetched_at": cycle_time,
+                    "expires_at": cycle_time + timedelta(minutes=30),
+                },
+            },
+        )
+        captured.clear()
+        payload = miniprogram_service.snapshot_payload(record, now=cycle_time)
+
+    assert payload["warnings_stale"] is False
+    assert payload["source_status"]["warnings"]["available"] is False
+    assert captured["warnings"] == []

--- a/tests/test_web_owner_write_guard.py
+++ b/tests/test_web_owner_write_guard.py
@@ -209,6 +209,7 @@ def test_account_delete_finishes_before_web_write_and_blocks_all_private_rows(
                 "form_id": "password",
                 "old_password": "web-owner-write-test-password",
                 "new_password": "NewConcurrentPassword!",
+                "confirm_password": "NewConcurrentPassword!",
             },
         ),
         ("/location", {"location": "都昌县"}),

--- a/tests/test_web_owner_write_guard.py
+++ b/tests/test_web_owner_write_guard.py
@@ -183,7 +183,7 @@ def test_account_delete_finishes_before_web_write_and_blocks_all_private_rows(
 
 
 @pytest.mark.parametrize(
-    ("path", "payload"),
+    ("path", "payload", "owner_role"),
     (
         (
             "/health-assessment",
@@ -194,6 +194,7 @@ def test_account_delete_finishes_before_web_write_and_blocks_all_private_rows(
                 "medication_adherence": "good",
                 "sleep_quality": "good",
             },
+            "user",
         ),
         (
             "/profile",
@@ -201,7 +202,9 @@ def test_account_delete_finishes_before_web_write_and_blocks_all_private_rows(
                 "form_id": "api_token",
                 "token_name": "删除竞态令牌",
                 "miniprogram_privacy_consent": "1",
+                "current_password": "web-owner-write-test-password",
             },
+            "admin",
         ),
         (
             "/profile",
@@ -211,8 +214,9 @@ def test_account_delete_finishes_before_web_write_and_blocks_all_private_rows(
                 "new_password": "NewConcurrentPassword!",
                 "confirm_password": "NewConcurrentPassword!",
             },
+            "user",
         ),
-        ("/location", {"location": "都昌县"}),
+        ("/location", {"location": "都昌县"}, "user"),
     ),
     ids=("assessment", "api-token", "password", "location"),
 )
@@ -222,13 +226,18 @@ def test_profile_delete_first_blocks_all_profile_private_writes(
     monkeypatch,
     path,
     payload,
+    owner_role,
 ):
     """资料路由完成计算后若注销先提交，不得重建评估、凭证或位置。"""
     from services.health_risk_service import HealthRiskService
     from services.user import profile_service
     from services.user.owner_write_guard import owner_write_guard as real_guard
 
-    owner = _new_owner(db_session, f"profile-delete-first-{path.rsplit('/', 1)[-1]}")
+    owner = _new_owner(
+        db_session,
+        f"profile-delete-first-{path.rsplit('/', 1)[-1]}",
+        role=owner_role,
+    )
     owner_id = int(owner.id)
     original_password_hash = owner.password_hash
     app.config["FEATURE_NOTIFICATIONS"] = False

--- a/tests/test_web_weather_fail_closed.py
+++ b/tests/test_web_weather_fail_closed.py
@@ -179,6 +179,14 @@ def test_daily_risk_snapshot_requires_fresh_real_snapshot(monkeypatch):
         {**valid, 'current': {**REAL_WEATHER, 'is_demo': True}},
         {**valid, 'risk': {'available': False, 'level': '高风险'}},
         {**valid, 'risk': {'available': True, 'level': '未知'}},
+        {
+            **valid,
+            'available': False,
+            'source_status': {
+                'risk': {'available': True, 'stale': False},
+            },
+            'risk_stale': False,
+        },
     ]
 
     for payload in invalid_payloads:
@@ -193,6 +201,26 @@ def test_daily_risk_snapshot_requires_fresh_real_snapshot(monkeypatch):
         caregiver_service,
         'get_bootstrap_payload',
         lambda: valid,
+    )
+    assert caregiver_service._load_daily_risk_snapshot() == {
+        'snapshot_id': 'fresh-real-snapshot',
+        'risk_level': '高风险',
+    }
+
+    forecast_only_stale = {
+        **valid,
+        'stale': True,
+        'forecast_stale': True,
+        'risk_stale': False,
+        'source_status': {
+            'risk': {'available': True, 'stale': False},
+            'forecast': {'available': True, 'stale': True},
+        },
+    }
+    monkeypatch.setattr(
+        caregiver_service,
+        'get_bootstrap_payload',
+        lambda: forecast_only_stale,
     )
     assert caregiver_service._load_daily_risk_snapshot() == {
         'snapshot_id': 'fresh-real-snapshot',


### PR DESCRIPTION
## 这次改了什么

一次性收口 Grok 多角色 QA 暴露的 GIS、注册首登、错误页、输入校验、天气快照新鲜度、行动交接和发布脚本边界，形成服务器与微信小程序的统一候选代码。

## 为什么要改

- 修复 GIS 放大后网格层可能持续消失，以及完整 GIS 入口难发现的问题。
- 修复注册后首登错位、游客导航误显示退出、429/404 英文裸页和表单重试信息丢失。
- 对地点、年龄、健康筛查等输入做服务端严格校验，避免静默截断或错误数据进入风险模型。
- 统一 current、risk、forecast、warnings 的组件级新鲜度合同，阻止过期或不完整快照跨 Web、小程序、照护和推送链路传播，同时保留独立官方预警。
- 完善 Web 与微信正式版行动交接分流，并修复 macOS 下发布归档管道的 SIGPIPE 风险。

## 怎么验证

- Python 全量：`1732 passed, 2 skipped, 11 deselected`。
- 激活发布测试四分片：合计 `187 passed`。
- 微信小程序 Node 全量：`326/326 passed`。
- 独立集成审查：Python `432 passed`，mini + GIS Node `335/335 passed`，未发现仍可复现的 P0-P2。
- Edge：`7/7 passed`；GIS 相机状态机：`9/9 passed`。
- 浏览器桌面与 390px 回归覆盖注册、首登、429、404、风险、行动、健康、ML、公开地图、GIS 门禁与 dashboard；无横向溢出或 JavaScript console error/warn。
- `compileall`、`pip check`、`git diff --check`、密钥与仓库边界检查均通过。
- 修改了 `scripts/deploy.sh`，已运行 `bash -n scripts/deploy.sh`；仓库内 16 个 shell 文件语法检查全部通过。
- 微信小程序主包 `560,826 bytes`，低于内部 1.5 MiB 与平台 2 MiB 门槛。

## 文件去向

无文件迁移。所有产品、测试和发布脚本改动保留在主仓库；临时浏览器、数据库与测试资料未进入仓库。

## 发布边界

- 候选提交：`102a84a1cdf4daef6c890614838deb949235ab18`。
- 精确 SHA 的远端 CI 已完成：21 项成功、1 项条件性跳过、0 失败、0 pending。
- 本 PR 保持 Draft，供最终人工审阅与私有发布配置核验。
- 未执行生产部署、服务器切换或微信上传。
- 本地未配置 AMap 正式密钥，因此真实底图加载由生产配置后的发布前回归继续验证；本轮已验证无密钥降级路径与 GIS 状态机。
- 正式微信冻结仍需私有 `.env.wechat-release` 与 `project.private.config.json` 校验，不在仓库提交。
- Notion 当前无法访问，待回填。
