### PR TITLE
fix: 提醒话术改为网页短码确认，同步 Web 与小程序三路文案

### DIFF
--- a/miniprogram/pages/template/index.js
+++ b/miniprogram/pages/template/index.js
@@ -15,6 +15,8 @@ function buildMessage({ trigger, elderName, relation, locationText, tmax, tmin }
       '建议：尽量少出门，外出注意保暖防滑；室内注意保暖，别受凉。',
       `地点：${locationText || '-'}`,
       '说明：这是行动提醒，不提供医疗诊断/治疗建议；如明显不适请及时就医。',
+      '可在网页行动页输入短码完成确认。',
+      '微信小程序也可查看提醒。',
     ].join('\n');
   }
   if (trigger === 'heat') {
@@ -26,12 +28,16 @@ function buildMessage({ trigger, elderName, relation, locationText, tmax, tmin }
       '建议：避开中午外出，多喝水；室内开风扇/空调或找阴凉处休息。',
       `地点：${locationText || '-'}`,
       '说明：这是行动提醒，不提供医疗诊断/治疗建议；如明显不适请及时就医。',
+      '可在网页行动页输入短码完成确认。',
+      '微信小程序也可查看提醒。',
     ].join('\n');
   }
   return [
     `【日常提醒】${address}，我这边看看你那边天气有变化，注意劳逸结合，出门记得带水/外套。`,
     `地点：${locationText || '-'}`,
     '说明：这是行动提醒，不提供医疗诊断/治疗建议；如明显不适请及时就医。',
+    '可在网页行动页输入短码完成确认。',
+    '微信小程序也可查看提醒。',
   ].join('\n');
 }
 

--- a/services/user/_helpers.py
+++ b/services/user/_helpers.py
@@ -187,6 +187,8 @@ def _build_caregiver_message(pair, alert_kind=None, weather_data=None, member=No
 
     lines.append('说明：这是行动提醒，不提供医疗诊断/治疗建议；如明显不适请及时就医。')
     lines.append(f'（可选）行动页：{action_link}  短码：{pair.short_code}')
+    lines.append('可在网页行动页输入短码完成确认。')
+    lines.append('微信小程序也可查看提醒。')
     return '\n'.join([line for line in lines if line])
 
 

--- a/services/user/caregiver_service.py
+++ b/services/user/caregiver_service.py
@@ -76,7 +76,9 @@ def _build_weather_waiting_message(pair, action_link):
     location = (pair.location_query or pair.community_code or '').strip()
     lines = [
         '【天气更新中】',
-        '风险等级暂不显示。仍可打开行动页完成安全确认或求助。',
+        '风险等级暂不显示。',
+        '可在网页行动页输入短码完成确认。',
+        '微信小程序也可查看提醒。',
     ]
     if location:
         lines.append(f'地点：{location}')
@@ -582,10 +584,14 @@ def caregiver_wechat_template():
         for item in actions:
             message_lines.append(f'- {item["title"]}：{item["detail"]}')
         message_lines.append('如需帮助请在页面内点击“我需要帮助”。')
+        message_lines.append('可在网页行动页输入短码完成确认。')
+        message_lines.append('微信小程序也可查看提醒。')
     else:
         message_lines = [
             '【天气更新中】',
-            '风险等级暂不显示。仍可打开行动页完成安全确认或求助。',
+            '风险等级暂不显示。',
+            '可在网页行动页输入短码完成确认。',
+            '微信小程序也可查看提醒。',
             f'行动链接：{action_link}',
             f'短码：{short_code or "请填写"}',
         ]

--- a/services/user/community_service.py
+++ b/services/user/community_service.py
@@ -318,6 +318,8 @@ def community_wechat(community_code):
                     name_line += f'（{item.address_hint}）'
                 message_lines.append(name_line)
         message_lines.append('如需帮助请联系社区服务人员。')
+        message_lines.append('可在网页行动页输入短码完成确认。')
+        message_lines.append('微信小程序也可查看提醒。')
 
     return render_template(
         'community_wechat.html',

--- a/templates/caregiver_wechat_template.html
+++ b/templates/caregiver_wechat_template.html
@@ -24,14 +24,14 @@
             {% if not weather_available %}
             <div class="alert alert-warning" role="status">
                 <strong>天气更新中</strong><br>
-                风险等级暂不显示。你仍可复制行动链接和短码，提醒对方完成安全确认或求助。
+                风险等级暂不显示。可在网页行动页输入短码完成确认。微信小程序也可查看提醒。
             </div>
             {% endif %}
             <textarea class="form-control" rows="10" id="wechatMessage" readonly>{{ message }}</textarea>
             <button class="btn btn-primary mt-3" type="button" id="copyMessage">
                 <i class="bi bi-clipboard"></i> {% if weather_available %}复制文本{% else %}复制行动链接说明{% endif %}
             </button>
-            <div class="text-muted small mt-2">建议提醒对方进入链接并输入短码完成确认。</div>
+            <div class="text-muted small mt-2">可在网页行动页输入短码完成确认。微信小程序也可查看提醒。</div>
         </div>
     </div>
 </div>

--- a/templates/community_wechat.html
+++ b/templates/community_wechat.html
@@ -26,11 +26,11 @@
             <button class="btn btn-primary mt-3" type="button" id="copyMessage">
                 <i class="bi bi-clipboard"></i> 复制文本
             </button>
-            <div class="text-muted small mt-2">仅提供通用行动建议，不包含医疗诊断或治疗建议。</div>
+            <div class="text-muted small mt-2">可在网页行动页输入短码完成确认。微信小程序也可查看提醒。仅提供通用行动建议，不包含医疗诊断或治疗建议。</div>
             {% else %}
             <div class="alert alert-warning mb-0" role="status">
                 <strong>天气更新中</strong><br>
-                可转发提醒暂缓更新。你仍可返回社区详情查看居民反馈和避暑资源。
+                可转发提醒暂缓更新。可在网页行动页输入短码完成确认。微信小程序也可查看提醒。你仍可返回社区详情查看居民反馈和避暑资源。
             </div>
             {% endif %}
         </div>

--- a/tests/test_checkin_copy_web_or_mp.py
+++ b/tests/test_checkin_copy_web_or_mp.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+"""P5：复制话术必须诚实写明网页短码确认，且 Web / 小程序三路同步。"""
+from pathlib import Path
+from types import SimpleNamespace
+
+from core.db_models import Community, Pair, User
+from core.security import hash_short_code
+from core.time_utils import utcnow
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WEB_CONFIRM = '可在网页行动页输入短码完成确认。'
+MP_VIEW = '微信小程序也可查看提醒。'
+FORBIDDEN_COPY = (
+    '确认需在微信小程序完成',
+    '可在微信小程序完成确认',
+)
+PAIR_MANAGEMENT_FAIL_CLOSED = '风险等级暂不显示。仍可发送行动链接并记录确认结果。'
+LISTED_COPY_SITES = (
+    'services/user/caregiver_service.py',
+    'services/user/_helpers.py',
+    'services/user/community_service.py',
+    'miniprogram/pages/template/index.js',
+    'templates/caregiver_wechat_template.html',
+    'templates/community_wechat.html',
+)
+
+MOCK_WEATHER = {
+    'temperature': 37.0,
+    'temperature_max': 39.0,
+    'temperature_min': 29.0,
+    'humidity': 70.0,
+    'data_source': 'Demo',
+    'is_mock': True,
+    'is_demo': True,
+}
+REAL_WEATHER = {
+    'temperature': 37.0,
+    'temperature_max': 39.0,
+    'temperature_min': 29.0,
+    'humidity': 70.0,
+    'data_source': 'QWeather',
+    'is_mock': False,
+}
+
+
+def _login_as(client, user_id, csrf_token='test-csrf-token'):
+    with client.session_transaction() as session:
+        session['_user_id'] = str(user_id)
+        session['_fresh'] = True
+        session['_csrf_token'] = csrf_token
+
+
+def _create_user(db_session, username, role, community='都昌'):
+    user = User(username=username, role=role, community=community)
+    user.set_password('checkin-copy-test-password')
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+def _create_pair(db_session, user_id, short_code='27182818'):
+    pair = Pair(
+        caregiver_id=user_id,
+        community_code='都昌',
+        location_query='都昌',
+        elder_code=f'elder-{short_code}',
+        short_code=short_code,
+        short_code_hash=hash_short_code(short_code),
+        status='active',
+        created_at=utcnow(),
+        last_active_at=utcnow(),
+    )
+    db_session.add(pair)
+    db_session.commit()
+    return pair
+
+
+def _patch_caregiver_location(monkeypatch):
+    monkeypatch.setattr(
+        'services.user.caregiver_service.resolve_location',
+        lambda _label: {
+            'location_code': '101240201',
+            'display_name': '都昌',
+        },
+    )
+
+
+def _read(relpath):
+    return (REPO_ROOT / relpath).read_text(encoding='utf-8')
+
+
+def test_listed_copy_sites_all_share_web_short_code_sentence():
+    """漏改任一列出的站点就会让网页与小程序话术分叉。"""
+    for relpath in LISTED_COPY_SITES:
+        text = _read(relpath)
+        assert WEB_CONFIRM in text, f'{relpath} 缺少网页短码确认句'
+        assert MP_VIEW in text, f'{relpath} 缺少小程序可查看提醒句'
+        for forbidden in FORBIDDEN_COPY:
+            assert forbidden not in text, f'{relpath} 出现禁止话术'
+
+
+def test_miniprogram_build_message_has_hint_on_all_three_branches():
+    js = _read('miniprogram/pages/template/index.js')
+    assert js.count(WEB_CONFIRM) == 3
+    assert js.count(MP_VIEW) == 3
+    assert "trigger === 'cold'" in js
+    assert "trigger === 'heat'" in js
+    assert '【日常提醒】' in js
+
+
+def test_pair_management_weather_fail_closed_sentence_unchanged():
+    text = _read('templates/pair_management.html')
+    assert PAIR_MANAGEMENT_FAIL_CLOSED in text
+    assert '确认需在微信小程序完成' not in text
+    assert '可在微信小程序完成确认' not in text
+
+
+def test_action_checkin_post_forms_unchanged():
+    text = _read('templates/action_checkin.html')
+    assert 'method="POST"' in text
+    assert "url_for('public.action_confirm')" in text
+    assert "url_for('public.action_help')" in text
+    assert WEB_CONFIRM not in text
+
+
+def test_helpers_caregiver_message_appends_web_confirm_for_all_alert_kinds():
+    from services.user._helpers import _build_caregiver_message
+
+    pair = SimpleNamespace(short_code='31415926', location_query='都昌', community_code='都昌')
+    weather = {'temperature_max': 36, 'temperature_min': 2}
+    for alert_kind in ('heat', 'cold', None):
+        message = _build_caregiver_message(
+            pair,
+            alert_kind=alert_kind,
+            weather_data=weather,
+            action_link='https://example.test/action',
+        )
+        assert WEB_CONFIRM in message
+        assert MP_VIEW in message
+        assert message.count(WEB_CONFIRM) == 1
+
+
+def test_caregiver_waiting_and_wechat_messages_use_web_confirm(
+    client,
+    db_session,
+    monkeypatch,
+):
+    user = _create_user(db_session, 'copy_caregiver_wait', 'caregiver')
+    pair = _create_pair(db_session, user.id, short_code='14142135')
+    _login_as(client, user.id)
+    _patch_caregiver_location(monkeypatch)
+    monkeypatch.setattr(
+        'services.user.caregiver_service.get_weather_with_cache',
+        lambda _location: (dict(MOCK_WEATHER), False),
+    )
+
+    dashboard = client.get('/caregiver')
+    assert dashboard.status_code == 200
+    dashboard_body = dashboard.get_data(as_text=True)
+    assert WEB_CONFIRM in dashboard_body
+    assert MP_VIEW in dashboard_body
+    assert PAIR_MANAGEMENT_FAIL_CLOSED in dashboard_body
+
+    wechat = client.get(f'/caregiver/wechat_template?short_code={pair.short_code}')
+    assert wechat.status_code == 200
+    wechat_body = wechat.get_data(as_text=True)
+    assert WEB_CONFIRM in wechat_body
+    assert MP_VIEW in wechat_body
+    assert 'id="wechatMessage"' in wechat_body
+    assert '今日热风险：极高' not in wechat_body
+    for forbidden in FORBIDDEN_COPY:
+        assert forbidden not in wechat_body
+
+
+def test_caregiver_and_community_wechat_real_weather_include_web_confirm(
+    client,
+    db_session,
+    monkeypatch,
+):
+    user = _create_user(db_session, 'copy_real_weather_admin', 'admin')
+    pair = _create_pair(db_session, user.id, short_code='17320508')
+    db_session.add(Community(name='都昌', population=800, elderly_ratio=0.35))
+    db_session.commit()
+    _login_as(client, user.id)
+    _patch_caregiver_location(monkeypatch)
+    monkeypatch.setattr(
+        'services.user.caregiver_service.get_weather_with_cache',
+        lambda _location: (dict(REAL_WEATHER), False),
+    )
+    monkeypatch.setattr(
+        'services.user.community_service.get_weather_with_cache',
+        lambda _location: (dict(REAL_WEATHER), False),
+    )
+    monkeypatch.setattr(
+        'services.user.caregiver_service.get_consecutive_hot_days',
+        lambda *_args, **_kwargs: 0,
+    )
+    monkeypatch.setattr(
+        'services.user.community_service.get_consecutive_hot_days',
+        lambda *_args, **_kwargs: 0,
+    )
+
+    dashboard = client.get('/caregiver')
+    assert dashboard.status_code == 200
+    dashboard_body = dashboard.get_data(as_text=True)
+    assert WEB_CONFIRM in dashboard_body
+    assert '复制提醒话术' in dashboard_body
+
+    caregiver_wechat = client.get(
+        f'/caregiver/wechat_template?short_code={pair.short_code}&community_code=都昌'
+    )
+    assert caregiver_wechat.status_code == 200
+    caregiver_body = caregiver_wechat.get_data(as_text=True)
+    assert WEB_CONFIRM in caregiver_body
+    assert MP_VIEW in caregiver_body
+    assert '今日热风险：极高' in caregiver_body
+    assert '天气更新中' not in caregiver_body
+
+    community_wechat = client.get('/community/都昌/wechat')
+    assert community_wechat.status_code == 200
+    community_body = community_wechat.get_data(as_text=True)
+    assert WEB_CONFIRM in community_body
+    assert MP_VIEW in community_body
+    assert 'id="wechatMessage"' in community_body
+    assert '今日热风险：极高' in community_body
+    for forbidden in FORBIDDEN_COPY:
+        assert forbidden not in caregiver_body
+        assert forbidden not in community_body


### PR DESCRIPTION
## 这次改了什么

- 照护工作台复制话术、照护/社区微信模板、小程序 `buildMessage()` 三路，统一追加网页短码确认句：`可在网页行动页输入短码完成确认。`
- 可选半句同步为：`微信小程序也可查看提醒。`
- 未改打卡 POST，也未改 `pair_management.html` 的天气失败关闭句。

## 为什么要改

- 现网小程序还不能完成确认。若话术写成「需在小程序完成」或「可在小程序完成确认」，复制进微信会撒谎，且 Web/MP 漏改一处就会分叉。

## 怎么验证

- [x] 运行了相关 pytest
- [ ] 手动验证了受影响页面 / API
- [ ] 补充了必要文档
- [x] 已检查 `git diff --staged`
- [x] 当前改动只覆盖这一个问题

验证说明：

```text
conda activate case-weather-py312
python -m pytest -q tests/test_checkin_copy_web_or_mp.py tests/test_web_weather_fail_closed.py
# 12 passed
```

## 文件分类 / 边界检查

- [x] 本 PR 不包含缓存、测试产物、`.claude/`、重复副本或一次性报告
- [x] 如涉及文件迁移，已说明文件去向：主仓库 / 本地归档 / 私有 ops / 本地忽略
- [x] 未提交真实 key、真实 host、真实服务器路径、默认口令
- [x] 如涉及清理仓库，优先处理噪音文件，没有误删运行链路文件
- [x] 如修改 `.sh` 或 `.githooks`，已至少运行一次 `bash -n`

## 关联信息

- 执行者 / Agent：Cursor Grok（P5 worktree）
- Notion 条目：待回填
- 分支名：`codex/fix/checkin-copy-web-or-mp`
- 相关 Issue / 备注：产品清单 P5 诚实话术
- 相关文件分类说明：产品主仓库（运行代码 + 必要测试）
- `origin/main` 基线 SHA：`faa39347960977d513cae7ed8e744d8b9eb62631`
- 本地归档路径（如适用）：无
- Notion 回填责任人 / 说明（如当前无法访问 Notion）：当前执行者无 Notion 访问，条目占位待回填

## 备份检查

- [x] 当前分支已 push 到 GitHub
- [x] 本 PR 可以作为本轮工作的远端备份
- [x] 如未完成验证，本 PR 保持 Draft

Made with [Cursor](https://cursor.com)