### PR TITLE
fix: 慢病热夜规则改读 temperature_min

### DIFF
--- a/services/chronic_risk_service.py
+++ b/services/chronic_risk_service.py
@@ -277,7 +277,7 @@ class ChronicRiskService:
     
     @staticmethod
     def _parse_night_temperature(weather_data):
-        """Parse overnight min temp: temperature_min → tmin → missing."""
+        """解析夜间最低温度：temperature_min → tmin → 缺失。"""
         if not isinstance(weather_data, dict):
             return None
         for key in ('temperature_min', 'tmin'):

--- a/services/chronic_risk_service.py
+++ b/services/chronic_risk_service.py
@@ -13,6 +13,7 @@ PersonalRisk = DLNMRR × Chronic-layer Age Amplifier × Comorbidity Amplifier
 
 触发条件（可审计）→ 建议模板（可版本化）
 """
+import math
 import pandas as pd
 import numpy as np
 from datetime import datetime, timedelta
@@ -75,10 +76,10 @@ class ChronicRiskService:
                 'trigger': lambda ctx: ctx.get('hot_night', False),
                 'priority': 'high',
                 'category': '热夜预警',
-                'thresholds': {'hot_night': True, 'hot_night_temp': '>22'},
+                'thresholds': {'hot_night': True, 'hot_night_temp': '>=22'},
                 'context_fields': ['hot_night_temp'],
-                'reason_template': '夜间温度偏高（{hot_night_temp}°C）',
-                'template': '今晚预计为热夜(夜间温度>{hot_night_temp}°C)，心血管疾病风险增加，建议：使用空调或风扇，保持卧室凉爽',
+                'reason_template': '预计夜间最低温度为 {hot_night_temp}°C',
+                'template': '今晚预计为热夜(预计夜间最低温度为 {hot_night_temp}°C)，心血管疾病风险增加，建议：使用空调或风扇，保持卧室凉爽',
                 'diseases': ['cardiovascular']
             },
             'heat_wave': {
@@ -274,6 +275,25 @@ class ChronicRiskService:
             return '中风险'
         return '低风险'
     
+    @staticmethod
+    def _parse_night_temperature(weather_data):
+        """Parse overnight min temp: temperature_min → tmin → missing."""
+        if not isinstance(weather_data, dict):
+            return None
+        for key in ('temperature_min', 'tmin'):
+            if key not in weather_data:
+                continue
+            raw = weather_data.get(key)
+            if raw is None:
+                continue
+            try:
+                value = float(raw)
+            except (TypeError, ValueError):
+                continue
+            if math.isfinite(value):
+                return value
+        return None
+
     def predict_individual_risk(self, user_info, weather_data, target_diseases=None):
         """
         预测个体慢病风险
@@ -401,6 +421,7 @@ class ChronicRiskService:
                 max_risk = {'rr': personal_rr, 'disease_type': disease_type}
         
         # 生成个性化建议
+        night_temp = self._parse_night_temperature(weather_data)
         context = {
             'age': age,
             'temperature': temperature,
@@ -410,8 +431,8 @@ class ChronicRiskService:
             'has_chronic_disease': len(chronic_diseases) > 0,
             'disease_count': len(chronic_diseases),
             'aqi': weather_data.get('aqi', 50),
-            'hot_night': weather_data.get('tmin', 15) >= 22 if 'tmin' in weather_data else False,
-            'hot_night_temp': weather_data.get('tmin', 22),
+            'hot_night': night_temp is not None and night_temp >= 22.0,
+            'hot_night_temp': night_temp,
             'heat_wave_days': weather_data.get('heat_wave_days', 0),
             'cold_wave_days': weather_data.get('cold_wave_days', 0)
         }
@@ -518,7 +539,7 @@ class ChronicRiskService:
             'disease_count': context.get('disease_count', 0),
             'aqi': context.get('aqi', 50),
             'hot_night': context.get('hot_night', False),
-            'hot_night_temp': context.get('hot_night_temp', 22),
+            'hot_night_temp': context.get('hot_night_temp'),
             'heat_wave_days': context.get('heat_wave_days', 0),
             'cold_wave_days': context.get('cold_wave_days', 0)
         }

--- a/tests/test_chronic_hot_night.py
+++ b/tests/test_chronic_hot_night.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""慢病热夜规则：夜温读 temperature_min，阈值 ≥22°C。"""
+
+import numpy as np
+import pytest
+
+from services.chronic_risk_service import ChronicRiskService
+
+USER = {'age': 70, 'chronic_diseases': ['高血压']}
+HOT_NIGHT_PHRASE = '预计夜间最低温度为'
+MISLEADING_PHRASE = '夜间温度>'
+
+
+@pytest.fixture
+def chronic_service(monkeypatch):
+    class FakeDLNMService:
+        def calculate_rr(self, temperature, lag_temperatures=None, disease_type=None, age=None):
+            del temperature, lag_temperatures, disease_type, age
+            return 1.0, {
+                'raw_dlnm_rr': 1.0,
+                'dlnm_disease_modifier': 1.0,
+                'dlnm_age_modifier': 1.0,
+                'uncapped_final_rr': 1.0,
+                'dlnm_adjusted_rr': 1.0,
+                'rr_cap': 3.5,
+                'rr_cap_applied': False,
+                'calculation_branch': 'test_stub',
+            }
+
+    monkeypatch.setattr(
+        'services.dlnm_risk_service.get_dlnm_service',
+        lambda: FakeDLNMService(),
+    )
+    return ChronicRiskService()
+
+
+def _predict(service, weather_data):
+    return service.predict_individual_risk(USER, weather_data, target_diseases=['cardiovascular'])
+
+
+def _rule_ids(result):
+    return [item.get('rule_id') for item in result.get('triggered_rules') or []]
+
+
+def _advice_blob(result):
+    texts = []
+    for item in result.get('recommendations') or []:
+        if isinstance(item, dict) and item.get('advice'):
+            texts.append(str(item['advice']))
+    explain = result.get('explain') or {}
+    for reason in explain.get('reasons') or []:
+        texts.append(str(reason))
+    return '\n'.join(texts)
+
+
+def test_temperature_min_22_triggers_without_tmin(chronic_service):
+    night_temp = ChronicRiskService._parse_night_temperature({'temperature_min': 22.0})
+    assert night_temp == pytest.approx(22.0)
+
+    result = _predict(chronic_service, {'temperature': 28, 'temperature_min': 22.0})
+    assert 'heat_night' in _rule_ids(result)
+    blob = _advice_blob(result)
+    assert HOT_NIGHT_PHRASE in blob
+    assert '22' in blob
+    assert MISLEADING_PHRASE not in blob
+
+
+def test_temperature_min_21_9_does_not_trigger(chronic_service):
+    result = _predict(chronic_service, {'temperature': 28, 'temperature_min': 21.9})
+    assert 'heat_night' not in _rule_ids(result)
+    assert HOT_NIGHT_PHRASE not in _advice_blob(result)
+
+
+def test_legacy_tmin_22_still_triggers(chronic_service):
+    result = _predict(chronic_service, {'temperature': 28, 'tmin': 22.0})
+    assert 'heat_night' in _rule_ids(result)
+    blob = _advice_blob(result)
+    assert HOT_NIGHT_PHRASE in blob
+    assert '22' in blob
+
+
+@pytest.mark.parametrize(
+    'weather_data',
+    [
+        {'temperature': 28},
+        {'temperature': 28, 'temperature_min': None, 'tmin': None},
+        {'temperature': 28, 'temperature_min': 'n/a'},
+        {'temperature': 28, 'tmin': 'n/a'},
+        {'temperature': 28, 'temperature_min': float('nan')},
+        {'temperature': 28, 'tmin': np.nan},
+    ],
+)
+def test_missing_or_invalid_night_temp_does_not_trigger(chronic_service, weather_data):
+    assert ChronicRiskService._parse_night_temperature(weather_data) is None
+
+    result = _predict(chronic_service, weather_data)
+    assert 'heat_night' not in _rule_ids(result)
+    blob = _advice_blob(result)
+    assert HOT_NIGHT_PHRASE not in blob
+    assert '热夜' not in blob
+    assert MISLEADING_PHRASE not in blob
+
+
+def test_triggered_copy_uses_actual_min_temp_not_greater_than(chronic_service):
+    result = _predict(chronic_service, {'temperature': 30, 'temperature_min': 23.5})
+    blob = _advice_blob(result)
+    assert 'heat_night' in _rule_ids(result)
+    assert HOT_NIGHT_PHRASE in blob
+    assert '23.5' in blob
+    assert MISLEADING_PHRASE not in blob
+    assert chronic_service.recommendation_rules['heat_night']['thresholds']['hot_night_temp'] == '>=22'
+
+
+def test_safe_context_does_not_fake_missing_hot_night_temp(chronic_service):
+    safe = chronic_service._build_safe_context({'hot_night': False})
+    assert safe['hot_night'] is False
+    assert safe['hot_night_temp'] is None

--- a/tests/test_chronic_hot_night.py
+++ b/tests/test_chronic_hot_night.py
@@ -79,6 +79,23 @@ def test_legacy_tmin_22_still_triggers(chronic_service):
     assert '22' in blob
 
 
+def test_invalid_temperature_min_falls_back_to_valid_tmin(chronic_service):
+    weather_data = {'temperature': 28, 'temperature_min': 'n/a', 'tmin': 23.0}
+    assert ChronicRiskService._parse_night_temperature(weather_data) == pytest.approx(23.0)
+
+    result = _predict(chronic_service, weather_data)
+    assert 'heat_night' in _rule_ids(result)
+    assert '23' in _advice_blob(result)
+
+
+def test_temperature_min_takes_priority_over_legacy_tmin(chronic_service):
+    weather_data = {'temperature': 28, 'temperature_min': 21.9, 'tmin': 23.0}
+    assert ChronicRiskService._parse_night_temperature(weather_data) == pytest.approx(21.9)
+
+    result = _predict(chronic_service, weather_data)
+    assert 'heat_night' not in _rule_ids(result)
+
+
 @pytest.mark.parametrize(
     'weather_data',
     [


### PR DESCRIPTION
## 这次改了什么

- 慢病热夜规则夜温取值改为 `temperature_min` → `tmin` → 缺失；`None` / NaN / 非法字符串视为缺失
- 触发条件改为解析后的夜温 **≥ 22.0°C**（含 22.0；21.9 不触发）
- `thresholds.hot_night_temp` 由 `>22` 改为 `>=22`
- `template` / `reason_template` 改为「预计夜间最低温度为 {hot_night_temp}°C」，不再写「夜间温度>{hot_night_temp}°C」
- 缺失夜温时 `hot_night=False`，`_build_safe_context` 不再用假的 22 填文案
- 新增 `tests/test_chronic_hot_night.py`

**行为变化：** 夏季夜间最低温 Tmin≥22°C 时会出现热夜建议文案。这是修死规则，**不改风险分、不改推送**，也未改 `forecast_service` / `dlnm_risk_service` / 推送模块。

## 为什么要改

- 生产天气字典字段是 `temperature_min`，代码原先只认 `tmin`，热夜建议结构上永不触发
- 文案写成「夜间温度>X°C」且元数据是 `>22`，与实际 ≥22 触发不一致，会误导
- 本 PR 只做这一件事（PR-B2）

## 怎么验证

- [x] 运行了相关 pytest
- [ ] 手动验证了受影响页面 / API（规则层单测覆盖；页面/推送不在本 PR）
- [ ] 补充了必要文档（无需文档变更）
- [x] 已检查 `git diff --staged`
- [x] 当前改动只覆盖这一个问题

验证说明：

```text
cd /Users/imac/Desktop/老家/wt-b2-hot-night

conda run -n case-weather-py312 python -m pytest -q tests/test_chronic_hot_night.py tests/test_chronic_dlnm_transparency.py
# 15 passed

conda run -n case-weather-py312 python -m pytest -q
# 405 passed, 11 deselected, 1 warning（flask_login utcnow，既有）
```

## 文件分类 / 边界检查

- [x] 本 PR 不包含缓存、测试产物、`.claude/`、重复副本或一次性报告
- [x] 如涉及文件迁移，已说明文件去向：主仓库 / 本地归档 / 私有 ops / 本地忽略
- [x] 未提交真实 key、真实 host、真实服务器路径、默认口令
- [x] 如涉及清理仓库，优先处理噪音文件，没有误删运行链路文件
- [x] 如修改 `.sh` 或 `.githooks`，已至少运行一次 `bash -n`（本 PR 未改脚本）

## 关联信息

- 执行者 / Agent：Grok 4.6 extra high（独立 worktree，PR-B2）
- Notion 条目：待回填（当前执行者无 Notion 访问）
- 分支名：`codex/fix/chronic-hot-night-temperature-min`
- 相关 Issue / 备注：宜老天气通最小修复计划 PR-B2；未做 A1/A2/A3/B1
- 相关文件分类说明：产品主仓库运行代码 + 必要测试
- `origin/main` 基线 SHA：`6329a1f9b1e1945f4ac27230854b633fbdc0fc89`（fetch 后未前进，与计划书一致）
- 本地归档路径（如适用）：无
- Notion 回填责任人 / 说明（如当前无法访问 Notion）：请人工在网站迭代库回填分支名、PR 链接与验证结果

## 备份检查

- [x] 当前分支已 push 到 GitHub
- [x] 本 PR 可以作为本轮工作的远端备份
- [x] 如未完成验证，本 PR 保持 Draft

Made with [Cursor](https://cursor.com)