### PR TITLE
fix: 限流键对游客与匿名使用受信客户端 IP

### DIFF
--- a/core/extensions.py
+++ b/core/extensions.py
@@ -3,7 +3,6 @@
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from flask_limiter import Limiter
-from flask_limiter.util import get_remote_address
 
 db = SQLAlchemy()
 # SQLAlchemy 连接池配置（在 core/config.py 的 configure_app 中设置）
@@ -15,7 +14,15 @@ db = SQLAlchemy()
 # }
 
 login_manager = LoginManager()
-limiter = Limiter(get_remote_address)
+
+
+def _limiter_key_func():
+    """默认 Limiter 复用 security.rate_limit_key；函数内 import 避免模块级环依赖。"""
+    from core.security import rate_limit_key
+    return rate_limit_key()
+
+
+limiter = Limiter(_limiter_key_func)
 
 
 def init_extensions(app):

--- a/core/security.py
+++ b/core/security.py
@@ -11,12 +11,43 @@ logger = logging.getLogger(__name__)
 from flask_login import current_user
 from flask_limiter.util import get_remote_address
 
+from core.constants import GUEST_ID_PREFIX
+
+
+def _is_guest_rate_limit_subject(user):
+    """游客：is_guest、role=guest、或 id 前缀 guest:。"""
+    if getattr(user, 'is_guest', False):
+        return True
+    if getattr(user, 'role', None) == 'guest':
+        return True
+    uid = str(getattr(user, 'id', '') or '')
+    return uid.startswith(GUEST_ID_PREFIX)
+
+
+def _client_ip_for_rate_limit():
+    """解析受信客户端 IP；失败或空则回退 get_remote_address()。"""
+    try:
+        # core.audit 已 import hash_identifier 与 db，必须 lazy 以免环依赖
+        from core.audit import _get_client_ip
+        client_ip = _get_client_ip()
+    except Exception:
+        client_ip = None
+    if not client_ip:
+        client_ip = get_remote_address()
+    return client_ip
+
 
 def rate_limit_key():
-    """按用户或IP进行限流"""
-    if current_user.is_authenticated:
-        return str(getattr(current_user, 'id', 'anonymous'))
-    return get_remote_address()
+    """按正式用户或受信客户端 IP 分桶。
+
+    正式登录用户：``user:<id>``。
+    游客（is_guest / role=guest / id 前缀 guest:）与未登录：``ip:<client_ip>``。
+    游客每次 GET /guest 会换新 id，不能按 user id 限流。
+    """
+    if getattr(current_user, 'is_authenticated', False) and not _is_guest_rate_limit_subject(current_user):
+        uid = str(getattr(current_user, 'id', '') or '')
+        return f"user:{uid}"
+    return f"ip:{_client_ip_for_rate_limit()}"
 
 
 def generate_csrf_token():

--- a/tests/test_rate_limit_key.py
+++ b/tests/test_rate_limit_key.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+"""限流键：正式用户 user:<id>；游客与匿名 ip:<受信客户端IP>。"""
+from flask_login import UserMixin, current_user, login_user
+
+
+class _FormalUser(UserMixin):
+    def __init__(self, user_id, role='user'):
+        self.id = user_id
+        self.role = role
+        self.is_guest = False
+
+
+class _PseudoGuest(UserMixin):
+    """漏标 is_guest、仅靠 role / id 前缀识别的伪游客。"""
+    def __init__(self, user_id, role='guest'):
+        self.id = user_id
+        self.role = role
+
+
+def test_guest_same_ip_rotating_id_keeps_ip_bucket(app):
+    """游客、同 IP、轮换 guest id → 键不变，格式 ip:...，键中无 guest id。"""
+    from core.guest import GuestUser
+    from core.security import rate_limit_key
+
+    same_ip = {'REMOTE_ADDR': '203.0.113.10'}
+    profile = {'username': '游客'}
+
+    with app.app_context():
+        with app.test_request_context('/', environ_base=same_ip):
+            guest_a = GuestUser('guest:token-a', profile)
+            login_user(guest_a)
+            assert current_user.is_authenticated is True
+            assert getattr(current_user, 'is_guest', False) is True
+            key_a = rate_limit_key()
+
+        with app.test_request_context('/', environ_base=same_ip):
+            guest_b = GuestUser('guest:token-b', profile)
+            login_user(guest_b)
+            assert current_user.id == 'guest:token-b'
+            key_b = rate_limit_key()
+
+        with app.test_request_context('/', environ_base=same_ip):
+            anon_key = rate_limit_key()
+
+    assert key_a == 'ip:203.0.113.10'
+    assert key_b == key_a
+    assert anon_key == key_a
+    assert 'guest:token-a' not in key_a
+    assert 'guest:token-b' not in key_b
+
+
+def test_different_ips_use_different_buckets(app):
+    """不同客户端 IP 分到不同桶。"""
+    from core.guest import GuestUser
+    from core.security import rate_limit_key
+
+    profile = {'username': '游客'}
+
+    with app.app_context():
+        with app.test_request_context('/', environ_base={'REMOTE_ADDR': '203.0.113.10'}):
+            login_user(GuestUser('guest:token-a', profile))
+            key_a = rate_limit_key()
+
+        with app.test_request_context('/', environ_base={'REMOTE_ADDR': '203.0.113.11'}):
+            login_user(GuestUser('guest:token-b', profile))
+            key_b = rate_limit_key()
+
+        with app.test_request_context('/', environ_base={'REMOTE_ADDR': '203.0.113.11'}):
+            anon_key = rate_limit_key()
+
+    assert key_a == 'ip:203.0.113.10'
+    assert key_b == 'ip:203.0.113.11'
+    assert key_a != key_b
+    assert anon_key == key_b
+
+
+def test_formal_user_uses_user_id_bucket(app):
+    """正式用户 → user:<id>。"""
+    from core.security import rate_limit_key
+
+    with app.app_context():
+        with app.test_request_context(
+            '/',
+            environ_base={'REMOTE_ADDR': '203.0.113.10'},
+        ):
+            login_user(_FormalUser(42))
+            assert current_user.is_authenticated is True
+            assert getattr(current_user, 'is_guest', False) is False
+            key = rate_limit_key()
+
+    assert key == 'user:42'
+    assert not key.startswith('ip:')
+
+
+def test_trusted_proxy_xff_becomes_client_ip_key(app):
+    """受信代理：REMOTE_ADDR 在 TRUSTED_PROXY_CIDRS 内时采用 XFF 客户端 IP。"""
+    from core.security import rate_limit_key
+
+    app.config['TRUSTED_PROXY_CIDRS'] = '127.0.0.1/32,::1/128'
+    with app.test_request_context(
+        '/',
+        headers={'X-Forwarded-For': '203.0.113.10'},
+        environ_base={'REMOTE_ADDR': '127.0.0.1'},
+    ):
+        key = rate_limit_key()
+
+    assert key == 'ip:203.0.113.10'
+
+
+def test_untrusted_xff_is_ignored(app):
+    """未受信 XFF：remote_addr 不在受信 CIDR 时忽略 XFF，键仍为 ip:<remote_addr>。"""
+    from core.security import rate_limit_key
+
+    app.config['TRUSTED_PROXY_CIDRS'] = '127.0.0.1/32,::1/128'
+    with app.test_request_context(
+        '/',
+        headers={'X-Forwarded-For': '203.0.113.10'},
+        environ_base={'REMOTE_ADDR': '198.51.100.23'},
+    ):
+        key = rate_limit_key()
+
+    assert key == 'ip:198.51.100.23'
+    assert '203.0.113.10' not in key
+
+
+def test_guest_prefix_and_role_without_is_guest_use_ip(app):
+    """role=guest 或 id 前缀 guest:（即使漏标 is_guest）仍走 IP 桶。"""
+    from core.security import rate_limit_key
+
+    with app.app_context():
+        with app.test_request_context(
+            '/',
+            environ_base={'REMOTE_ADDR': '198.51.100.7'},
+        ):
+            login_user(_PseudoGuest('guest:forged-no-flag', role='guest'))
+            key = rate_limit_key()
+
+    assert key == 'ip:198.51.100.7'
+    assert 'guest:forged-no-flag' not in key
+
+
+def test_default_limiter_reuses_rate_limit_key(app):
+    """默认 Limiter 与 rate_limit_key 同一套分桶，而不是裸 get_remote_address。"""
+    from core.extensions import limiter
+    from core.security import rate_limit_key
+
+    key_func = getattr(limiter, '_key_func', None) or getattr(limiter, 'key_func', None)
+    assert key_func is not None
+
+    app.config['TRUSTED_PROXY_CIDRS'] = '127.0.0.1/32,::1/128'
+    with app.test_request_context(
+        '/',
+        headers={'X-Forwarded-For': '203.0.113.10'},
+        environ_base={'REMOTE_ADDR': '127.0.0.1'},
+    ):
+        assert key_func() == rate_limit_key() == 'ip:203.0.113.10'
+
+    with app.app_context():
+        with app.test_request_context(
+            '/',
+            environ_base={'REMOTE_ADDR': '203.0.113.10'},
+        ):
+            login_user(_FormalUser(7))
+            assert key_func() == rate_limit_key() == 'user:7'


### PR DESCRIPTION
## Summary
- 正式登录用户限流键改为 `user:<id>`；游客（`is_guest` / `role=guest` / id 前缀 `guest:`）与未登录改为 `ip:<解析后的客户端IP>`。
- 游客不能再靠刷新 `GET /guest` 轮换 id 换配额；匿名/游客在反代后按受信客户端 IP 分桶，避免 gunicorn 绑环回地址时整站塌进同一个桶。
- 默认 Flask-Limiter 复用同一个 `rate_limit_key`（薄包装 lazy import），不再用裸 `get_remote_address`。IP 解析 lazy import 现有 `core.audit._get_client_ip`，不引入 ProxyFix、不复制 TRUSTED_PROXY 逻辑。

## 行为变化
- **游客 / 匿名**：同一客户端 IP 共用 `ip:` 桶；轮换 guest id 不会换桶。
- **受信代理**：`REMOTE_ADDR` 落在 `TRUSTED_PROXY_CIDRS` 时采用 `X-Forwarded-For` 中的客户端 IP。
- **未受信 XFF**：`remote_addr` 不在受信 CIDR 时忽略 XFF，键仍为 `ip:<remote_addr>`。
- **正式用户**：走 `user:<id>` 桶，不再和环回地址挤在一起。

## 基线
- `origin/main` @ `6329a1f9b1e1945f4ac27230854b633fbdc0fc89`（与计划书审阅 SHA 一致，未前进）
- 分支：`codex/fix/rate-limit-client-ip`
- Worktree：`/Users/imac/Desktop/老家/wt-b1-rate-limit`
- 计划书：PR-B1（Notion 条目待回填）

## 改动文件
- `core/security.py`
- `core/extensions.py`
- `tests/test_rate_limit_key.py`（新建）

## Test plan
- [x] `conda run -n case-weather-py312 python -m pytest -q tests/test_rate_limit_key.py tests/test_bugfix_batch1.py` → 33 passed
- [x] `conda run -n case-weather-py312 python -m pytest -q` → 401 passed, 11 deselected
- [ ] GitHub Actions CI 绿

覆盖：游客同 IP 轮换 id 键不变且不含 guest id；不同 IP 分桶；正式用户 `user:<id>`；受信/未受信 XFF；默认 Limiter 复用同一 key；既有 `_get_client_ip` 用例未改坏。


Made with [Cursor](https://cursor.com)