### PR TITLE
fix: 页脚补充运营主体与联系邮箱

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -418,6 +418,7 @@
                 <a href="{{ url_for('public.transparency') }}#privacy">隐私边界</a>
             </nav>
             <p class="mb-0">© {{ now().year }} · 宜老天气通 · 把天气变成照护提醒</p>
+            <p class="mb-0 mt-1 small">运营主体：宜老天气通 · <a href="mailto:wuxy.alf2024@gdhfi.com">wuxy.alf2024@gdhfi.com</a></p>
         </div>
     </footer>
 

--- a/tests/test_nav_offcanvas.py
+++ b/tests/test_nav_offcanvas.py
@@ -60,7 +60,13 @@ def test_base_has_skip_link_nav_hooks_and_footer_links(client):
     assert 'id="main-content"' in body
     assert 'aria-label="主导航"' in body
     assert 'aria-label="页脚导航"' in body
+    assert 'href="/risk"' in body
+    assert 'href="/cooling"' in body
+    assert 'href="/transparency"' in body
     assert 'href="/transparency#privacy"' in body
+    assert '运营主体：宜老天气通' in body
+    assert 'mailto:wuxy.alf2024@gdhfi.com' in body
+    assert 'admin@example.com' not in body
 
 
 def test_narrow_guest_nav_moves_registration_into_drawer(client):


### PR DESCRIPTION
## 这次改了什么

- 在 `templates/base.html` 版权段落下增加运营主体行：`运营主体：宜老天气通`，并硬编码 `mailto:wuxy.alf2024@gdhfi.com`（与透明度页同一地址）
- 扩展 `tests/test_nav_offcanvas.py` 的页脚回归：锁四条页脚导航、指定 mailto，并断言页脚不含默认管理员邮箱

## 为什么要改

- 公开站点页脚需要标明运营主体与可联系邮箱，方便用户反馈；邮箱不能走 `DEFAULT_ADMIN_EMAIL`（默认占位地址）

## 怎么验证

- [x] 运行了相关 pytest
- [ ] 手动验证了受影响页面 / API
- [ ] 补充了必要文档
- [x] 已检查 `git diff --staged`
- [x] 当前改动只覆盖这一个问题

验证说明：

```text
conda run -n case-weather-py312 python -m pytest tests/test_nav_offcanvas.py::test_base_has_skip_link_nav_hooks_and_footer_links -q
# 1 passed
```

## 文件分类 / 边界检查

- [x] 本 PR 不包含缓存、测试产物、`.claude/`、重复副本或一次性报告
- [x] 如涉及文件迁移，已说明文件去向：主仓库 / 本地归档 / 私有 ops / 本地忽略
- [x] 未提交真实 key、真实 host、真实服务器路径、默认口令
- [x] 如涉及清理仓库，优先处理噪音文件，没有误删运行链路文件
- [x] 如修改 `.sh` 或 `.githooks`，已至少运行一次 `bash -n`

## 关联信息

- 执行者 / Agent：Cursor Grok（P3 子代理）
- Notion 条目：待回填（当前执行者无 Notion 访问）
- 分支名：`codex/fix/footer-operator`
- 相关 Issue / 备注：产品清单 P3；不改 GIS 科研页脚、透明度页、`core/app.py`
- 相关文件分类说明：产品主仓库运行模板 + 必要测试
- `origin/main` 基线 SHA：`faa39347960977d513cae7ed8e744d8b9eb62631`
- 本地归档路径（如适用）：无
- Notion 回填责任人 / 说明（如当前无法访问 Notion）：待人工回填「网站迭代库」条目

## 备份检查

- [x] 当前分支已 push 到 GitHub
- [x] 本 PR 可以作为本轮工作的远端备份
- [x] 如未完成验证，本 PR 保持 Draft

Made with [Cursor](https://cursor.com)