### PR TITLE
chore: rsync 排除根目录 analysis 研究目录

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -164,6 +164,7 @@ upload_files() {
             --exclude 'tmp' \
             --exclude 'output' \
             --exclude 'blueprints/tools 2.py' \
+            --exclude=/analysis/ \
             -e "ssh $SSH_OPTS" "$LOCAL_DIR/" "$USER@$SERVER:$PROJECT_DIR/"
         return
     fi
@@ -172,7 +173,7 @@ upload_files() {
         expect -c "
             set timeout 600
             set password \$env(SSHPASS)
-        spawn rsync -avz --exclude '__pycache__' --exclude '*.pyc' --exclude 'instance' --exclude 'storage' --exclude 'health_weather.db' --exclude 'data/research/*.xlsx' --exclude 'data/research/*.xls' --exclude '.git' --exclude '.claude' --exclude 'venv' --exclude '.venv' --exclude '.venv2' --exclude '.env' --exclude '.env.local' --exclude '.superpowers' --exclude '.pytest_cache' --exclude '.playwright-cli' --exclude '.vscode' --exclude '.DS_Store' --exclude 'backups' --exclude 'tmp' --exclude 'output' --exclude 'blueprints/tools 2.py' -e \"ssh $SSH_OPTS\" $LOCAL_DIR/ $USER@$SERVER:$PROJECT_DIR/
+        spawn rsync -avz --exclude '__pycache__' --exclude '*.pyc' --exclude 'instance' --exclude 'storage' --exclude 'health_weather.db' --exclude 'data/research/*.xlsx' --exclude 'data/research/*.xls' --exclude '.git' --exclude '.claude' --exclude 'venv' --exclude '.venv' --exclude '.venv2' --exclude '.env' --exclude '.env.local' --exclude '.superpowers' --exclude '.pytest_cache' --exclude '.playwright-cli' --exclude '.vscode' --exclude '.DS_Store' --exclude 'backups' --exclude 'tmp' --exclude 'output' --exclude 'blueprints/tools 2.py' --exclude=/analysis/ -e \"ssh $SSH_OPTS\" $LOCAL_DIR/ $USER@$SERVER:$PROJECT_DIR/
         expect {
                 \"*password:\" {
                     send \"\$password\r\"
@@ -188,7 +189,7 @@ upload_files() {
         return
     fi
 
-    rsync -avz --exclude '__pycache__' --exclude '*.pyc' --exclude 'instance' --exclude 'storage' --exclude 'health_weather.db' --exclude 'data/research/*.xlsx' --exclude 'data/research/*.xls' --exclude '.git' --exclude '.claude' --exclude 'venv' --exclude '.venv' --exclude '.venv2' --exclude '.env' --exclude '.env.local' --exclude '.superpowers' --exclude '.pytest_cache' --exclude '.playwright-cli' --exclude '.vscode' --exclude '.DS_Store' --exclude 'backups' --exclude 'tmp' --exclude 'output' --exclude 'blueprints/tools 2.py' -e "ssh $SSH_OPTS" "$LOCAL_DIR/" "$USER@$SERVER:$PROJECT_DIR/"
+    rsync -avz --exclude '__pycache__' --exclude '*.pyc' --exclude 'instance' --exclude 'storage' --exclude 'health_weather.db' --exclude 'data/research/*.xlsx' --exclude 'data/research/*.xls' --exclude '.git' --exclude '.claude' --exclude 'venv' --exclude '.venv' --exclude '.venv2' --exclude '.env' --exclude '.env.local' --exclude '.superpowers' --exclude '.pytest_cache' --exclude '.playwright-cli' --exclude '.vscode' --exclude '.DS_Store' --exclude 'backups' --exclude 'tmp' --exclude 'output' --exclude 'blueprints/tools 2.py' --exclude=/analysis/ -e "ssh $SSH_OPTS" "$LOCAL_DIR/" "$USER@$SERVER:$PROJECT_DIR/"
 }
 
 echo "步骤1: 测试服务器连接..."

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -76,12 +76,13 @@ if use_sshpass && [ -n "$SSHPASS" ]; then
         --exclude .venv2 \
         --exclude .env \
         --exclude .env.local \
+        --exclude=/analysis/ \
         -e ssh "$LOCAL_DIR/" "$USER@$SERVER:$PROJECT_DIR/"
 elif use_expect && [ -n "$SSHPASS" ]; then
     expect -c "
         set timeout 600
         set password \$env(SSHPASS)
-        spawn rsync -avz --exclude __pycache__ --exclude *.pyc --exclude instance --exclude storage --exclude health_weather.db --exclude .git --exclude venv --exclude .venv --exclude .venv2 --exclude .env --exclude .env.local -e ssh $LOCAL_DIR/ $USER@$SERVER:$PROJECT_DIR/
+        spawn rsync -avz --exclude __pycache__ --exclude *.pyc --exclude instance --exclude storage --exclude health_weather.db --exclude .git --exclude venv --exclude .venv --exclude .venv2 --exclude .env --exclude .env.local --exclude=/analysis/ -e ssh $LOCAL_DIR/ $USER@$SERVER:$PROJECT_DIR/
         expect {
             \"*password:\" {
                 send \"\$password\r\"
@@ -97,7 +98,7 @@ elif use_expect && [ -n "$SSHPASS" ]; then
         exit [lindex \$wait_result 3]
     "
 else
-    rsync -avz --exclude __pycache__ --exclude *.pyc --exclude instance --exclude storage --exclude health_weather.db --exclude .git --exclude venv --exclude .venv --exclude .venv2 --exclude .env --exclude .env.local -e ssh "$LOCAL_DIR/" "$USER@$SERVER:$PROJECT_DIR/"
+    rsync -avz --exclude __pycache__ --exclude *.pyc --exclude instance --exclude storage --exclude health_weather.db --exclude .git --exclude venv --exclude .venv --exclude .venv2 --exclude .env --exclude .env.local --exclude=/analysis/ -e ssh "$LOCAL_DIR/" "$USER@$SERVER:$PROJECT_DIR/"
 fi
 
 # 重启服务

--- a/tests/test_deploy_script.py
+++ b/tests/test_deploy_script.py
@@ -70,6 +70,21 @@ def test_deploy_script_excludes_local_design_drafts():
     assert "--exclude 'blueprints/tools 2.py'" in content
 
 
+def test_deploy_script_excludes_root_analysis_dir():
+    content = _load_deploy_script()
+    flag = "--exclude=/analysis/"
+
+    assert content.count(flag) == 3
+    assert "--exclude '/analysis/'" not in content
+
+    rsync_starts = [idx for idx in range(len(content)) if content.startswith("rsync -avz", idx)]
+    assert len(rsync_starts) == 3
+    for start in rsync_starts:
+        end = content.find("$PROJECT_DIR/", start)
+        assert end != -1
+        assert flag in content[start:end]
+
+
 def test_deploy_script_requires_https_public_base_url():
     content = _load_deploy_script()
 

--- a/tests/test_sync_script.py
+++ b/tests/test_sync_script.py
@@ -56,3 +56,18 @@ def test_sync_script_expect_branch_propagates_child_status():
     assert "set -euo pipefail" in content
     assert content.count("set wait_result [wait]") == 2
     assert content.count("exit [lindex \\$wait_result 3]") == 2
+
+
+def test_sync_script_excludes_root_analysis_dir():
+    content = SYNC_SCRIPT.read_text(encoding="utf-8")
+    flag = "--exclude=/analysis/"
+
+    assert content.count(flag) == 3
+    assert "--exclude '/analysis/'" not in content
+
+    rsync_starts = [idx for idx in range(len(content)) if content.startswith("rsync -avz", idx)]
+    assert len(rsync_starts) == 3
+    for start in rsync_starts:
+        end = content.find("$PROJECT_DIR/", start)
+        assert end != -1
+        assert flag in content[start:end]


### PR DESCRIPTION
## 这次改了什么

- 在 `scripts/deploy.sh` 与 `scripts/sync.sh` 的 6 处 rsync（各 3 处：sshpass 多行、expect 单行、fallback 单行）统一增加 `--exclude=/analysis/`。
- 测试分别读取两个脚本，断言该参数在每个脚本中恰好出现 3 次，且三处 `rsync -avz` 命令都包含它。
- 现有 `test_deploy_script_excludes_local_design_drafts` 对其它带引号 exclude 的断言未改。

## 为什么要改

- 本机未跟踪的研究目录 `analysis/` 会被 rsync 打上服务器。
- 该目录不是产品蓝图 `blueprints.analysis`；排除后零产品行为变化。
- 使用 `=` 形式且带前导 `/`，只匹配仓库根目录 `analysis/`，避免 Expect/Tcl 把单引号当字面字符传给 rsync。
- 本批不追加 `docs/algorithm-audit/`、`outputs/` 等其它排除，不加 `--delete-excluded`，不改 systemd / bind。

## 怎么验证

- [x] 运行了相关 pytest
- [ ] 手动验证了受影响页面 / API
- [ ] 补充了必要文档
- [x] 已检查 `git diff --staged`
- [x] 当前改动只覆盖这一个问题

验证说明：

```text
bash -n scripts/deploy.sh
bash -n scripts/sync.sh
conda run -n case-weather-py312 python -m pytest -q tests/test_deploy_script.py tests/test_sync_script.py
# 结果：12 passed
# 每个脚本中 --exclude=/analysis/ 恰好 3 次，合计 6 处
```

## 文件分类 / 边界检查

- [x] 本 PR 不包含缓存、测试产物、`.claude/`、重复副本或一次性报告
- [x] 如涉及文件迁移，已说明文件去向：主仓库 / 本地归档 / 私有 ops / 本地忽略
- [x] 未提交真实 key、真实 host、真实服务器路径、默认口令
- [x] 如涉及清理仓库，优先处理噪音文件，没有误删运行链路文件
- [x] 如修改 `.sh` 或 `.githooks`，已至少运行一次 `bash -n`

## 关联信息

- 执行者 / Agent：Grok 4.6 extra high（PR-A2 独立 worktree）
- Notion 条目：待回填（当前执行者无 Notion 访问要求以外的回填能力；请维护者回填网站迭代库）
- 分支名：`codex/chore/rsync-exclude-analysis-dir`
- 相关 Issue / 备注：宜老天气通最小修复批次计划 PR-A2
- 相关文件分类说明：产品主仓库运行脚本与必要测试
- `origin/main` 基线 SHA：`6329a1f9b1e1945f4ac27230854b633fbdc0fc89`（fetch 后未前进）
- 本地归档路径（如适用）：无
- Notion 回填责任人 / 说明：请仓库维护者回填 Notion 条目、PR 链接与验证结果

## 备份检查

- [x] 当前分支已 push 到 GitHub
- [x] 本 PR 可以作为本轮工作的远端备份
- [x] 如未完成验证，本 PR 保持 Draft

Made with [Cursor](https://cursor.com)