### PR TITLE
fix: 打卡页与小程序入口互通，保留网页短码确认

### DIFF
--- a/miniprogram/config.js
+++ b/miniprogram/config.js
@@ -4,4 +4,6 @@ module.exports = {
   // 公开仓库默认留空。调试或联调前，必须先改成真实 HTTPS API 地址。
   // Production: must be HTTPS and whitelisted in WeChat MiniProgram console.
   API_BASE_URL: '',
+  // Elders still confirm on the website. Copy this path; do not invent a production host here.
+  WEB_ACTION_URL: '/action',
 };

--- a/miniprogram/pages/bind-token/index.js
+++ b/miniprogram/pages/bind-token/index.js
@@ -1,9 +1,11 @@
 const { api } = require('../../utils/request');
+const { WEB_ACTION_URL } = require('../../config');
 
 Page({
   data: {
     tokenInput: '',
     busy: false,
+    webActionUrl: WEB_ACTION_URL || '/action',
   },
 
   onLoad() {
@@ -39,6 +41,11 @@ Page({
     } finally {
       this.setData({ busy: false });
     }
+  },
+
+  copyWebAction() {
+    const url = (this.data.webActionUrl || '/action').trim();
+    wx.setClipboardData({ data: url });
   },
 });
 

--- a/miniprogram/pages/bind-token/index.wxml
+++ b/miniprogram/pages/bind-token/index.wxml
@@ -23,5 +23,18 @@
       注意：小程序请求域名必须配置 HTTPS 合法域名，且与后端一致。
     </view>
   </view>
+
+  <view style="height: 12px;"></view>
+
+  <view class="card">
+    <view style="font-weight: 700; font-size: 16px;">网页也能打卡</view>
+    <view class="muted" style="margin-top: 6px; font-size: 12px;">
+      扫码进入本页是为了绑定 Token。老人确认仍在网页短码页完成，小程序本批没有打卡。
+    </view>
+    <view style="margin-top: 8px; font-size: 13px;">{{webActionUrl}}</view>
+    <view style="margin-top: 12px;">
+      <button class="btn-outline" bindtap="copyWebAction">复制网页打卡地址</button>
+    </view>
+  </view>
 </view>
 

--- a/miniprogram/pages/elders/index.js
+++ b/miniprogram/pages/elders/index.js
@@ -1,9 +1,11 @@
 const { api } = require('../../utils/request');
+const { WEB_ACTION_URL } = require('../../config');
 
 Page({
   data: {
     elders: [],
     loading: false,
+    webActionUrl: WEB_ACTION_URL || '/action',
   },
 
   async onShow() {
@@ -57,6 +59,11 @@ Page({
 
   goSettings() {
     wx.navigateTo({ url: '/pages/settings/index' });
+  },
+
+  copyWebAction() {
+    const url = (this.data.webActionUrl || '/action').trim();
+    wx.setClipboardData({ data: url });
   },
 });
 

--- a/miniprogram/pages/elders/index.wxml
+++ b/miniprogram/pages/elders/index.wxml
@@ -14,6 +14,19 @@
 
   <view style="height: 12px;"></view>
 
+  <view class="card">
+    <view style="font-weight: 700; font-size: 16px;">网页也能打卡</view>
+    <view class="muted" style="margin-top: 6px; font-size: 12px;">
+      老人确认仍在网页短码页完成。小程序本批没有打卡。复制下方地址到浏览器打开。
+    </view>
+    <view style="margin-top: 8px; font-size: 13px;">{{webActionUrl}}</view>
+    <view style="margin-top: 12px;">
+      <button class="btn-outline" bindtap="copyWebAction">复制网页打卡地址</button>
+    </view>
+  </view>
+
+  <view style="height: 12px;"></view>
+
   <block wx:if="{{loading}}">
     <view class="muted" style="text-align:center; padding: 20px;">加载中…</view>
   </block>

--- a/static/css/yilao.css
+++ b/static/css/yilao.css
@@ -2265,3 +2265,68 @@ body.elder-focus-page main.page-shell {
         grid-template-columns: minmax(0, 1fr);
     }
 }
+
+/* 打卡页：网页 ↔ 小程序入口（CSS 编号三步） */
+.yl-mp-bridge__layout {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.yl-mp-bridge__qr-wrap {
+    flex: 0 0 auto;
+}
+
+.yl-mp-bridge__qr {
+    display: block;
+    width: 144px;
+    height: 144px;
+    object-fit: contain;
+    border: 1px solid var(--yl-line, #ece3d6);
+    border-radius: var(--yl-radius-sm, 10px);
+    background: #fff;
+}
+
+.yl-mp-bridge__copy {
+    flex: 1 1 12rem;
+    min-width: 0;
+}
+
+.yl-mp-bridge__name {
+    margin-bottom: .35rem;
+}
+
+.yl-mp-bridge__steps {
+    list-style: none;
+    counter-reset: yl-mp-step;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: .55rem;
+}
+
+.yl-mp-bridge__steps > li {
+    counter-increment: yl-mp-step;
+    display: flex;
+    align-items: flex-start;
+    gap: .65rem;
+    color: var(--yl-ink, #2a2620);
+    font-size: .92rem;
+    line-height: 1.45;
+}
+
+.yl-mp-bridge__steps > li::before {
+    content: counter(yl-mp-step);
+    flex: 0 0 1.6rem;
+    width: 1.6rem;
+    height: 1.6rem;
+    border-radius: 999px;
+    background: var(--yl-orange-500, #ee7e2d);
+    color: #fff;
+    font-size: .82rem;
+    font-weight: 700;
+    line-height: 1.6rem;
+    text-align: center;
+}

--- a/templates/action_checkin.html
+++ b/templates/action_checkin.html
@@ -2,7 +2,7 @@
 {% from "partials/metric_info.html" import metric_info with context %}
 {% set needs_chartjs = true %}
 
-{% block title %}行动打卡 - 天气健康风险预测系统{% endblock %}
+{% block title %}行动打卡 · 宜老天气通{% endblock %}
 
 {% block content %}
 <div class="container my-4">
@@ -44,6 +44,11 @@
                         {% include "partials/disclaimer_block.html" %}
                     </div>
                 </div>
+            </div>
+        </div>
+        <div class="row mt-4">
+            <div class="col-lg-6">
+                {% include "partials/mp_bridge.html" %}
             </div>
         </div>
     {% else %}
@@ -266,6 +271,9 @@
             </div>
 
             <div class="col-lg-4">
+                <div class="mb-4">
+                    {% include "partials/mp_bridge.html" %}
+                </div>
                 <div class="card shadow-sm mb-4">
                     <div class="card-header bg-light">
                         <h6 class="mb-0"><i class="bi bi-geo-alt"></i> 备选联系人（仅本机保存）</h6>

--- a/templates/partials/mp_bridge.html
+++ b/templates/partials/mp_bridge.html
@@ -1,0 +1,29 @@
+{# Web ↔ Mini Program entry. Scan lands on bind-token; elders still confirm on this page. #}
+<div class="card shadow-sm yl-mp-bridge" data-mp-bridge>
+    <div class="card-header bg-light">
+        <h6 class="mb-0"><i class="bi bi-wechat"></i> 微信小程序入口</h6>
+    </div>
+    <div class="card-body">
+        <div class="yl-mp-bridge__layout">
+            <div class="yl-mp-bridge__qr-wrap">
+                <img
+                    class="yl-mp-bridge__qr"
+                    src="{{ url_for('static', filename='brand/mp-qrcode.png') }}"
+                    alt="宜老天气通小程序码"
+                    width="144"
+                    height="144"
+                    onerror="this.style.display='none'; this.removeAttribute('src'); this.setAttribute('data-qr-missing','1');"
+                >
+            </div>
+            <div class="yl-mp-bridge__copy">
+                <div class="yl-mp-bridge__name">微信小程序名称：<strong>宜老天气通</strong></div>
+                <p class="text-muted small mb-2 mb-md-3">扫码进入绑定 Token 页。码图缺失时请搜索名称。老人确认仍在本页用短码完成，小程序本批不能打卡。</p>
+                <ol class="yl-mp-bridge__steps">
+                    <li>微信搜索「宜老天气通」打开小程序</li>
+                    <li>家属在小程序里绑定 Token</li>
+                    <li>老人仍在本页输入短码完成确认</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+</div>

--- a/tests/test_checkin_web_mp_bridge.py
+++ b/tests/test_checkin_web_mp_bridge.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+"""P4: web check-in stays posted; Mini Program only exposes a reverse /action entry."""
+
+import re
+from datetime import timedelta
+from pathlib import Path
+
+from core.db_models import DailyStatus, Pair, PairActionToken, User
+from core.extensions import db
+from core.security import hash_pair_token, hash_short_code
+from core.time_utils import today_local, utcnow
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+ACTION_TEMPLATE = PROJECT_ROOT / "templates" / "action_checkin.html"
+MP_BRIDGE_PARTIAL = PROJECT_ROOT / "templates" / "partials" / "mp_bridge.html"
+YILAO_CSS = PROJECT_ROOT / "static" / "css" / "yilao.css"
+MP_CONFIG = PROJECT_ROOT / "miniprogram" / "config.js"
+ELDERS_WXML = PROJECT_ROOT / "miniprogram" / "pages" / "elders" / "index.wxml"
+ELDERS_JS = PROJECT_ROOT / "miniprogram" / "pages" / "elders" / "index.js"
+BIND_WXML = PROJECT_ROOT / "miniprogram" / "pages" / "bind-token" / "index.wxml"
+BIND_JS = PROJECT_ROOT / "miniprogram" / "pages" / "bind-token" / "index.js"
+QR_PATH = PROJECT_ROOT / "static" / "brand" / "mp-qrcode.png"
+AVATAR_PATH = PROJECT_ROOT / "static" / "brand" / "yilao-avatar.png"
+
+
+def _create_user(username, password):
+    user = User(username=username, role="user")
+    user.set_password(password)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _create_pair(user, short_code):
+    pair = Pair(
+        caregiver_id=user.id,
+        community_code="都昌",
+        location_query="都昌",
+        elder_code=f"elder-{short_code}",
+        short_code=short_code,
+        short_code_hash=hash_short_code(short_code),
+        short_code_expires_at=utcnow() + timedelta(days=90),
+        status="active",
+        created_at=utcnow(),
+        last_active_at=utcnow(),
+    )
+    db.session.add(pair)
+    db.session.commit()
+    return pair
+
+
+def test_action_checkin_title_and_preserved_forms():
+    template = ACTION_TEMPLATE.read_text(encoding="utf-8")
+    assert "{% block title %}行动打卡 · 宜老天气通{% endblock %}" in template
+    assert template.count('{% include "partials/mp_bridge.html" %}') == 2
+    assert 'action="{{ entry_action or url_for(\'public.action_check\') }}"' in template
+    assert 'action="{{ confirm_action or url_for(\'public.action_confirm\') }}"' in template
+    assert 'action="{{ help_action or url_for(\'public.action_help\') }}"' in template
+    assert 'action="{{ debrief_action or url_for(\'public.action_debrief\') }}"' in template
+    assert 'name="csrf_token"' in template
+    assert 'name="short_code"' in template
+    assert "进入行动页面" in template
+    assert "我很安全" in template
+    assert "我需要帮助" in template
+    assert "提交复盘" in template
+    assert "window.matchMedia('(prefers-reduced-motion: reduce)').matches" in template
+    assert "behavior: reduceMotion ? 'auto' : 'smooth'" in template
+
+
+def test_mp_bridge_partial_uses_qr_path_with_onerror_not_avatar():
+    partial = MP_BRIDGE_PARTIAL.read_text(encoding="utf-8")
+    assert "brand/mp-qrcode.png" in partial
+    assert "yilao-avatar" not in partial
+    assert "onerror=" in partial
+    assert "data-qr-missing" in partial
+    assert "宜老天气通" in partial
+    assert "家属在小程序里绑定 Token" in partial
+    assert "老人仍在本页输入短码完成确认" in partial
+    assert "小程序本批不能打卡" in partial
+    assert "weixin://" not in partial
+    assert "web-view" not in partial
+    if QR_PATH.exists() and AVATAR_PATH.exists():
+        assert QR_PATH.read_bytes() != AVATAR_PATH.read_bytes()
+
+
+def test_mp_bridge_steps_are_css_numbered():
+    css = YILAO_CSS.read_text(encoding="utf-8")
+    assert "counter-reset: yl-mp-step" in css
+    assert "counter-increment: yl-mp-step" in css
+    assert "content: counter(yl-mp-step)" in css
+
+
+def test_miniprogram_copies_web_action_url_without_native_checkin():
+    config = MP_CONFIG.read_text(encoding="utf-8")
+    elders_wxml = ELDERS_WXML.read_text(encoding="utf-8")
+    elders_js = ELDERS_JS.read_text(encoding="utf-8")
+    bind_wxml = BIND_WXML.read_text(encoding="utf-8")
+    bind_js = BIND_JS.read_text(encoding="utf-8")
+
+    assert "WEB_ACTION_URL: '/action'" in config
+    for blob in (elders_wxml, bind_wxml):
+        assert "网页也能打卡" in blob
+        assert "copyWebAction" in blob
+        assert "{{webActionUrl}}" in blob
+        assert "web-view" not in blob
+        assert "weixin://" not in blob
+    for blob in (elders_js, bind_js):
+        assert "WEB_ACTION_URL" in blob
+        assert "wx.setClipboardData" in blob
+        assert "web-view" not in blob
+        assert "weixin://" not in blob
+        assert "navigateToMiniProgram" not in blob
+        assert "/mp/api/v1/checkin" not in blob
+
+
+def test_action_lookup_renders_mp_bridge(app, client):
+    with app.app_context():
+        db.create_all()
+    resp = client.get("/action")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "行动打卡 · 宜老天气通" in html
+    assert "data-mp-bridge" in html
+    assert "/static/brand/mp-qrcode.png" in html
+    assert "微信小程序名称" in html
+    assert "宜老天气通" in html
+    assert "老人仍在本页输入短码完成确认" in html
+    assert 'onerror=' in html
+    qr_tags = re.findall(r'<img\b[^>]*class="yl-mp-bridge__qr"[^>]*>', html, flags=re.I | re.S)
+    assert qr_tags
+    for tag in qr_tags:
+        assert 'mp-qrcode.png' in tag
+        assert 'yilao-avatar' not in tag
+        assert 'onerror=' in tag
+
+
+def test_action_respond_keeps_confirm_help_and_shows_bridge(app, client):
+    with app.app_context():
+        db.create_all()
+        user = _create_user("bridge_lookup_user", "bridge_lookup_pass")
+        pair = _create_pair(user, "13572468")
+        pair_id = pair.id
+
+    with client.session_transaction() as sess:
+        sess["_csrf_token"] = "bridge-lookup-csrf"
+
+    lookup = client.post(
+        "/action",
+        data={"short_code": "13572468", "csrf_token": "bridge-lookup-csrf"},
+        follow_redirects=False,
+    )
+    assert lookup.status_code == 200
+    html = lookup.get_data(as_text=True)
+    assert "我很安全" in html
+    assert "我需要帮助" in html
+    assert "data-mp-bridge" in html
+    assert "/static/brand/mp-qrcode.png" in html
+
+    confirm = client.post(
+        "/action/confirm",
+        data={"short_code": "13572468", "csrf_token": "bridge-lookup-csrf"},
+        follow_redirects=False,
+    )
+    assert confirm.status_code == 200
+    with app.app_context():
+        status = DailyStatus.query.filter_by(pair_id=pair_id, status_date=today_local()).one()
+        assert status.confirmed_at is not None
+        assert status.help_flag is not True
+
+
+def test_action_help_post_still_sets_help_flag(app, client):
+    with app.app_context():
+        db.create_all()
+        user = _create_user("bridge_help_user", "bridge_help_pass")
+        pair = _create_pair(user, "24681357")
+        pair_id = pair.id
+
+    with client.session_transaction() as sess:
+        sess["_csrf_token"] = "bridge-help-csrf"
+
+    resp = client.post(
+        "/action/help",
+        data={"short_code": "24681357", "csrf_token": "bridge-help-csrf"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        status = DailyStatus.query.filter_by(pair_id=pair_id, status_date=today_local()).one()
+        assert status.help_flag is True
+        assert status.confirmed_at is None
+
+
+def test_token_checkin_post_still_confirms(app, client):
+    with app.app_context():
+        db.create_all()
+        user = _create_user("bridge_token_user", "bridge_token_pass")
+        pair = _create_pair(user, "11223344")
+        db.session.add(PairActionToken(
+            pair_id=pair.id,
+            token_hash=hash_pair_token("bridge-action-token"),
+            expires_at=utcnow() + timedelta(days=90),
+            created_at=utcnow(),
+        ))
+        db.session.commit()
+        pair_id = pair.id
+
+    with client.session_transaction() as sess:
+        sess["_csrf_token"] = "bridge-token-csrf"
+
+    resp = client.post(
+        "/e/bridge-action-token/checkin",
+        data={"short_code": "11223344", "csrf_token": "bridge-token-csrf"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        status = DailyStatus.query.filter_by(pair_id=pair_id, status_date=today_local()).one()
+        assert status.confirmed_at is not None
+
+
+def test_mp_checkin_api_is_not_added(app, client):
+    resp = client.post("/mp/api/v1/checkin", json={"short_code": "000000"})
+    assert resp.status_code in (404, 405)
+    mp_api = (PROJECT_ROOT / "blueprints" / "mp_api.py").read_text(encoding="utf-8")
+    assert "/checkin" not in mp_api
+    assert "action_confirm" not in mp_api


### PR DESCRIPTION
## 这次改了什么

- 打卡页 title 改为 `行动打卡 · 宜老天气通`；lookup 与 respond 共用新 partial，露出小程序名「宜老天气通」、`/static/brand/mp-qrcode.png`（`onerror` 藏图留搜索名）和 CSS 编号三步
- 小程序 `elders` / `bind-token` 增加「网页也能打卡」卡片，复制 `config.js` 的 `WEB_ACTION_URL`（`/action`）；扫码落地仍是现有绑定 Token 页
- 保留网页 lookup/confirm/help/debrief POST 与 `/e/<token>/checkin`；不新增 `POST /mp/api/v1/checkin`，不用 URL scheme / URL Link / `web-view`，不用 `yilao-avatar.png` 冒充可扫码图

## 为什么要改

- 现网小程序没有打卡页/API，本批只做入口互通。老人确认仍在网页短码完成，避免关掉网页打卡或谎称「需在小程序完成」

## 怎么验证

- [x] 运行了相关 pytest
- [ ] 手动验证了受影响页面 / API
- [ ] 补充了必要文档
- [x] 已检查 `git diff --staged`
- [x] 当前改动只覆盖这一个问题

验证说明：

```text
conda run -n case-weather-py312 python -m pytest \
  tests/test_checkin_web_mp_bridge.py \
  tests/test_public_token_flow.py \
  tests/test_motion_widgets.py::test_action_checkin_reduced_motion_uses_instant_scroll \
  -q
# 21 passed
```

## 文件分类 / 边界检查

- [x] 本 PR 不包含缓存、测试产物、`.claude/`、重复副本或一次性报告
- [x] 如涉及文件迁移，已说明文件去向：产品主仓库运行模板 / 小程序 / 必要测试
- [x] 未提交真实 key、真实 host、真实服务器路径、默认口令
- [x] 如涉及清理仓库，优先处理噪音文件，没有误删运行链路文件
- [x] 如修改 `.sh` 或 `.githooks`，已至少运行一次 `bash -n`

## 关联信息

- 执行者 / Agent：Cursor Grok（P4 子代理）
- Notion 条目：待回填（当前执行者无 Notion 访问）
- 分支名：`codex/fix/checkin-web-mp-bridge`
- 相关 Issue / 备注：产品清单 P4；不改 P5 照护/社区话术；不停用网页打卡 POST；不新增小程序打卡 API
- 相关文件分类说明：产品主仓库运行模板 + 小程序入口 + 必要测试
- `origin/main` 基线 SHA：`faa39347960977d513cae7ed8e744d8b9eb62631`
- 本地归档路径（如适用）：无
- Notion 回填责任人 / 说明（如当前无法访问 Notion）：待人工回填「网站迭代库」条目
- 运营阻塞：仓库 `static/brand/` 目前没有真实小程序码；页面会 `onerror` 藏图并留下搜索名「宜老天气通」。上线前需放入真实 `mp-qrcode.png`（扫码应落到 `pages/bind-token/index`），禁止用头像冒充

## 备份检查

- [x] 当前分支已 push 到 GitHub
- [x] 本 PR 可以作为本轮工作的远端备份
- [x] 如未完成验证，本 PR 保持 Draft

Made with [Cursor](https://cursor.com)