### PR TITLE
fix: 注册独立限流桶，校验通过才扣配额

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,7 @@ RATE_LIMITS=200 per minute
 # 生产环境不要使用 memory://，应配置 Redis
 RATE_LIMIT_STORAGE_URI=redis://localhost:6379/0
 RATE_LIMIT_LOGIN=5 per 5 minutes
+RATE_LIMIT_REGISTER=5 per hour
 LOGIN_MAX_FAILURES=5
 LOGIN_LOCKOUT_SECONDS=300
 RATE_LIMIT_SHORT_CODE=3 per hour

--- a/blueprints/public.py
+++ b/blueprints/public.py
@@ -11,7 +11,12 @@ logger = logging.getLogger(__name__)
 
 from core.extensions import limiter
 from core.extensions import db
-from core.security import rate_limit_key
+from core.security import (
+    rate_limit_key,
+    register_limit_is_exempt,
+    register_limit_should_deduct,
+    register_rate_limit_key,
+)
 from core.time_utils import utcnow
 from core.usage import log_usage_event
 from core.db_models import AlertDelivery
@@ -101,6 +106,14 @@ def login():
 
 
 @bp.route('/register', methods=['GET', 'POST'], endpoint='register')
+@limiter.limit(
+    lambda: current_app.config.get('RATE_LIMIT_REGISTER', '5 per hour'),
+    methods=['POST'],
+    key_func=register_rate_limit_key,
+    deduct_when=register_limit_should_deduct,
+    exempt_when=register_limit_is_exempt,
+    override_defaults=False,
+)
 def register():
     """注册"""
     return handle_register()

--- a/core/config.py
+++ b/core/config.py
@@ -370,6 +370,7 @@ def configure_app(app, logger):
     app.config.setdefault('RATE_LIMIT_ML', os.getenv('RATE_LIMIT_ML', app.config['RATE_LIMITS']))
     app.config.setdefault('RATE_LIMIT_AI', os.getenv('RATE_LIMIT_AI', '20 per minute'))
     app.config.setdefault('RATE_LIMIT_LOGIN', os.getenv('RATE_LIMIT_LOGIN', '5 per 5 minutes'))
+    app.config.setdefault('RATE_LIMIT_REGISTER', os.getenv('RATE_LIMIT_REGISTER', '5 per hour'))
     app.config.setdefault('LOGIN_MAX_FAILURES', parse_int(os.getenv('LOGIN_MAX_FAILURES', '5'), default=5))
     app.config.setdefault('LOGIN_LOCKOUT_SECONDS', parse_int(os.getenv('LOGIN_LOCKOUT_SECONDS', '300'), default=300))
     app.config.setdefault('RATE_LIMIT_SHORT_CODE', os.getenv('RATE_LIMIT_SHORT_CODE', '3 per hour'))

--- a/core/security.py
+++ b/core/security.py
@@ -5,7 +5,7 @@ import logging
 import os
 import secrets
 
-from flask import abort, current_app, has_app_context, jsonify, request, session
+from flask import abort, current_app, g, has_app_context, jsonify, request, session
 
 logger = logging.getLogger(__name__)
 from flask_login import current_user
@@ -134,3 +134,25 @@ def hash_identifier(value):
 def hash_short_code(value):
     """Hash short code before persistence."""
     return hash_identifier(value)
+
+
+def register_rate_limit_key():
+    """注册专用桶：受信客户端 IP + 用户名哈希。禁止复用 rate_limit_key。"""
+    username = (request.form.get('username') or '').strip()
+    digest = hash_identifier(username) or 'empty'
+    return f"register:{_client_ip_for_rate_limit()}:{digest}"
+
+
+def mark_register_limit_countable():
+    """标记本次注册请求应扣除专用配额。"""
+    g.register_limit_countable = True
+
+
+def register_limit_should_deduct(response):
+    """deduct_when：校验通过才扣；成功与失败都是 302，不能看 status。"""
+    return bool(getattr(g, 'register_limit_countable', False))
+
+
+def register_limit_is_exempt():
+    """GET 不走注册专用限额；POST 仍受全局 200/min。"""
+    return request.method != 'POST'

--- a/services/public_service.py
+++ b/services/public_service.py
@@ -13,7 +13,14 @@ from sqlalchemy import or_
 
 from core.constants import GUEST_ID_PREFIX
 from core.extensions import db
-from core.security import hash_identifier, hash_pair_token, hash_short_code, rate_limit_key, verify_pair_token
+from core.security import (
+    hash_identifier,
+    hash_pair_token,
+    hash_short_code,
+    mark_register_limit_countable,
+    rate_limit_key,
+    verify_pair_token,
+)
 from core.time_utils import today_local, utcnow, ensure_utc_aware
 from core.usage import log_usage_event
 from core.weather import (
@@ -1062,8 +1069,8 @@ def handle_register():
             return redirect(url_for('public.register'))
         username = result
 
-        # 验证密码
-        valid, result = validate_password(request.form.get('password'))
+        # 验证密码（仅注册路径要求 12 位；全局默认仍为 6）
+        valid, result = validate_password(request.form.get('password'), min_length=12)
         if not valid:
             flash(result, 'error')
             return redirect(url_for('public.register'))
@@ -1089,6 +1096,9 @@ def handle_register():
             flash(result, 'error')
             return redirect(url_for('public.register'))
         gender = result
+
+        # 全部 validate_* 通过后才扣专用配额；用户名/邮箱已占用也扣，反枚举。
+        mark_register_limit_countable()
 
         # 社区信息
         community = sanitize_input(request.form.get('community'), max_length=100)

--- a/templates/register.html
+++ b/templates/register.html
@@ -44,13 +44,13 @@
                                     <label for="password" class="form-label">
                                         <i class="bi bi-lock me-1"></i>密码 <span style="color:var(--yl-danger);">*</span>
                                     </label>
-                                    <input type="password" class="form-control" id="password" name="password" required>
+                                    <input type="password" class="form-control" id="password" name="password" required minlength="12">
                                 </div>
                                 <div class="col-md-6">
                                     <label for="confirm_password" class="form-label">
                                         <i class="bi bi-lock-fill me-1"></i>确认密码 <span style="color:var(--yl-danger);">*</span>
                                     </label>
-                                    <input type="password" class="form-control" id="confirm_password" name="confirm_password" required>
+                                    <input type="password" class="form-control" id="confirm_password" name="confirm_password" required minlength="12">
                                 </div>
                             </div>
 

--- a/tests/test_register_rate_limit.py
+++ b/tests/test_register_rate_limit.py
@@ -1,0 +1,320 @@
+# -*- coding: utf-8 -*-
+"""注册专用限流：校验通过才扣；用户名/邮箱占用也扣。不要 follow_redirects。"""
+from pathlib import Path
+
+from flask_login import UserMixin, current_user, login_user
+from utils.validators import validate_password
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REGISTER_HTML = REPO_ROOT / 'templates' / 'register.html'
+LOGIN_HTML = REPO_ROOT / 'templates' / 'login.html'
+VALID_PASSWORD = 'password1234'  # 12 位；默认 validate_password 仍接受更短
+
+
+class _FormalUser(UserMixin):
+    def __init__(self, user_id, role='user'):
+        self.id = user_id
+        self.role = role
+        self.is_guest = False
+
+
+def _csrf(client, token='register-csrf'):
+    with client.session_transaction() as sess:
+        sess['_csrf_token'] = token
+    return token
+
+
+def _prepare_register_limits(app, limit='2 per hour'):
+    from core.extensions import db, limiter
+
+    app.config['RATE_LIMIT_REGISTER'] = limit
+    with app.app_context():
+        db.create_all()
+        limiter.reset()
+
+
+def _post_register(client, username, password=VALID_PASSWORD, csrf='register-csrf', ip=None, **extra):
+    data = {
+        'username': username,
+        'password': password,
+        'confirm_password': extra.pop('confirm_password', password),
+        'csrf_token': csrf,
+    }
+    data.update(extra)
+    kwargs = {'data': data, 'follow_redirects': False}
+    if ip:
+        kwargs['environ_base'] = {'REMOTE_ADDR': ip}
+    return client.post('/register', **kwargs)
+
+
+def test_validate_password_default_still_six():
+    valid, result = validate_password('password123')
+    assert valid is True
+    assert result == 'password123'
+
+    valid, _ = validate_password('123')
+    assert valid is False
+
+    valid, msg = validate_password('password123', min_length=12)
+    assert valid is False
+    assert '12' in msg
+
+
+def test_register_template_minlength_login_has_none():
+    register_src = REGISTER_HTML.read_text(encoding='utf-8')
+    login_src = LOGIN_HTML.read_text(encoding='utf-8')
+    assert 'name="password"' in register_src
+    assert 'minlength="12"' in register_src
+    assert 'name="password"' in login_src
+    assert 'minlength' not in login_src
+
+
+def test_get_register_repeated_stays_200(app, client):
+    _prepare_register_limits(app, limit='1 per hour')
+    for _ in range(8):
+        resp = client.get('/register')
+        assert resp.status_code == 200
+
+
+def test_invalid_register_post_does_not_consume_quota(app, client):
+    _prepare_register_limits(app)
+    csrf = _csrf(client)
+    username = 'samequota'
+
+    for _ in range(5):
+        short_name = _post_register(client, 'ab', csrf=csrf)
+        assert short_name.status_code == 302
+        assert short_name.status_code != 429
+        assert '/register' in (short_name.headers.get('Location') or '')
+
+        short_password = _post_register(client, username, password='123456', csrf=csrf)
+        assert short_password.status_code == 302
+        assert short_password.status_code != 429
+        assert '/register' in (short_password.headers.get('Location') or '')
+
+    first = _post_register(client, username, csrf=csrf)
+    second = _post_register(client, username, csrf=csrf)
+    third = _post_register(client, username, csrf=csrf)
+    assert first.status_code == 302
+    assert '/login' in (first.headers.get('Location') or '')
+    assert second.status_code == 302
+    assert '/register' in (second.headers.get('Location') or '')
+    assert third.status_code == 429
+
+
+def test_valid_posts_exhaust_register_quota(app, client):
+    _prepare_register_limits(app)
+    csrf = _csrf(client)
+
+    first = _post_register(client, 'quota_user_a', csrf=csrf)
+    second = _post_register(client, 'quota_user_a', csrf=csrf)
+    third = _post_register(client, 'quota_user_a', csrf=csrf)
+
+    assert first.status_code == 302
+    assert '/login' in (first.headers.get('Location') or '')
+    assert second.status_code == 302
+    assert '/register' in (second.headers.get('Location') or '')
+    assert third.status_code == 429
+
+    still_get = client.get('/register')
+    assert still_get.status_code == 200
+
+
+def test_username_taken_still_counts(app, client):
+    from core.db_models import User
+    from core.extensions import db
+
+    _prepare_register_limits(app)
+    with app.app_context():
+        taken = User(username='taken_name', role='user')
+        taken.set_password(VALID_PASSWORD)
+        db.session.add(taken)
+        db.session.commit()
+
+    csrf = _csrf(client)
+    first = _post_register(client, 'taken_name', csrf=csrf)
+    second = _post_register(client, 'taken_name', csrf=csrf)
+    third = _post_register(client, 'taken_name', csrf=csrf)
+
+    assert first.status_code == 302
+    assert '/register' in (first.headers.get('Location') or '')
+    assert second.status_code == 302
+    assert third.status_code == 429
+
+
+def test_email_taken_still_counts(app, client):
+    from core.db_models import User
+    from core.extensions import db
+
+    _prepare_register_limits(app)
+    with app.app_context():
+        taken = User(username='email_owner', email='dup@example.com', role='user')
+        taken.set_password(VALID_PASSWORD)
+        db.session.add(taken)
+        db.session.commit()
+
+    csrf = _csrf(client)
+    first = _post_register(client, 'email_try_one', csrf=csrf, email='dup@example.com')
+    second = _post_register(client, 'email_try_one', csrf=csrf, email='dup@example.com')
+    third = _post_register(client, 'email_try_one', csrf=csrf, email='dup@example.com')
+
+    assert first.status_code == 302
+    assert '/register' in (first.headers.get('Location') or '')
+    assert second.status_code == 302
+    assert third.status_code == 429
+
+
+def test_same_ip_different_username_uses_separate_bucket(app, client):
+    _prepare_register_limits(app)
+    csrf = _csrf(client)
+    ip = '203.0.113.40'
+
+    assert _post_register(client, 'bucket_alice', csrf=csrf, ip=ip).status_code == 302
+    assert _post_register(client, 'bucket_alice', csrf=csrf, ip=ip).status_code == 302
+    assert _post_register(client, 'bucket_alice', csrf=csrf, ip=ip).status_code == 429
+
+    other = _post_register(client, 'bucket_bob', csrf=csrf, ip=ip)
+    assert other.status_code == 302
+    assert other.status_code != 429
+
+
+def test_same_username_different_ip_uses_separate_bucket(app, client):
+    _prepare_register_limits(app)
+    csrf = _csrf(client)
+
+    assert _post_register(client, 'shared_name', csrf=csrf, ip='203.0.113.41').status_code == 302
+    assert _post_register(client, 'shared_name', csrf=csrf, ip='203.0.113.41').status_code == 302
+    assert _post_register(client, 'shared_name', csrf=csrf, ip='203.0.113.41').status_code == 429
+
+    other_ip = _post_register(client, 'shared_name', csrf=csrf, ip='203.0.113.42')
+    assert other_ip.status_code == 302
+    assert other_ip.status_code != 429
+
+
+def test_register_key_uses_hashed_username_not_plaintext(app):
+    from core.security import hash_identifier, rate_limit_key, register_rate_limit_key
+
+    with app.app_context():
+        with app.test_request_context(
+            '/register',
+            method='POST',
+            data={'username': 'alice'},
+            environ_base={'REMOTE_ADDR': '203.0.113.10'},
+        ):
+            key = register_rate_limit_key()
+            digest = hash_identifier('alice')
+            global_key = rate_limit_key()
+
+    assert key == f'register:203.0.113.10:{digest}'
+    assert key.startswith('register:')
+    assert 'alice' not in key
+    assert key != global_key
+    assert not key.startswith('ip:')
+    assert not key.startswith('user:')
+
+
+def test_register_key_empty_username_uses_sentinel(app):
+    from core.security import register_rate_limit_key
+
+    with app.app_context():
+        with app.test_request_context(
+            '/register',
+            method='POST',
+            data={'username': ''},
+            environ_base={'REMOTE_ADDR': '198.51.100.9'},
+        ):
+            key = register_rate_limit_key()
+
+    assert key == 'register:198.51.100.9:empty'
+
+
+def test_register_key_ignores_logged_in_user_id(app):
+    from core.security import rate_limit_key, register_rate_limit_key
+
+    with app.app_context():
+        with app.test_request_context(
+            '/register',
+            method='POST',
+            data={'username': 'still_ip_user'},
+            environ_base={'REMOTE_ADDR': '203.0.113.77'},
+        ):
+            login_user(_FormalUser(42))
+            assert current_user.is_authenticated is True
+            register_key = register_rate_limit_key()
+            global_key = rate_limit_key()
+
+    assert global_key == 'user:42'
+    assert register_key.startswith('register:203.0.113.77:')
+    assert 'user:42' not in register_key
+    assert register_key != global_key
+
+
+def test_register_key_trusted_proxy_xff(app):
+    from core.security import register_rate_limit_key
+
+    app.config['TRUSTED_PROXY_CIDRS'] = '127.0.0.1/32,::1/128'
+    with app.app_context():
+        with app.test_request_context(
+            '/register',
+            method='POST',
+            data={'username': 'proxyuser'},
+            headers={'X-Forwarded-For': '203.0.113.10'},
+            environ_base={'REMOTE_ADDR': '127.0.0.1'},
+        ):
+            key = register_rate_limit_key()
+
+    assert '203.0.113.10' in key
+    assert key.startswith('register:203.0.113.10:')
+    assert '127.0.0.1' not in key
+
+
+def test_register_key_untrusted_xff_ignored(app):
+    from core.security import register_rate_limit_key
+
+    app.config['TRUSTED_PROXY_CIDRS'] = '127.0.0.1/32,::1/128'
+    with app.app_context():
+        with app.test_request_context(
+            '/register',
+            method='POST',
+            data={'username': 'proxyuser'},
+            headers={'X-Forwarded-For': '203.0.113.10'},
+            environ_base={'REMOTE_ADDR': '198.51.100.23'},
+        ):
+            key = register_rate_limit_key()
+
+    assert key.startswith('register:198.51.100.23:')
+    assert '203.0.113.10' not in key
+
+
+def test_default_limiter_still_uses_rate_limit_key(app):
+    from core.extensions import limiter
+    from core.security import rate_limit_key
+
+    key_func = getattr(limiter, '_key_func', None) or getattr(limiter, 'key_func', None)
+    assert key_func is not None
+
+    with app.test_request_context('/', environ_base={'REMOTE_ADDR': '203.0.113.10'}):
+        assert key_func() == rate_limit_key() == 'ip:203.0.113.10'
+
+
+def test_six_char_password_can_still_login(app, client):
+    from core.db_models import User
+    from core.extensions import db
+
+    _prepare_register_limits(app)
+    with app.app_context():
+        user = User(username='legacy6', role='user')
+        user.set_password('123456')
+        db.session.add(user)
+        db.session.commit()
+
+    csrf = _csrf(client, token='login-csrf')
+    resp = client.post(
+        '/login',
+        data={'username': 'legacy6', 'password': '123456', 'csrf_token': csrf},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert resp.status_code != 429
+    location = resp.headers.get('Location') or ''
+    assert '/dashboard' in location

--- a/utils/validators.py
+++ b/utils/validators.py
@@ -22,12 +22,12 @@ def validate_username(username):
     return True, username
 
 
-def validate_password(password):
-    """验证密码：至少6位"""
+def validate_password(password, min_length=6):
+    """验证密码：至少 min_length 位（默认 6）。"""
     if not password or not isinstance(password, str):
         return False, '密码不能为空'
-    if len(password) < 6:
-        return False, '密码长度至少6位'
+    if len(password) < min_length:
+        return False, f'密码长度至少{min_length}位'
     if len(password) > 100:
         return False, '密码长度不能超过100位'
     return True, password


### PR DESCRIPTION
## 这次改了什么

- 给 `POST /register` 增加独立限流键 `register:{受信IP}:{用户名哈希}`，`methods=['POST']` 且 `override_defaults=False`，不改 #31 的 `rate_limit_key` / 默认 Limiter。
- `deduct_when` 看 `g.register_limit_countable`：全部 `validate_*` 通过后才扣；用户名/邮箱已占用也扣，短密码等校验失败不扣。
- 仅注册路径 `validate_password(..., min_length=12)`，`register.html` 密码框加 `minlength="12"`；全局默认仍为 6，`login.html` 不加 minlength。
- 配置项 `RATE_LIMIT_REGISTER` 默认 `5 per hour`。

## 为什么要改

- `/register` 原先没有专用限额；失败路径是 flash+302，不能按 200 计数。
- 换用户名能绕开「纯用户名桶」；必须保留全局 200/min，且不能锁死存量 6 位用户登录。

## 怎么验证

- [x] 运行了相关 pytest
- [ ] 手动验证了受影响页面 / API
- [x] 补充了必要文档
- [x] 已检查 `git diff --staged`
- [x] 当前改动只覆盖这一个问题

验证说明：

```text
conda activate case-weather-py312
cd /Users/imac/Desktop/老家/worktrees/register-rate-limit
python -m pytest tests/test_register_rate_limit.py tests/test_rate_limit_key.py tests/test_security_fixes.py::test_validators_comprehensive tests/test_smoke.py tests/test_bugfix_batch1.py::TestPasswordChangeRequiresOldPassword tests/test_database_bootstrap.py -q
# 28+ related tests passed. 测限额未使用 follow_redirects，并 limiter.reset()。
```

## 文件分类 / 边界检查

- [x] 本 PR 不包含缓存、测试产物、`.claude/`、重复副本或一次性报告
- [x] 如涉及文件迁移，已说明文件去向：主仓库 / 本地归档 / 私有 ops / 本地忽略
- [x] 未提交真实 key、真实 host、真实服务器路径、默认口令
- [x] 如涉及清理仓库，优先处理噪音文件，没有误删运行链路文件
- [x] 如修改 `.sh` 或 `.githooks`，已至少运行一次 `bash -n`

## 关联信息

- 执行者 / Agent：Codex / Cursor 子代理
- Notion 条目：产品清单 P2 注册限流（待回填）
- 分支名：`codex/fix/register-rate-limit`
- 相关 Issue / 备注：计划步骤 P2；不实现 P1/P3–P7
- 相关文件分类说明：运行代码 + 必要测试 + `.env.example` 配置模板，属产品主仓库
- `origin/main` 基线 SHA：`faa39347960977d513cae7ed8e744d8b9eb62631`
- 本地归档路径（如适用）：
- Notion 回填责任人 / 说明（如当前无法访问 Notion）：当前执行者无 Notion 访问，条目待回填

## 备份检查

- [x] 当前分支已 push 到 GitHub
- [x] 本 PR 可以作为本轮工作的远端备份
- [x] 如未完成验证，本 PR 保持 Draft

Made with [Cursor](https://cursor.com)