### PR TITLE
fix: 限流 429 按路径返回中文页或 JSON

### DIFF
--- a/core/hooks.py
+++ b/core/hooks.py
@@ -7,9 +7,11 @@ import secrets
 import time
 from datetime import datetime
 
-from flask import g, request, session, url_for as flask_url_for
+from flask import g, jsonify, make_response, render_template, request, session, url_for as flask_url_for
+from flask_limiter import RateLimitExceeded
 from flask_login import current_user
 
+from core.extensions import limiter
 from core.metric_explanations import (
     get_metric_explanation_groups,
     get_metric_explanations,
@@ -25,6 +27,10 @@ logger = logging.getLogger(__name__)
 
 MAX_JSON_BYTES = 10 * 1024
 MAX_JSON_DEPTH = 5
+JSON_RATE_LIMIT_PREFIXES = ('/api/', '/mp/api/', '/_AMapService/')
+RATE_LIMITED_JSON_MESSAGE = '请求过于频繁，请稍后再试'
+GUEST_ELDER_MODE_FALLBACK = '/guest?next=/elder-mode'
+PUBLIC_RISK_FALLBACK = '/risk'
 
 
 def _redact_sensitive_path(path):
@@ -60,8 +66,80 @@ def _valid_key_length(value):
     return isinstance(value, str) and 20 <= len(value) <= 100
 
 
+def _wants_rate_limit_json(path=None):
+    """429 JSON 只按路径分流，不复用只认 /api/ 的 Accept 判断。"""
+    path = path if path is not None else (request.path or '')
+    return path.startswith(JSON_RATE_LIMIT_PREFIXES)
+
+
+def _retry_after_seconds():
+    """剩余秒数来自 limiter.current_limit.reset_at；exc.retry_after 恒为 None。"""
+    try:
+        current = limiter.current_limit
+        reset_at = getattr(current, 'reset_at', None) if current is not None else None
+        if reset_at is None:
+            return 0
+        return max(0, int(reset_at) - int(time.time()))
+    except Exception:
+        logger.debug("读取限流 reset_at 失败", exc_info=True)
+        return 0
+
+
+def _safe_url_for(endpoint, fallback, **values):
+    """url_for 失败时回退硬编码路径，避免 429 处理器自己变成 500。"""
+    try:
+        return flask_url_for(endpoint, **values)
+    except Exception:
+        logger.debug("429 逃生链接 url_for 失败: %s", endpoint, exc_info=True)
+        return fallback
+
+
+def _rate_limited_json_response(retry_after):
+    response = jsonify({
+        'success': False,
+        'error': 'rate_limited',
+        'message': RATE_LIMITED_JSON_MESSAGE,
+        'retry_after': retry_after,
+    })
+    response.status_code = 429
+    response.headers['Retry-After'] = str(retry_after)
+    return response
+
+
+def _rate_limited_html_response(retry_after):
+    risk_url = _safe_url_for('public.public_risk', PUBLIC_RISK_FALLBACK)
+    elder_mode_url = _safe_url_for(
+        'public.guest_login',
+        GUEST_ELDER_MODE_FALLBACK,
+        next='/elder-mode',
+    )
+    try:
+        html = render_template(
+            '429.html',
+            retry_after=retry_after,
+            risk_url=risk_url,
+            elder_mode_url=elder_mode_url,
+            request_method=request.method,
+        )
+        response = make_response(html, 429)
+    except Exception:
+        logger.exception("渲染中文 429 页失败，回退纯文本")
+        response = make_response(RATE_LIMITED_JSON_MESSAGE, 429)
+        response.mimetype = 'text/plain'
+    response.headers['Retry-After'] = str(retry_after)
+    return response
+
+
 def register_hooks(app):
     """Register app hooks, filters, and context processors."""
+    @app.errorhandler(RateLimitExceeded)
+    def handle_rate_limit_exceeded(_exc):
+        """Limiter 3.7 默认英文 Werkzeug HTML；按路径拆成 JSON / 中文页。"""
+        retry_after = _retry_after_seconds()
+        if _wants_rate_limit_json():
+            return _rate_limited_json_response(retry_after)
+        return _rate_limited_html_response(retry_after)
+
     @app.before_request
     def init_request_context():
         """初始化请求上下文（结构化日志使用）"""

--- a/templates/429.html
+++ b/templates/429.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+
+{% block title %}请求过于频繁 · 宜老天气通{% endblock %}
+
+{% block content %}
+<div class="container my-4">
+    <div class="row justify-content-center">
+        <div class="col-lg-7">
+            <section class="card shadow-sm yl-fade-up" aria-labelledby="rate-limit-title">
+                <div class="card-body p-4 p-md-5">
+                    <span class="section-kicker">稍后再试</span>
+                    <h1 id="rate-limit-title" class="mt-2 mb-3">请求过于频繁</h1>
+                    <p class="text-muted mb-3">
+                        为了保护服务稳定，请稍等片刻再继续。倒计时结束只表示可以重试，本页不会自动刷新。
+                    </p>
+                    <p class="mb-4">
+                        约 <strong id="retry-after-count">{{ retry_after }}</strong> 秒后可以重试。
+                        <span id="retry-hint" class="d-block mt-2"></span>
+                    </p>
+                    {% if request_method and request_method|upper != 'GET' %}
+                    <p class="small text-muted mb-4">请返回上一页后重新提交，不要刷新本页，以免再次提交刚才的操作。</p>
+                    {% endif %}
+                    <div class="d-flex flex-wrap gap-2">
+                        <a class="btn btn-primary" href="{{ risk_url }}">先看今日公开风险</a>
+                        <a class="btn btn-outline-secondary" href="{{ elder_mode_url }}">进入老人模式</a>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+    (function() {
+        var remaining = {{ retry_after|int }};
+        var countEl = document.getElementById('retry-after-count');
+        var hintEl = document.getElementById('retry-hint');
+        if (!countEl) return;
+
+        function showReady() {
+            countEl.textContent = '0';
+            if (hintEl) hintEl.textContent = '可以重试了';
+        }
+
+        function tick() {
+            if (remaining <= 0) {
+                showReady();
+                return;
+            }
+            countEl.textContent = String(remaining);
+            remaining -= 1;
+            window.setTimeout(tick, 1000);
+        }
+
+        tick();
+    })();
+</script>
+{% endblock %}

--- a/tests/test_html_429_zh.py
+++ b/tests/test_html_429_zh.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+"""P1：HTML 429 中文页与 API JSON 按路径分流。"""
+from flask_limiter.wrappers import LimitGroup
+
+from core.extensions import limiter
+from core.hooks import _wants_rate_limit_json
+
+HTML_ESCAPE_TEXT = '先看今日公开风险'
+ELDER_MODE_HREF = '/guest?next=/elder-mode'
+RISK_HREF = '/risk'
+
+
+def _reset_limiter():
+    limiter.reset()
+
+
+def _tighten_default_limit(limit_str='1 per minute'):
+    original = list(limiter.limit_manager._default_limits)
+    limiter.limit_manager.set_default_limits([
+        LimitGroup(limit_provider=limit_str, key_function=limiter._key_func),
+    ])
+    _reset_limiter()
+    return original
+
+
+def _restore_default_limits(original):
+    limiter.limit_manager.set_default_limits(original)
+    _reset_limiter()
+
+
+def test_rate_limit_json_split_is_path_only():
+    assert _wants_rate_limit_json('/api/v1/weather/current') is True
+    assert _wants_rate_limit_json('/mp/api/v1/me') is True
+    assert _wants_rate_limit_json('/_AMapService/v3/place/text') is True
+    assert _wants_rate_limit_json('/login') is False
+    assert _wants_rate_limit_json('/risk') is False
+    assert _wants_rate_limit_json('/guest') is False
+
+
+def test_html_get_429_is_chinese_page_with_escape_hatches(app, client):
+    original = _tighten_default_limit()
+    try:
+        first = client.get('/login', follow_redirects=False)
+        blocked = client.get(
+            '/login',
+            headers={'Accept': 'application/json'},
+            follow_redirects=False,
+        )
+
+        assert first.status_code == 200
+        assert blocked.status_code == 429
+        assert blocked.mimetype == 'text/html'
+        body = blocked.get_data(as_text=True)
+        assert HTML_ESCAPE_TEXT in body
+        assert f'href="{RISK_HREF}"' in body
+        assert f'href="{ELDER_MODE_HREF}"' in body
+        assert 'href="/elder"' not in body
+        assert 'href="/elder?' not in body
+        assert '回到今天' not in body
+        assert 'location.reload' not in body
+        assert blocked.headers.get('Retry-After', '').isdigit()
+        assert int(blocked.headers['Retry-After']) >= 0
+        assert blocked.get_json(silent=True) is None
+    finally:
+        _restore_default_limits(original)
+
+
+def test_html_post_429_does_not_auto_reload(app, client, db_session):
+    app.config['RATE_LIMIT_LOGIN'] = '1 per minute'
+    _reset_limiter()
+    csrf = 'html-429-csrf'
+    with client.session_transaction() as session:
+        session['_csrf_token'] = csrf
+    payload = {
+        'username': 'missing-user',
+        'password': 'wrong-password',
+        'csrf_token': csrf,
+    }
+
+    try:
+        first = client.post('/login', data=payload, follow_redirects=False)
+        blocked = client.post('/login', data=payload, follow_redirects=False)
+
+        assert first.status_code == 200
+        assert blocked.status_code == 429
+        body = blocked.get_data(as_text=True)
+        assert HTML_ESCAPE_TEXT in body
+        assert f'href="{ELDER_MODE_HREF}"' in body
+        assert 'location.reload' not in body
+        assert 'window.location' not in body
+        assert '请返回上一页后重新提交' in body
+        assert blocked.headers.get('Retry-After', '').isdigit()
+    finally:
+        _reset_limiter()
+
+
+def test_api_429_is_json_without_html_escape_copy(app, client):
+    app.config['RATE_LIMIT_WEATHER'] = '1 per minute'
+    _reset_limiter()
+    same_ip = {'REMOTE_ADDR': '203.0.113.40'}
+
+    try:
+        first = client.get(
+            '/api/v1/weather/current',
+            environ_overrides=same_ip,
+            follow_redirects=False,
+        )
+        blocked = client.get(
+            '/api/v1/weather/current',
+            headers={'Accept': 'text/html'},
+            environ_overrides=same_ip,
+            follow_redirects=False,
+        )
+
+        assert first.status_code in (200, 400, 503)
+        assert blocked.status_code == 429
+        assert blocked.is_json
+        body = blocked.get_json()
+        assert body['success'] is False
+        assert body['error'] == 'rate_limited'
+        assert body['message'] == '请求过于频繁，请稍后再试'
+        assert isinstance(body['retry_after'], int)
+        assert body['retry_after'] >= 0
+        raw = blocked.get_data(as_text=True)
+        assert HTML_ESCAPE_TEXT not in raw
+        assert '进入老人模式' not in raw
+        assert blocked.headers.get('Retry-After') == str(body['retry_after'])
+    finally:
+        _reset_limiter()
+
+
+def test_amap_proxy_429_is_json(app, client):
+    app.config['RATE_LIMIT_AMAP_PROXY'] = '1 per minute'
+    _reset_limiter()
+    path = '/_AMapService/v3/weather/weatherInfo'
+    same_ip = {'REMOTE_ADDR': '203.0.113.41'}
+
+    try:
+        first = client.get(path, environ_overrides=same_ip, follow_redirects=False)
+        blocked = client.get(path, environ_overrides=same_ip, follow_redirects=False)
+
+        assert first.status_code != 429
+        assert blocked.status_code == 429
+        assert blocked.is_json
+        body = blocked.get_json()
+        assert body['success'] is False
+        assert body['error'] == 'rate_limited'
+        assert HTML_ESCAPE_TEXT not in blocked.get_data(as_text=True)
+    finally:
+        _reset_limiter()

--- a/tests/test_mp_api_auth.py
+++ b/tests/test_mp_api_auth.py
@@ -111,6 +111,11 @@ def test_mp_api_invalid_bearer_rotation_cannot_bypass_ip_limit(
 
         assert first.status_code == 401
         assert rotated.status_code == 429
+        assert rotated.is_json
+        body = rotated.get_json()
+        assert body['success'] is False
+        assert body['error'] == 'rate_limited'
+        assert '先看今日公开风险' not in rotated.get_data(as_text=True)
         assert separate_ip.status_code == 401
     finally:
         limiter.reset()


### PR DESCRIPTION
## 这次改了什么

- 在 `core/hooks.py` 的 `register_hooks` 注册 `RateLimitExceeded` 处理器（不是裸 429，不进薄 `app.py`，不用 `Limiter(on_breach=)`）
- `/api/`、`/mp/api/`、`/_AMapService/` 返回 JSON：`success=false`、`error=rate_limited`、中文 message、`retry_after`
- 其余路径渲染中文 `templates/429.html`（extends `base.html`）
- `Retry-After` 取 `limiter.current_limit.reset_at` 剩余秒数
- 逃生入口：`/risk`（先看今日公开风险）、`/guest?next=/elder-mode`（进入老人模式）；`url_for` 失败有硬编码兜底
- 倒计时到 0 只提示可重试，POST 429 不自动 reload
- 未改 `core/security.py` 的 `rate_limit_key`

## 为什么要改

- Flask-Limiter 3.7 默认英文 Werkzeug HTML，会盖掉小程序/API 的 JSON 429；现有 MP 测试只断言状态码，测不出这个分叉

## 怎么验证

- [x] 运行了相关 pytest
- [ ] 手动验证了受影响页面 / API
- [ ] 补充了必要文档
- [x] 已检查 `git diff --staged`
- [x] 当前改动只覆盖这一个问题

验证说明：

```text
conda activate case-weather-py312
python -m pytest -q tests/test_html_429_zh.py tests/test_mp_api_auth.py tests/test_rate_limit_key.py tests/test_amap_proxy.py tests/test_nav_offcanvas.py tests/test_login_remember_me.py --tb=short
# 69 passed
```

## 文件分类 / 边界检查

- [x] 本 PR 不包含缓存、测试产物、`.claude/`、重复副本或一次性报告
- [x] 如涉及文件迁移，已说明文件去向：主仓库 / 本地归档 / 私有 ops / 本地忽略
- [x] 未提交真实 key、真实 host、真实服务器路径、默认口令
- [x] 如涉及清理仓库，优先处理噪音文件，没有误删运行链路文件
- [x] 如修改 `.sh` 或 `.githooks`，已至少运行一次 `bash -n`

## 关联信息

- 执行者 / Agent：Codex（P1 html-429-zh）
- Notion 条目：待回填（当前执行者无 Notion 访问）
- 分支名：`codex/fix/html-429-zh`
- 相关 Issue / 备注：产品清单修复 P1；worktree `/Users/imac/Desktop/老家/worktrees/html-429-zh`
- 相关文件分类说明：产品主仓库（运行代码 + 必要测试）
- `origin/main` 基线 SHA：`faa39347960977d513cae7ed8e744d8b9eb62631`
- 本地归档路径（如适用）：无
- Notion 回填责任人 / 说明（如当前无法访问 Notion）：待人工回填网站迭代库条目、分支名与 PR 链接

## 备份检查

- [x] 当前分支已 push 到 GitHub
- [x] 本 PR 可以作为本轮工作的远端备份
- [x] 如未完成验证，本 PR 保持 Draft

Made with [Cursor](https://cursor.com)