### PR TITLE
fix: 老人模式用页内锚点回到今日小结，不再链回 /elder-mode

### DIFF
--- a/static/css/yilao.css
+++ b/static/css/yilao.css
@@ -1900,6 +1900,41 @@ body.elder-focus-page .yl-elder-120-dialog-actions {
     display: grid;
     gap: 12px;
 }
+
+/* 左下角「回到今天」：默认隐藏，避开右下角 AI 浮窗；非全宽、非危险按钮。 */
+body.elder-focus-page .yl-elder-back-today {
+    position: fixed;
+    left: max(16px, env(safe-area-inset-left));
+    right: auto;
+    bottom: max(20px, env(safe-area-inset-bottom));
+    z-index: 1025;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: auto;
+    max-width: min(16rem, calc(100vw - 96px));
+    min-height: 56px;
+    padding: 12px 20px;
+    border-radius: 999px;
+    background: #1F2A34;
+    color: #FFFFFF;
+    font-size: 1.12rem;
+    font-weight: 700;
+    line-height: 1.2;
+    text-decoration: none;
+    box-shadow: 0 10px 28px rgba(31, 42, 52, .22);
+}
+body.elder-focus-page .yl-elder-back-today.is-visible {
+    display: inline-flex;
+}
+body.elder-focus-page .yl-elder-back-today[hidden] {
+    display: none !important;
+}
+body.elder-focus-page .yl-elder-back-today:focus-visible {
+    outline: 3px solid #D85B16;
+    outline-offset: 3px;
+}
 .yl-elder-shell {
     max-width: 1040px;
     margin: 0 auto;
@@ -2119,6 +2154,13 @@ body.elder-focus-page .yl-elder-120-dialog-actions {
     }
     body.elder-focus-page .yl-elder-sos-actions.has-family {
         grid-template-columns: minmax(0, 1fr);
+    }
+    body.elder-focus-page .yl-elder-back-today {
+        left: max(12px, env(safe-area-inset-left));
+        right: auto;
+        width: auto;
+        min-height: 52px;
+        font-size: 1.05rem;
     }
 }
 

--- a/templates/elder_dashboard.html
+++ b/templates/elder_dashboard.html
@@ -43,7 +43,7 @@
         </div>
     </dialog>
 
-    <section class="yl-elder-hero yl-fade-up" aria-label="今日健康小结">
+    <section class="yl-elder-hero yl-fade-up" id="today" aria-label="今日健康小结">
         <div class="yl-elder-status">
             <span>今天</span>
             <h1>
@@ -163,6 +163,10 @@
 
     <p class="yl-elder-disclaimer">提示只用于日常行动参考，身体明显不舒服时请及时寻求专业帮助。</p>
 </div>
+<a href="#today" class="yl-elder-back-today" id="yl-elder-back-today" hidden>
+    <i class="bi bi-chevron-up" aria-hidden="true"></i>
+    回到今天
+</a>
 {% endblock %}
 
 {% block extra_js %}
@@ -184,6 +188,36 @@ document.addEventListener('DOMContentLoaded', function () {
             dialog.close();
         });
     }
+});
+</script>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var todayEl = document.getElementById('today');
+    var callEl = document.querySelector('.yl-elder-call-card');
+    var backBtn = document.getElementById('yl-elder-back-today');
+    if (!todayEl || !callEl || !backBtn || !('IntersectionObserver' in window)) {
+        return;
+    }
+    var todayInView = true;
+    var callInView = false;
+    function syncBackToday() {
+        var show = !todayInView && !callInView;
+        backBtn.hidden = !show;
+        backBtn.classList.toggle('is-visible', show);
+    }
+    var observer = new IntersectionObserver(function (entries) {
+        for (var i = 0; i < entries.length; i++) {
+            var entry = entries[i];
+            if (entry.target === todayEl) {
+                todayInView = entry.isIntersecting;
+            } else if (entry.target === callEl) {
+                callInView = entry.isIntersecting;
+            }
+        }
+        syncBackToday();
+    }, { threshold: 0 });
+    observer.observe(todayEl);
+    observer.observe(callEl);
 });
 </script>
 {% endblock %}

--- a/tests/test_elder_back_to_today.py
+++ b/tests/test_elder_back_to_today.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+"""老人模式左下角「回到今天」回归测试。"""
+import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _login_as(client, user_id, csrf_token='test-csrf-token'):
+    with client.session_transaction() as session:
+        session['_user_id'] = str(user_id)
+        session['_fresh'] = True
+        session['_csrf_token'] = csrf_token
+
+
+def _create_user(db_session, username='elder_back_today_user', role='user', community='都昌'):
+    from core.db_models import User
+
+    user = User(username=username, role=role, community=community)
+    user.set_password('testpass')
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+def _patch_unavailable_weather(monkeypatch, temperature=36.5):
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_weather_with_cache',
+        lambda location: ({
+            'temperature': temperature,
+            'temperature_max': 39,
+            'temperature_min': None,
+            'humidity': 80,
+            'pressure': 1000,
+            'weather_condition': '晴',
+            'wind_speed': 2,
+            'aqi': 88,
+            'is_mock': False,
+            'data_source': 'QWeather',
+        }, False),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        'services.user.dashboard_service.get_qweather_forecast_with_cache',
+        lambda location, days=7: ([], False, {'error': 'qweather_unavailable'}),
+        raising=False,
+    )
+
+
+def _back_today_html(body):
+    match = re.search(
+        r'<a\b[^>]*\byl-elder-back-today\b[^>]*>.*?</a>',
+        body,
+        re.S,
+    )
+    assert match, '老人模式必须有「回到今天」锚点按钮'
+    return match.group(0)
+
+
+def _hero_html(body):
+    match = re.search(
+        r'<section\b[^>]*\byl-elder-hero\b[^>]*>',
+        body,
+    )
+    assert match, '老人模式必须有今日小结 hero'
+    return match.group(0)
+
+
+def _css_rule(css, selector):
+    match = re.search(
+        re.escape(selector) + r' \{(?P<body>.*?)\n\}',
+        css,
+        re.S,
+    )
+    assert match, f'必须存在选择器 {selector}'
+    return match.group('body')
+
+
+def test_elder_mode_has_in_page_back_to_today_not_self_refresh(
+    client,
+    db_session,
+    monkeypatch,
+):
+    user = _create_user(db_session)
+    _login_as(client, user.id)
+    _patch_unavailable_weather(monkeypatch)
+
+    response = client.get('/elder-mode')
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+
+    hero = _hero_html(body)
+    assert 'id="today"' in hero
+
+    back = _back_today_html(body)
+    assert '回到今天' in back
+    assert 'href="#today"' in back
+    assert 'href="/elder-mode"' not in back
+    assert 'btn-danger' not in back
+    assert 'hidden' in back
+    assert 'id="yl-elder-back-today"' in back
+
+    scripts = re.findall(r'<script>(.*?)</script>', body, re.S)
+    back_script = next((script for script in scripts if 'IntersectionObserver' in script), '')
+    assert back_script
+    assert "getElementById('today')" in back_script
+    assert "querySelector('.yl-elder-call-card')" in back_script
+    assert 'href="/elder-mode"' not in back_script
+
+    assert '<h2>一键联系</h2>' in body
+    assert '天气更新中' in body
+    assert '补水、通风并避免暴晒' in body
+    assert '36.5' not in body
+    assert 'data-yl-open-120' in body
+    assert 'showModal' in body
+    assert 'window.confirm' not in body
+
+
+def test_guest_elder_mode_also_has_back_to_today(client, db_session, monkeypatch):
+    _patch_unavailable_weather(monkeypatch)
+
+    guest = client.get('/guest?next=/elder-mode', follow_redirects=True)
+    assert guest.status_code == 200
+    body = guest.get_data(as_text=True)
+
+    back = _back_today_html(body)
+    assert 'href="#today"' in back
+    assert '回到今天' in back
+    assert 'href="/elder-mode"' not in back
+    assert 'id="today"' in _hero_html(body)
+    assert '<h2>一键联系</h2>' in body
+    assert '天气更新中' in body
+    assert '36.5' not in body
+
+
+def test_back_to_today_css_is_left_fixed_scoped_and_not_full_width():
+    css = (PROJECT_ROOT / 'static/css/yilao.css').read_text(encoding='utf-8')
+    back_css = _css_rule(css, 'body.elder-focus-page .yl-elder-back-today')
+
+    assert 'position: fixed' in back_css
+    assert 'left:' in back_css
+    assert 'bottom:' in back_css
+    assert 'right: auto' in back_css
+    assert 'width: auto' in back_css
+    assert 'width: 100%' not in back_css
+    assert 'btn-danger' not in back_css
+    z_match = re.search(r'z-index:\s*(\d+)', back_css)
+    assert z_match
+    assert int(z_match.group(1)) < 1030
+
+    assert 'body.elder-mode .yl-elder-back-today' not in css
+    assert 'body.elder-mode a.yl-elder-back-today' not in css
+
+    visible_css = _css_rule(css, 'body.elder-focus-page .yl-elder-back-today.is-visible')
+    assert 'inline-flex' in visible_css
+    hidden_css = _css_rule(css, 'body.elder-focus-page .yl-elder-back-today[hidden]')
+    assert 'display: none' in hidden_css
+
+
+def test_back_to_today_markup_and_js_stay_in_elder_template_only():
+    template = (PROJECT_ROOT / 'templates/elder_dashboard.html').read_text(encoding='utf-8')
+    extra = template.split('{% block extra_js %}', 1)[1]
+
+    assert 'id="today"' in template
+    assert 'yl-elder-back-today' in template
+    assert '回到今天' in template
+    assert 'href="#today"' in template
+    assert 'href="/elder-mode"' not in template.split('{% block extra_js %}', 1)[0]
+    assert 'IntersectionObserver' in extra
+    assert "querySelector('.yl-elder-call-card')" in extra
+    assert 'showModal' in extra
+    assert 'window.confirm' not in extra
+
+    hits = []
+    for path in (PROJECT_ROOT / 'templates').rglob('*.html'):
+        text = path.read_text(encoding='utf-8')
+        if '回到今天' in text or 'yl-elder-back-today' in text:
+            hits.append(str(path.relative_to(PROJECT_ROOT)))
+    assert hits == ['templates/elder_dashboard.html']
+
+    base = (PROJECT_ROOT / 'templates/base.html').read_text(encoding='utf-8')
+    assert '回到今天' not in base
+    assert 'yl-elder-back-today' not in base
+    assert 'yl-elder-back-today' not in (PROJECT_ROOT / 'static/js/ai-floating-chat.js').read_text(encoding='utf-8')
+
+
+def test_home_action_and_429_do_not_render_back_to_today(client, db_session):
+    home = client.get('/').get_data(as_text=True)
+    action = client.get('/action').get_data(as_text=True)
+
+    for body in (home, action):
+        assert '回到今天' not in body
+        assert 'yl-elder-back-today' not in body
+
+    page_429 = PROJECT_ROOT / 'templates/429.html'
+    if page_429.exists():
+        text = page_429.read_text(encoding='utf-8')
+        assert '回到今天' not in text
+        assert 'yl-elder-back-today' not in text


### PR DESCRIPTION
Depends on #37.

## 这次改了什么

- 给 `.yl-elder-hero` 加上 `id="today"`。左下角「回到今天」按钮 `href="#today"`，**不**链 `/elder-mode`（那会整页刷新）。
- 按钮默认隐藏；今日小结滚出视口、且中部「一键联系」卡不在视口时才显示；call card 一进入视口立刻藏。
- 非全宽底栏、非 `btn-danger`、不靠右（右下角是 AI 浮窗）。CSS 写在 `body.elder-focus-page` 下，不用 `body.elder-mode`。
- JS 只放在本模板 `extra_js`，与 P6 的 120 dialog 脚本分开，不改 120 / 一键联系 / 家属 `tel:`。不写入 `base.html`、429、`/action`、首页。

## 为什么要改

- `/elder-mode` 就是本页，链回自己等于刷新，老人滑下去后找不到今日小结。
- 必须叠在 #37 的 120 卡之上，所以本 PR 以 `codex/fix/elder-120-confirm` 为 base，避免把 P6 提交再算进 P7。

## 怎么验证

- [x] 运行了相关 pytest
- [ ] 手动验证了受影响页面 / API
- [x] 补充了必要文档
- [x] 已检查 `git diff --staged`
- [x] 当前改动只覆盖这一个问题

验证说明：

```text
conda activate case-weather-py312
cd /Users/imac/Desktop/老家/worktrees/elder-back-to-today
python -m pytest tests/test_elder_back_to_today.py tests/test_elder_120_confirm.py tests/test_motion_widgets.py tests/test_nav_offcanvas.py::test_anonymous_elder_card_enters_guest_elder_mode -q
# 24 passed
# 「回到今天」只出现在 /elder-mode；首页 /action 没有；href="#today"；P6 的 120/一键联系/天气更新中/无 mock 36.5 仍绿
```

## 文件分类 / 边界检查

- [x] 本 PR 不包含缓存、测试产物、`.claude/`、重复副本或一次性报告
- [x] 如涉及文件迁移，已说明文件去向：主仓库 / 本地归档 / 私有 ops / 本地忽略
- [x] 未提交真实 key、真实 host、真实服务器路径、默认口令
- [x] 如涉及清理仓库，优先处理噪音文件，没有误删运行链路文件
- [x] 如修改 `.sh` 或 `.githooks`，已至少运行一次 `bash -n`

## 关联信息

- 执行者 / Agent：Cursor 子代理
- Notion 条目：产品清单 P7 回到今天（待回填）
- 分支名：`codex/fix/elder-back-to-today`
- 相关 Issue / 备注：计划步骤 P7；**依赖 #37**（P6 老人 120 卡）。请先合并 #37，再 squash 本 PR。
- 相关文件分类说明：运行代码 + 必要测试，属产品主仓库
- `origin/main` 基线 SHA：`faa39347960977d513cae7ed8e744d8b9eb62631`
- 本地归档路径（如适用）：
- Notion 回填责任人 / 说明（如当前无法访问 Notion）：当前执行者无 Notion 访问，条目待回填

## 备份检查

- [x] 当前分支已 push 到 GitHub
- [x] 本 PR 可以作为本轮工作的远端备份
- [x] 如未完成验证，本 PR 保持 Draft


Made with [Cursor](https://cursor.com)