### PR TITLE
chore: CI 默认测试合并弃用警告检查

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,6 @@ jobs:
           test "$oversized" -eq 0
 
       - name: 运行默认测试
-        run: python -m pytest -q
-
-      - name: 检查弃用警告
         run: >-
           python -m pytest -q
           -W error::DeprecationWarning


### PR DESCRIPTION
## Summary
- 把 CI 里「运行默认测试」和「检查弃用警告」合成一步，避免默认 job 对整仓 pytest 跑两遍。
- 默认步现在是：`python -m pytest -q -W error::DeprecationWarning -W ignore::DeprecationWarning:flask_login.login_manager`。
- `python -m pytest -q -m manual` 仍单独保留；未改 `pytest.ini` 的 `addopts = -m "not manual"`，也未改 compileall / 仓库边界等其它步骤。

## 基线
- `origin/main` @ `6329a1f9b1e1945f4ac27230854b633fbdc0fc89`（与计划书审阅 SHA 一致，fetch 后未前进）

## Test plan
- [x] YAML 合法（PyYAML / Ruby YAML 均可解析）
- [x] 默认 job 里非 `-m manual` 的 pytest 只出现一次
- [x] `-m manual` 步骤仍在
- [x] flask_login 的 `DeprecationWarning` ignore 仍在
- [x] 本地等价命令通过：`conda run -n case-weather-py312 python -m pytest -q -W error::DeprecationWarning -W ignore::DeprecationWarning:flask_login.login_manager` → `394 passed, 11 deselected`
- [ ] GitHub Actions CI 绿


Made with [Cursor](https://cursor.com)