### PR TITLE
fix: 老人模式顶部增加 120 确认卡，家属电话不回退紧急号

### DIFF
--- a/services/user/dashboard_service.py
+++ b/services/user/dashboard_service.py
@@ -451,17 +451,22 @@ def user_dashboard(force_elder=False):
         elder_actions = elder_actions[:3]
 
         emergency_contact = None
+        family_contact = None
         if not is_guest:
             profiles = FamilyMemberProfile.query.join(FamilyMember).filter(
                 FamilyMember.user_id == current_user.id
             ).all()
             for profile in profiles:
                 contact = safe_json_loads(profile.contact_prefs, {})
-                if contact.get('emergency_phone'):
+                if emergency_contact is None and contact.get('emergency_phone'):
                     emergency_contact = {
                         'name': contact.get('emergency_name') or '紧急联系人',
                         'phone': contact.get('emergency_phone')
                     }
+                family_phone = str(contact.get('phone') or '').strip()
+                if family_contact is None and family_phone:
+                    family_contact = {'phone': family_phone}
+                if emergency_contact and family_contact:
                     break
 
         return render_template(
@@ -475,6 +480,7 @@ def user_dashboard(force_elder=False):
             assessment_explain=assessment_explain,
             elder_actions=elder_actions,
             emergency_contact=emergency_contact,
+            family_contact=family_contact,
             heat_result=heat_result,
             heat_risk_label=heat_risk_label,
             heat_actions=heat_actions,

--- a/static/css/yilao.css
+++ b/static/css/yilao.css
@@ -1835,6 +1835,71 @@ body.elder-focus-page {
 body.elder-focus-page main.page-shell {
     padding-top: clamp(14px, 2vw, 24px) !important;
 }
+
+/* 顶部 120 卡：sticky 贴在导航下，低于 navbar 1020 与 AI 1030。 */
+body.elder-focus-page .yl-elder-sos {
+    position: sticky;
+    top: 4.5rem;
+    z-index: 1010;
+    margin-bottom: 18px;
+    padding: clamp(16px, 3vw, 24px);
+    border-radius: 22px;
+    background: #FFFFFF;
+    border: 1px solid #F0D4CC;
+    box-shadow: 0 10px 28px rgba(199, 71, 46, .08);
+}
+body.elder-focus-page .yl-elder-sos-actions {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 12px;
+}
+body.elder-focus-page .yl-elder-sos-actions.has-family {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+body.elder-focus-page .yl-elder-sos-120,
+body.elder-focus-page .yl-elder-sos-family,
+body.elder-focus-page .yl-elder-120-confirm {
+    width: 100%;
+    justify-content: center;
+    min-height: 68px;
+    font-size: 1.2rem;
+}
+body.elder-focus-page .yl-elder-sos-hint {
+    margin: 12px 0 0;
+    color: #39454F;
+    font-size: 1.12rem;
+    line-height: 1.55;
+}
+body.elder-focus-page .yl-elder-sos-register {
+    display: inline-block;
+    margin-top: 6px;
+    font-size: 1.08rem;
+    font-weight: 600;
+}
+body.elder-focus-page .yl-elder-120-dialog {
+    border: none;
+    border-radius: 22px;
+    padding: clamp(22px, 4vw, 32px);
+    width: min(32rem, calc(100vw - 32px));
+    box-shadow: 0 24px 50px rgba(33, 22, 11, .18);
+}
+body.elder-focus-page .yl-elder-120-dialog::backdrop {
+    background: rgba(20, 16, 12, .45);
+}
+body.elder-focus-page .yl-elder-120-dialog h2 {
+    font-size: clamp(1.55rem, 3vw, 2.1rem);
+    margin-bottom: 10px;
+}
+body.elder-focus-page .yl-elder-120-dialog p {
+    color: #39454F;
+    font-size: 1.12rem;
+    line-height: 1.65;
+    margin-bottom: 18px;
+}
+body.elder-focus-page .yl-elder-120-dialog-actions {
+    display: grid;
+    gap: 12px;
+}
 .yl-elder-shell {
     max-width: 1040px;
     margin: 0 auto;
@@ -2048,6 +2113,12 @@ body.elder-focus-page main.page-shell {
     }
     .yl-elder-status h1 {
         font-size: clamp(2.4rem, 14vw, 3.6rem);
+    }
+    body.elder-focus-page .yl-elder-sos {
+        border-radius: 18px;
+    }
+    body.elder-focus-page .yl-elder-sos-actions.has-family {
+        grid-template-columns: minmax(0, 1fr);
     }
 }
 

--- a/templates/elder_dashboard.html
+++ b/templates/elder_dashboard.html
@@ -17,6 +17,32 @@
 } %}
 
 <div class="yl-elder-shell">
+    <aside class="yl-elder-sos" aria-label="紧急求助">
+        <div class="yl-elder-sos-actions{% if family_contact and family_contact.phone %} has-family{% endif %}">
+            <button type="button" class="btn btn-danger btn-lg yl-elder-sos-120" data-yl-open-120 aria-haspopup="dialog" aria-controls="yl-elder-120-dialog">
+                <i class="bi bi-telephone-fill" aria-hidden="true"></i> 拨打 120
+            </button>
+            {% if family_contact and family_contact.phone %}
+                <a class="btn btn-outline-secondary btn-lg yl-elder-sos-family" href="tel:{{ family_contact.phone }}">
+                    <i class="bi bi-person-heart" aria-hidden="true"></i> 联系家属
+                </a>
+            {% endif %}
+        </div>
+        {% if is_guest %}
+            <p class="yl-elder-sos-hint">请让身边人联系家属或社区</p>
+            <a class="yl-elder-sos-register" href="{{ url_for('public.register') }}">去注册</a>
+        {% endif %}
+    </aside>
+
+    <dialog id="yl-elder-120-dialog" class="yl-elder-120-dialog" aria-labelledby="yl-elder-120-title">
+        <h2 id="yl-elder-120-title">确认拨打 120？</h2>
+        <p>仅在突发急病、昏迷、胸痛等紧急情况时拨打急救电话。</p>
+        <div class="yl-elder-120-dialog-actions">
+            <a class="btn btn-danger btn-lg yl-elder-120-confirm" href="tel:120">确认拨打 120</a>
+            <button type="button" class="btn btn-outline-secondary btn-lg" data-yl-close-120>取消</button>
+        </div>
+    </dialog>
+
     <section class="yl-elder-hero yl-fade-up" aria-label="今日健康小结">
         <div class="yl-elder-status">
             <span>今天</span>
@@ -137,4 +163,27 @@
 
     <p class="yl-elder-disclaimer">提示只用于日常行动参考，身体明显不舒服时请及时寻求专业帮助。</p>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var dialog = document.getElementById('yl-elder-120-dialog');
+    var openBtn = document.querySelector('[data-yl-open-120]');
+    var closeBtn = document.querySelector('[data-yl-close-120]');
+    if (!dialog || !openBtn) {
+        return;
+    }
+    openBtn.addEventListener('click', function () {
+        if (typeof dialog.showModal === 'function') {
+            dialog.showModal();
+        }
+    });
+    if (closeBtn) {
+        closeBtn.addEventListener('click', function () {
+            dialog.close();
+        });
+    }
+});
+</script>
 {% endblock %}

--- a/tests/test_elder_120_confirm.py
+++ b/tests/test_elder_120_confirm.py
@@ -1,0 +1,245 @@
+# -*- coding: utf-8 -*-
+"""老人模式顶部 120 确认卡回归测试。"""
+import json
+import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _login_as(client, user_id, csrf_token='test-csrf-token'):
+    with client.session_transaction() as session:
+        session['_user_id'] = str(user_id)
+        session['_fresh'] = True
+        session['_csrf_token'] = csrf_token
+
+
+def _create_user(db_session, username='elder_120_user', role='user', community='都昌'):
+    from core.db_models import User
+
+    user = User(username=username, role=role, community=community)
+    user.set_password('testpass')
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+def _add_member_with_prefs(db_session, user_id, name, contact_prefs):
+    from core.db_models import FamilyMember, FamilyMemberProfile
+
+    member = FamilyMember(user_id=user_id, name=name, relation='父亲', age=76)
+    db_session.add(member)
+    db_session.flush()
+    db_session.add(FamilyMemberProfile(
+        member_id=member.id,
+        contact_prefs=json.dumps(contact_prefs, ensure_ascii=False),
+    ))
+    db_session.commit()
+    return member
+
+
+def _patch_unavailable_weather(monkeypatch, temperature=36.5):
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_weather_with_cache',
+        lambda location: ({
+            'temperature': temperature,
+            'temperature_max': 39,
+            'temperature_min': None,
+            'humidity': 80,
+            'pressure': 1000,
+            'weather_condition': '晴',
+            'wind_speed': 2,
+            'aqi': 88,
+            'is_mock': False,
+            'data_source': 'QWeather',
+        }, False),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_qweather_forecast_with_cache',
+        lambda location, days=7: ([], False, {'error': 'qweather_unavailable'}),
+        raising=False,
+    )
+
+
+def _sos_html(body):
+    start = body.find('class="yl-elder-sos"')
+    end = body.find('</aside>', start)
+    assert start != -1
+    assert end != -1
+    return body[start:end]
+
+
+def _dialog_html(body):
+    start = body.find('id="yl-elder-120-dialog"')
+    end = body.find('</dialog>', start)
+    assert start != -1
+    assert end != -1
+    return body[start:end]
+
+
+def _call_card_html(body):
+    start = body.find('class="yl-elder-call-card"')
+    end = body.find('</div>', start)
+    assert start != -1
+    return body[start:end + len('</div>')]
+
+
+def test_guest_elder_mode_shows_120_dialog_and_register_not_family_members(
+    client,
+    db_session,
+    monkeypatch,
+):
+    _patch_unavailable_weather(monkeypatch)
+
+    guest = client.get('/guest?next=/elder-mode', follow_redirects=True)
+    assert guest.status_code == 200
+    body = guest.get_data(as_text=True)
+
+    sos = _sos_html(body)
+    dialog = _dialog_html(body)
+    call_card = _call_card_html(body)
+
+    assert 'data-yl-open-120' in sos
+    assert 'href="tel:120"' not in sos
+    assert '请让身边人联系家属或社区' in sos
+    assert 'href="/register"' in sos
+    assert '/family-members' not in sos
+    assert '/family-members' not in body
+    assert 'yl-elder-sos-family' not in body
+
+    assert '<dialog' in body
+    assert 'href="tel:120"' in dialog
+    assert 'showModal' in body
+    assert 'window.confirm' not in body
+    assert 'a[href^="tel:"]' not in body
+    assert "a[href^='tel:']" not in body
+
+    assert '<h2>一键联系</h2>' in call_card
+    assert '还没有设置紧急联系人。' in call_card
+    assert '注册后设置' in call_card
+    assert '天气更新中' in body
+    assert '补水、通风并避免暴晒' in body
+    assert '36.5' not in body
+
+
+def test_family_phone_is_direct_tel_and_does_not_use_emergency_phone(
+    client,
+    db_session,
+    monkeypatch,
+):
+    user = _create_user(db_session, username='elder_120_family_user')
+    _add_member_with_prefs(
+        db_session,
+        user.id,
+        '父亲',
+        {
+            'phone': '13800138000',
+            'emergency_name': '邻居王叔',
+            'emergency_phone': '13900139000',
+        },
+    )
+    _login_as(client, user.id)
+    _patch_unavailable_weather(monkeypatch)
+
+    response = client.get('/elder-mode')
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+
+    sos = _sos_html(body)
+    dialog = _dialog_html(body)
+    call_card = _call_card_html(body)
+
+    assert 'yl-elder-sos-family' in sos
+    assert 'href="tel:13800138000"' in sos
+    assert '13900139000' not in sos
+    assert '请让身边人联系家属或社区' not in body
+    assert 'href="/register"' not in sos
+
+    assert 'href="tel:120"' in dialog
+    assert '13800138000' not in dialog
+    assert '13900139000' not in dialog
+    assert 'data-yl-open-120' in sos
+    assert 'window.confirm' not in body
+    assert 'a[href^="tel:"]' not in body
+
+    assert '<h2>一键联系</h2>' in call_card
+    assert '邻居王叔' in call_card
+    assert 'href="tel:13900139000"' in call_card
+    assert '现在拨打' in call_card
+    assert '天气更新中' in body
+    assert '补水、通风并避免暴晒' in body
+    assert '36.5' not in body
+
+
+def test_top_family_tel_never_falls_back_to_emergency_phone(
+    client,
+    db_session,
+    monkeypatch,
+):
+    user = _create_user(db_session, username='elder_120_emergency_only')
+    _add_member_with_prefs(
+        db_session,
+        user.id,
+        '母亲',
+        {
+            'emergency_name': '紧急联系人',
+            'emergency_phone': '13700137000',
+        },
+    )
+    _login_as(client, user.id)
+    _patch_unavailable_weather(monkeypatch)
+
+    body = client.get('/elder-mode').get_data(as_text=True)
+    sos = _sos_html(body)
+    call_card = _call_card_html(body)
+
+    assert 'yl-elder-sos-family' not in sos
+    assert '13700137000' not in sos
+    assert 'href="tel:13700137000"' in call_card
+    assert '<h2>一键联系</h2>' in call_card
+    assert '去设置联系人' not in call_card
+
+
+def test_logged_in_without_family_phone_does_not_link_sos_to_family_members(
+    client,
+    db_session,
+    monkeypatch,
+):
+    user = _create_user(db_session, username='elder_120_no_phone')
+    _login_as(client, user.id)
+    _patch_unavailable_weather(monkeypatch)
+
+    body = client.get('/elder-mode').get_data(as_text=True)
+    sos = _sos_html(body)
+    call_card = _call_card_html(body)
+
+    assert '/family-members' not in sos
+    assert 'yl-elder-sos-family' not in sos
+    assert 'href="/family-members"' in call_card
+    assert '去设置联系人' in call_card
+
+
+def test_sos_css_is_sticky_scoped_and_below_navbar_zindex():
+    css = (PROJECT_ROOT / 'static/css/yilao.css').read_text(encoding='utf-8')
+    sos_match = re.search(
+        r'body\.elder-focus-page \.yl-elder-sos \{(?P<body>.*?)\n\}',
+        css,
+        re.S,
+    )
+    assert sos_match, 'SOS 卡样式必须写在 body.elder-focus-page 下'
+    sos_css = sos_match.group('body')
+    assert 'position: sticky' in sos_css
+    assert 'position: fixed' not in sos_css
+    assert 'top: 4.5rem' in sos_css
+    z_match = re.search(r'z-index:\s*(\d+)', sos_css)
+    assert z_match
+    assert int(z_match.group(1)) < 1020
+
+    base = (PROJECT_ROOT / 'templates/base.html').read_text(encoding='utf-8')
+    assert 'yl-elder-sos' not in base
+    assert 'tel:120' not in base
+    assert 'yl-elder-120-dialog' not in base
+
+    config = (PROJECT_ROOT / 'core/config.py').read_text(encoding='utf-8')
+    assert "os.getenv('FEATURE_ELDER_MODE', '0')" in config


### PR DESCRIPTION
## 这次改了什么

- 在 `/elder-mode` 导航下增加 sticky 大卡：120 触发走原生 `<dialog>`，确认 CTA 才是 `tel:120`；不用 `window.confirm`，不绑定全部 `tel:` 链接。
- 登录且 `contact_prefs.phone` 有值时，第二颗按钮直接 `tel:` 家属号、无确认；**不回退** `emergency_phone`。
- 游客显示「请让身边人联系家属或社区」+ 注册；顶部卡不链 `/family-members`。
- 中部「一键联系」一字不改，仍用 `emergency_phone`。SOS 卡只做在 `elder_dashboard.html`，CSS 限定 `body.elder-focus-page`，不改 `FEATURE_ELDER_MODE` 默认值，不写入 `base.html`。

## 为什么要改

- 老人模式原先只有中部紧急联系，没有顶部 120，也没有误拨确认。
- 顶部家属电话若回退 `emergency_phone`，会和中部「一键联系」混成同一号码，并可能把急救确认绑到家属 `tel:`。

## 怎么验证

- [x] 运行了相关 pytest
- [ ] 手动验证了受影响页面 / API
- [x] 补充了必要文档
- [x] 已检查 `git diff --staged`
- [x] 当前改动只覆盖这一个问题

验证说明：

```text
conda activate case-weather-py312
cd /Users/imac/Desktop/老家/worktrees/elder-120-confirm
python -m pytest tests/test_elder_120_confirm.py tests/test_motion_widgets.py tests/test_nav_offcanvas.py::test_anonymous_elder_card_enters_guest_elder_mode -q
# 19 passed
# 老人模式仍有「天气更新中」「补水、通风并避免暴晒」，无 mock 36.5；家属 tel: 不弹 120 确认
```

## 文件分类 / 边界检查

- [x] 本 PR 不包含缓存、测试产物、`.claude/`、重复副本或一次性报告
- [x] 如涉及文件迁移，已说明文件去向：主仓库 / 本地归档 / 私有 ops / 本地忽略
- [x] 未提交真实 key、真实 host、真实服务器路径、默认口令
- [x] 如涉及清理仓库，优先处理噪音文件，没有误删运行链路文件
- [x] 如修改 `.sh` 或 `.githooks`，已至少运行一次 `bash -n`

## 关联信息

- 执行者 / Agent：Codex / Cursor 子代理
- Notion 条目：产品清单 P6 老人 120 卡（待回填）
- 分支名：`codex/fix/elder-120-confirm`
- 相关 Issue / 备注：计划步骤 P6；不实现 P7「回到今天」（同文件，后续 rebase 本 PR）
- 相关文件分类说明：运行代码 + 必要测试，属产品主仓库
- `origin/main` 基线 SHA：`faa39347960977d513cae7ed8e744d8b9eb62631`
- 本地归档路径（如适用）：
- Notion 回填责任人 / 说明（如当前无法访问 Notion）：当前执行者无 Notion 访问，条目待回填

## 备份检查

- [x] 当前分支已 push 到 GitHub
- [x] 本 PR 可以作为本轮工作的远端备份
- [x] 如未完成验证，本 PR 保持 Draft


Made with [Cursor](https://cursor.com)