### PR TITLE
fix: 补齐生产可用性收口

### DIFF
--- a/blueprints/health.py
+++ b/blueprints/health.py
@@ -143,6 +143,22 @@ def family_members():
 
     members = FamilyMember.query.filter_by(user_id=current_user.id).order_by(FamilyMember.created_at.desc()).all()
     member_ids = [m.id for m in members]
+    active_paired_member_ids = set()
+    if member_ids:
+        # 仅 active 关系代表档案已真正加入当前照护人的监测。
+        active_paired_member_ids = {
+            row[0]
+            for row in Pair.query.with_entities(Pair.member_id).filter(
+                Pair.caregiver_id == current_user.id,
+                Pair.status == 'active',
+                Pair.member_id.in_(member_ids),
+            ).all()
+            if row[0] is not None
+        }
+    unpaired_member_count = sum(
+        1 for member_id in member_ids
+        if member_id not in active_paired_member_ids
+    )
     profiles = []
     if member_ids:
         profiles = FamilyMemberProfile.query.filter(FamilyMemberProfile.member_id.in_(member_ids)).all()
@@ -251,7 +267,8 @@ def family_members():
         risk_chart_labels=risk_chart_labels,
         risk_chart_values=risk_chart_values,
         risk_tag_options=risk_tag_options,
-        chronic_options=chronic_options
+        chronic_options=chronic_options,
+        unpaired_member_count=unpaired_member_count
     )
 
 

--- a/services/public_service.py
+++ b/services/public_service.py
@@ -1739,6 +1739,7 @@ def render_cooling_resources_page(
         CoolingResource.name
     ).all()
     all_resources = CoolingResource.query.filter_by(is_active=True).all()
+    cooling_filters_enabled = bool(all_resources)
     candidate_preview = (
         list(cooling_candidates or [])
         if not all_resources
@@ -1775,6 +1776,7 @@ def render_cooling_resources_page(
         cooling_weather_location=weather_location,
         outdoor_temp=outdoor_temp,
         cooling_candidates=candidate_preview,
+        cooling_filters_enabled=cooling_filters_enabled,
     ))
     if not map_points:
         # 没有可计算距离的正式点位时，浏览器不应提供定位能力。

--- a/services/user/profile_service.py
+++ b/services/user/profile_service.py
@@ -22,7 +22,7 @@ from core.db_models import (
 from core.extensions import db
 from core.guest import build_guest_profile, get_guest_assessment, is_guest_user
 from core.notifications import create_notification
-from core.time_utils import utcnow
+from core.time_utils import utc_to_local_datetime, utcnow
 from core.usage import create_api_token
 from core.weather import (
     compact_assessment_weather_condition,
@@ -588,6 +588,8 @@ def profile():
         'profile.html',
         communities=communities,
         chronic_diseases_list=chronic_diseases_list,
+        created_at_local=utc_to_local_datetime(current_user.created_at),
+        last_login_local=utc_to_local_datetime(current_user.last_login),
         last_api_token_plain=last_api_token_plain,
         wxpusher_feature_enabled=wxpusher_feature_enabled,
         wxpusher_available=bool(

--- a/static/css/apple-polish.css
+++ b/static/css/apple-polish.css
@@ -327,6 +327,75 @@ body.motion-ready[data-motion~="m1"] .yl-feature-icon {
 }
 
 @media (max-width: 767.98px) {
+    /* 手机端只扩明确控件的触控区，正文中的普通链接保持原排版。 */
+    .btn {
+        min-width: 44px;
+        min-height: 44px;
+    }
+
+    .navbar-toggler {
+        display: inline-flex;
+        min-width: 44px;
+        min-height: 44px;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .btn-close {
+        width: 44px;
+        height: 44px;
+        padding: 0;
+        background-size: 16px;
+    }
+
+    .yl-metric-info {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+
+    .site-footer nav a,
+    .site-footer p a {
+        display: inline-flex;
+        min-height: 44px;
+        align-items: center;
+        padding: 4px 8px;
+    }
+
+    details > summary {
+        min-height: 44px;
+        box-sizing: border-box;
+        padding-top: 10px;
+        padding-bottom: 10px;
+        cursor: pointer;
+    }
+
+    /* 保留原生选择控件，整行标签提供 44px 命中区。 */
+    .form-check {
+        display: flex;
+        min-height: 44px;
+        align-items: center;
+    }
+
+    .form-check .form-check-input {
+        flex: 0 0 auto;
+        width: 24px;
+        height: 24px;
+        margin-top: 0;
+    }
+
+    .form-check-label {
+        display: inline-flex;
+        min-height: 44px;
+        align-items: center;
+        padding-left: 4px;
+    }
+
+    .form-switch .form-check-input {
+        width: 40px;
+    }
+
     .ai-floating-chat:not(.open) {
         right: max(16px, env(safe-area-inset-right));
         bottom: max(16px, env(safe-area-inset-bottom));

--- a/static/css/cooling-map.css
+++ b/static/css/cooling-map.css
@@ -27,7 +27,8 @@
 
 .cooling-locate-button {
     flex: 0 0 auto;
-    min-height: 42px;
+    min-width: 44px;
+    min-height: 44px;
 }
 
 .cooling-map-canvas {

--- a/static/css/elder-fix.css
+++ b/static/css/elder-fix.css
@@ -46,6 +46,36 @@
     font-size: 1.2rem;
 }
 
+/* 老人页单独扩大精细控件，避免影响普通页面的信息密度。 */
+body.elder-focus-page .yl-metric-info {
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    min-height: 44px;
+}
+
+body.elder-focus-page .navbar-toggler {
+    display: inline-flex;
+    min-width: 44px;
+    min-height: 44px;
+    align-items: center;
+    justify-content: center;
+}
+
+body.elder-focus-page .btn-close {
+    width: 44px;
+    height: 44px;
+    padding: 0;
+    background-size: 16px;
+}
+
+body.elder-focus-page .site-footer nav a {
+    display: inline-flex;
+    min-height: 44px;
+    align-items: center;
+    padding: 4px 10px;
+}
+
 @media (max-width: 680px) {
     .yl-elder-score-line {
         align-items: flex-start;

--- a/templates/base.html
+++ b/templates/base.html
@@ -103,6 +103,9 @@
 </head>
 <body class="{% block body_class %}{% endblock %}" data-viewport-tier="wide" data-motion="m1 m2 m4 m5">
     {% set nav_endpoint = request.endpoint or '' %}
+    {% set nav_today_url = url_for('user.elder_dashboard') if nav_endpoint == 'user.elder_dashboard' else url_for('user.user_dashboard') %}
+    {% set nav_desktop_today_active = nav_endpoint in ['user.user_dashboard', 'user.elder_dashboard'] %}
+    {% set nav_drawer_today_active = nav_endpoint == 'user.user_dashboard' or (nav_endpoint == 'user.elder_dashboard' and not feature_flags.elder_mode) %}
     {% set nav_is_guest = current_user.is_authenticated and current_user.role == 'guest' %}
     {% if nav_is_guest or not current_user.is_authenticated %}
         {% set nav_community_risk_url = url_for('public.public_risk') %}
@@ -151,9 +154,9 @@
             {# 高频入口,仅登录后显示在桌面端 #}
             {% if current_user.is_authenticated %}
                 <div class="app-desktop-nav d-none d-lg-flex align-items-center gap-1 mx-auto">
-                    <a class="nav-link {% if request.endpoint == 'user.user_dashboard' %}active{% endif %}"
-                       href="{{ url_for('user.user_dashboard') }}" data-nav-key="today"
-                       {% if request.endpoint == 'user.user_dashboard' %}aria-current="page"{% endif %}>今天</a>
+                    <a class="nav-link {% if nav_desktop_today_active %}active{% endif %}"
+                       href="{{ nav_today_url }}" data-nav-key="today"
+                       {% if nav_desktop_today_active %}aria-current="page"{% endif %}>今天</a>
 
                     <a class="nav-link {% if nav_care_active %}active{% endif %}"
                        href="{{ nav_care_url }}" data-nav-key="care"
@@ -289,7 +292,7 @@
             <nav class="nav flex-column mb-3" aria-label="今天">
                 <a class="nav-link {% if nav_endpoint == 'public.index' %}active{% endif %}" href="{{ url_for('public.index') }}" data-nav-key="home" {% if nav_endpoint == 'public.index' %}aria-current="page"{% endif %}><i class="bi bi-house-door me-2"></i>首页</a>
                 {% if current_user.is_authenticated %}
-                    <a class="nav-link {% if nav_endpoint == 'user.user_dashboard' %}active{% endif %}" href="{{ url_for('user.user_dashboard') }}" data-nav-key="today" {% if nav_endpoint == 'user.user_dashboard' %}aria-current="page"{% endif %}><i class="bi bi-heart-pulse me-2"></i>今日主页</a>
+                    <a class="nav-link {% if nav_drawer_today_active %}active{% endif %}" href="{{ nav_today_url }}" data-nav-key="today" {% if nav_drawer_today_active %}aria-current="page"{% endif %}><i class="bi bi-heart-pulse me-2"></i>今日主页</a>
                     {% if feature_flags.elder_mode %}
                         <a class="nav-link {% if nav_endpoint == 'user.elder_dashboard' %}active{% endif %}" href="{{ url_for('user.elder_dashboard') }}" data-nav-key="elder" {% if nav_endpoint == 'user.elder_dashboard' %}aria-current="page"{% endif %}><i class="bi bi-eyeglasses me-2"></i>老人模式</a>
                     {% endif %}

--- a/templates/cooling.html
+++ b/templates/cooling.html
@@ -48,7 +48,9 @@
     </section>
     {% endif %}
 
-    <form method="GET" class="yl-section mb-4 yl-fade-up yl-fade-up-d1">
+    <form method="GET"
+          class="yl-section mb-4 yl-fade-up yl-fade-up-d1"
+          {% if not cooling_filters_enabled %}aria-describedby="coolingFilterAvailability"{% endif %}>
         <div class="row g-3 align-items-end">
             <div class="col-md-5">
                 <label class="form-label" for="coolingCommunity">所在地</label>
@@ -59,12 +61,16 @@
                        value="{{ selected_community or '' }}"
                        placeholder="输入社区名（可选）"
                        autocomplete="off"
-                       list="locOpts">
+                       list="locOpts"
+                       {% if not cooling_filters_enabled %}disabled aria-disabled="true"{% endif %}>
                 <datalist id="locOpts">{% for loc in (communities or location_options or []) %}<option value="{{ loc }}"></option>{% endfor %}</datalist>
             </div>
             <div class="col-md-4">
                 <label class="form-label" for="coolingResourceType">类型</label>
-                <select name="resource_type" id="coolingResourceType" class="form-select">
+                <select name="resource_type"
+                        id="coolingResourceType"
+                        class="form-select"
+                        {% if not cooling_filters_enabled %}disabled aria-disabled="true"{% endif %}>
                     <option value="">全部</option>
                     {% for item_type in (resource_types or []) %}
                     <option value="{{ item_type }}" {% if selected_resource_type == item_type %}selected{% endif %}>{{ item_type }}</option>
@@ -72,9 +78,18 @@
                 </select>
             </div>
             <div class="col-md-3 d-grid">
-                <button class="btn btn-primary"><i class="bi bi-search me-1"></i>查找</button>
+                <button class="btn btn-primary"
+                        id="coolingFilterSubmit"
+                        {% if not cooling_filters_enabled %}disabled aria-disabled="true"{% endif %}>
+                    <i class="bi bi-search me-1"></i>查找
+                </button>
             </div>
         </div>
+        {% if not cooling_filters_enabled %}
+        <p class="text-muted small mt-3 mb-0" id="coolingFilterAvailability" role="status">
+            筛选将在人工核验发布后开放，待核验预览不参与筛选。
+        </p>
+        {% endif %}
     </form>
 
     <section class="yl-section mb-4 yl-fade-up yl-fade-up-d2 cooling-map-panel"
@@ -168,7 +183,11 @@
             <section class="yl-section text-center mb-0">
                 <div style="font-size:2rem; color:var(--yl-orange-500);"><i class="bi bi-geo-alt"></i></div>
                 <h4 class="mt-2" style="font-size:1.05rem;">暂无已发布且完成核验的避暑资源</h4>
+                {% if cooling_filters_enabled %}
                 <p class="text-muted mb-0" style="font-size:.9rem;">当前筛选条件下没有可展示的正式资源。请调整地区或类型，或等待管理员完成现场核验。</p>
+                {% else %}
+                <p class="text-muted mb-0" style="font-size:.9rem;">运营人员完成现场核验并发布后，正式资源、地图点位和筛选功能才会开放。</p>
+                {% endif %}
             </section>
         </div>
         {% endif %}

--- a/templates/family_member_detail.html
+++ b/templates/family_member_detail.html
@@ -212,5 +212,24 @@
             </div>
         </div>
     </div>
+
+    <div class="card border-danger mt-4">
+        <div class="card-body d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3">
+            <div>
+                <h6 class="text-danger mb-2">删除家人档案</h6>
+                <p class="mb-0 text-muted">
+                    档案与相关健康记录会被删除，关联监测对象会停用并解除。此操作无法撤销。
+                </p>
+            </div>
+            <form method="POST"
+                  action="{{ url_for('health.family_member_delete', member_id=member.id) }}"
+                  onsubmit="return confirm('确定删除这份家人档案吗？此操作无法撤销。');">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="btn btn-outline-danger flex-shrink-0">
+                    <i class="bi bi-trash me-1"></i>删除档案
+                </button>
+            </form>
+        </div>
+    </div>
 </div>
 {% endblock %}

--- a/templates/family_members.html
+++ b/templates/family_members.html
@@ -18,6 +18,18 @@
         </a>
     </div>
 
+    {% if unpaired_member_count %}
+    <div class="alert alert-info d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 yl-fade-up" role="status">
+        <div>
+            <div class="fw-semibold">档案已建立，还有 {{ unpaired_member_count }} 位家人尚未加入监测。</div>
+            <div class="small">下一步填写所在地，开始查看对应的天气风险与照护行动。</div>
+        </div>
+        <a href="{{ url_for('user.pair_management') }}" class="btn btn-primary flex-shrink-0">
+            下一步：添加监测对象
+        </a>
+    </div>
+    {% endif %}
+
     {# 概览 #}
     <div class="row g-3 mb-4 yl-fade-up yl-fade-up-d1">
         <div class="col-6 col-md-3">

--- a/templates/pair_management.html
+++ b/templates/pair_management.html
@@ -51,7 +51,7 @@
                     </div>
                 </div>
                 <div class="card-body">
-                    <form method="POST" action="{{ pair_create_action or url_for('user.pair_management') }}">
+                    <form id="pairCreateForm" method="POST" action="{{ pair_create_action or url_for('user.pair_management') }}">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <div class="mb-3">
                             <label class="form-label">关联老人档案（可选）</label>
@@ -267,7 +267,18 @@
                         </div>
                         <div class="text-muted small mt-3">升级链仅记录状态，请结合实际情况与社区沟通。</div>
                     {% else %}
-                        <div class="text-muted">暂无监测对象，请先在左侧添加老人并设置所在地。</div>
+                        <div class="alert alert-info mb-0">
+                            <div class="fw-semibold mb-2">暂无监测对象，按下面三步完成设置：</div>
+                            <ol class="list-unstyled mb-0">
+                                <li class="mb-2">1. 建立家人档案，可在<a href="{{ url_for('health.family_members') }}">家庭成员</a>中补充慢病信息。</li>
+                                <li class="mb-2">2. 添加监测对象，在左侧选择家人并填写所在地。</li>
+                                {% if config.get('WECHAT_FORMAL_RUNTIME') %}
+                                    <li>3. 微信搜索宜老平安 → 宜老天气通 → 照护选择家人。</li>
+                                {% else %}
+                                    <li>3. 创建后可把网页行动入口发给家人，完成今日确认或求助。</li>
+                                {% endif %}
+                            </ol>
+                        </div>
                     {% endif %}
                 </div>
             </div>

--- a/templates/partials/elder_bottom_nav.html
+++ b/templates/partials/elder_bottom_nav.html
@@ -1,5 +1,5 @@
 <nav class="yl-elder-return-nav" aria-label="老人模式返回导航">
-    <a class="btn btn-outline-primary btn-lg" href="{{ url_for('user.user_dashboard') }}">
+    <a class="btn btn-outline-primary btn-lg" href="{{ url_for('user.elder_dashboard') }}">
         <i class="bi bi-house-heart" aria-hidden="true"></i>
         回到今天
     </a>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -244,10 +244,10 @@
                         </dd>
                         
                         <dt class="col-sm-5">注册时间：</dt>
-                        <dd class="col-sm-7">{{ current_user.created_at.strftime('%Y-%m-%d') if current_user.created_at else '-' }}</dd>
+                        <dd class="col-sm-7">{{ created_at_local.strftime('%Y-%m-%d') if created_at_local else '-' }}</dd>
                         
                         <dt class="col-sm-5">最后登录：</dt>
-                        <dd class="col-sm-7 mb-0">{{ current_user.last_login.strftime('%Y-%m-%d %H:%M') if current_user.last_login else '首次登录' }}</dd>
+                        <dd class="col-sm-7 mb-0">{{ last_login_local.strftime('%Y-%m-%d %H:%M') if last_login_local else '首次登录' }}</dd>
                     </dl>
                 </div>
             </div>

--- a/tests/test_action_handoff_elder_cooling_ui.py
+++ b/tests/test_action_handoff_elder_cooling_ui.py
@@ -197,7 +197,61 @@ def test_elder_page_prioritizes_risk_and_confirms_calls(
     assert '直接联系 家人小吴' in body
     assert '紧急情况直接拨打 120' in body
     assert '回到今天' in body
+    assert re.search(
+        r'class="btn btn-outline-primary btn-lg" href="/elder-mode"[^>]*>.*?回到今天',
+        body,
+        re.DOTALL,
+    )
+    assert body.count('href="/elder-mode" data-nav-key="today"') == 2
+    assert re.search(
+        r'class="nav-link active"\s+href="/elder-mode" data-nav-key="today"\s+aria-current="page">今天</a>',
+        body,
+    )
+    assert body.count('href="/elder-mode" data-nav-key="today" aria-current="page"') == 1
     assert '/static/css/elder-fix.css' in body
+
+    family_response = client.get('/dashboard')
+    family_body = family_response.get_data(as_text=True)
+    assert family_response.status_code == 200
+    assert family_body.count('href="/dashboard" data-nav-key="today"') == 2
+
+
+def test_mobile_touch_target_styles_cover_controls_without_expanding_body_links():
+    polish_css = (
+        PROJECT_ROOT / 'static/css/apple-polish.css'
+    ).read_text(encoding='utf-8')
+    elder_css = (
+        PROJECT_ROOT / 'static/css/elder-fix.css'
+    ).read_text(encoding='utf-8')
+
+    assert '@media (max-width: 767.98px)' in polish_css
+    assert '.btn {' in polish_css
+    assert 'min-width: 44px;' in polish_css
+    assert 'min-height: 44px;' in polish_css
+    assert '.navbar-toggler {' in polish_css
+    assert '.btn-close {' in polish_css
+    assert '.yl-metric-info {' in polish_css
+    assert '.site-footer nav a,' in polish_css
+    assert '.site-footer p a {' in polish_css
+    assert 'details > summary {' in polish_css
+    assert '.form-check {' in polish_css
+    assert '.form-check-label {' in polish_css
+    assert '.form-check .form-check-input {' in polish_css
+    assert 'width: 24px;' in polish_css
+    form_control_rule = re.search(
+        r'\.form-check \.form-check-input\s*\{(?P<body>.*?)\}',
+        polish_css,
+        re.DOTALL,
+    )
+    assert form_control_rule is not None
+    assert 'opacity:' not in form_control_rule.group('body')
+    assert '.page-shell a {' not in polish_css
+    assert 'main a {' not in polish_css
+
+    assert 'body.elder-focus-page .yl-metric-info {' in elder_css
+    assert 'body.elder-focus-page .navbar-toggler {' in elder_css
+    assert 'body.elder-focus-page .btn-close {' in elder_css
+    assert 'body.elder-focus-page .site-footer nav a {' in elder_css
 
 
 def test_formal_wechat_template_uses_miniprogram_copy_label():

--- a/tests/test_confirmed_at_timezone_display.py
+++ b/tests/test_confirmed_at_timezone_display.py
@@ -198,3 +198,41 @@ def test_confirmed_at_templates_never_format_database_utc_directly():
     assert "status_today.confirmed_at.strftime('%H:%M')" not in caregiver_detail
     assert 'item.confirmed_at_local_display' in pair_management
     assert 'confirmed_at_local_display' in caregiver_detail
+
+
+def test_profile_displays_account_times_in_app_timezone(
+    app,
+    client,
+    db_session,
+):
+    """个人资料页的注册与最后登录时间都应由 UTC 转成应用时区。"""
+    app.config['APP_TIMEZONE'] = 'Asia/Shanghai'
+    user = User(
+        username='profile_timezone_user',
+        role='user',
+        created_at=datetime(2026, 8, 9, 16, 30),
+        last_login=datetime(2026, 8, 9, 4, 0),
+    )
+    user.set_password('profile-timezone-test-password')
+    db_session.add(user)
+    db_session.commit()
+    _login_as(client, user.id)
+
+    response = client.get('/profile')
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert '2026-08-10' in body
+    assert '2026-08-09 12:00' in body
+
+
+def test_profile_template_never_formats_database_utc_directly():
+    """个人资料模板只消费服务层准备好的本地时间。"""
+    profile_template = (
+        PROJECT_ROOT / 'templates' / 'profile.html'
+    ).read_text(encoding='utf-8')
+
+    assert 'current_user.created_at.strftime' not in profile_template
+    assert 'current_user.last_login.strftime' not in profile_template
+    assert 'created_at_local.strftime' in profile_template
+    assert 'last_login_local.strftime' in profile_template

--- a/tests/test_health_profile_regressions.py
+++ b/tests/test_health_profile_regressions.py
@@ -581,3 +581,124 @@ def test_web_family_member_delete_detaches_pair_and_removes_all_member_records(
     assert retained_pair.status == 'inactive'
     assert retained_pair.member_id is None
     assert refreshed_communities == [{'都昌县'}]
+
+
+def test_family_members_only_prompts_for_unpaired_active_members(
+    authenticated_client,
+    db_session,
+    monkeypatch,
+):
+    """建档页只在仍有家人未加入 active 监测时显示下一步。"""
+    from core.db_models import FamilyMember, Pair
+
+    owner = User.query.filter_by(username='testuser').one()
+    linked_member = FamilyMember(user_id=owner.id, name='已监测家人', relation='母亲')
+    unpaired_member = FamilyMember(user_id=owner.id, name='待监测家人', relation='父亲')
+    db_session.add_all([linked_member, unpaired_member])
+    db_session.flush()
+    db_session.add_all([
+        Pair(
+            caregiver_id=owner.id,
+            member_id=linked_member.id,
+            community_code='都昌县',
+            location_query='都昌县',
+            elder_code='linked-elder',
+            short_code='71111111',
+            status='active',
+        ),
+        Pair(
+            caregiver_id=owner.id,
+            member_id=unpaired_member.id,
+            community_code='都昌县',
+            location_query='都昌县',
+            elder_code='inactive-elder',
+            short_code='72222222',
+            status='inactive',
+        ),
+    ])
+    db_session.commit()
+    monkeypatch.setattr('blueprints.health.ensure_user_location_valid', lambda: '都昌县')
+    monkeypatch.setattr(
+        'blueprints.health.get_weather_with_cache',
+        lambda _location: ({'data_source': 'Demo', 'is_mock': True}, None),
+    )
+
+    pending_response = authenticated_client.get('/family-members')
+
+    assert pending_response.status_code == 200
+    pending_html = pending_response.get_data(as_text=True)
+    assert '还有 1 位家人尚未加入监测' in pending_html
+    assert 'href="/pairs"' in pending_html
+
+    db_session.add(Pair(
+        caregiver_id=owner.id,
+        member_id=unpaired_member.id,
+        community_code='都昌县',
+        location_query='都昌县',
+        elder_code='new-active-elder',
+        short_code='73333333',
+        status='active',
+    ))
+    db_session.commit()
+
+    complete_response = authenticated_client.get('/family-members')
+
+    assert complete_response.status_code == 200
+    assert '尚未加入监测' not in complete_response.get_data(as_text=True)
+
+
+def test_pair_empty_state_explains_three_steps_for_formal_and_web_runtime(
+    app,
+    authenticated_client,
+):
+    """空工作台给出完整三步，正式态只引导微信小程序。"""
+    app.config['WECHAT_FORMAL_RUNTIME'] = True
+    app.config['WEB_PRIVATE_FEATURES_ENABLED'] = True
+
+    formal_response = authenticated_client.get('/pairs')
+
+    assert formal_response.status_code == 200
+    formal_html = formal_response.get_data(as_text=True)
+    assert '按下面三步完成设置' in formal_html
+    assert '1. 建立家人档案' in formal_html
+    assert '2. 添加监测对象' in formal_html
+    assert '3. 微信搜索宜老平安 → 宜老天气通 → 照护选择家人' in formal_html
+    assert '复制网页行动链接' not in formal_html
+
+    app.config['WECHAT_FORMAL_RUNTIME'] = False
+
+    web_response = authenticated_client.get('/pairs')
+
+    assert web_response.status_code == 200
+    web_html = web_response.get_data(as_text=True)
+    assert '按下面三步完成设置' in web_html
+    assert '3. 创建后可把网页行动入口发给家人' in web_html
+
+
+def test_family_member_detail_renders_destructive_delete_form(
+    authenticated_client,
+    db_session,
+    monkeypatch,
+):
+    """详情页明确删除影响，并使用已有 POST 与 CSRF 删除路由。"""
+    from core.db_models import FamilyMember
+
+    owner = User.query.filter_by(username='testuser').one()
+    member = FamilyMember(user_id=owner.id, name='可删除家人', relation='家人')
+    db_session.add(member)
+    db_session.commit()
+    monkeypatch.setattr('blueprints.health.ensure_user_location_valid', lambda: '都昌县')
+    monkeypatch.setattr(
+        'blueprints.health.get_weather_with_cache',
+        lambda _location: ({'data_source': 'Demo', 'is_mock': True}, None),
+    )
+
+    response = authenticated_client.get(f'/family-members/{member.id}')
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert f'action="/family-members/{member.id}/delete"' in html
+    assert 'method="POST"' in html
+    assert 'name="csrf_token"' in html
+    assert '档案与相关健康记录会被删除' in html
+    assert '关联监测对象会停用并解除' in html

--- a/tests/test_tools_page_regressions.py
+++ b/tests/test_tools_page_regressions.py
@@ -657,6 +657,11 @@ def test_cooling_page_empty_database_renders_safe_candidate_preview(
     assert '29.249263' not in body
     assert 'data-publication-status="candidate-only"' in body
     assert 'data-verification-status="pending-human-verification"' in body
+    assert body.count('data-cooling-candidate="pending"') == 7
+    assert '筛选将在人工核验发布后开放，待核验预览不参与筛选' in body
+    assert re.search(r'id="coolingCommunity"[^>]*\sdisabled(?:\s|>)', body)
+    assert re.search(r'id="coolingResourceType"[^>]*\sdisabled(?:\s|>)', body)
+    assert re.search(r'id="coolingFilterSubmit"[^>]*\sdisabled(?:\s|>)', body)
     assert 'data-cooling-map-focus' not in body
     assert 'id="coolingLocateButton"' in body
     assert 'id="coolingLocateButton"\n                    disabled' in body
@@ -671,6 +676,8 @@ def test_cooling_page_empty_database_renders_safe_candidate_preview(
 
 
 def test_cooling_page_renders_real_resources_only(client, db_session, monkeypatch):
+    import re
+
     from core.db_models import CoolingResource
 
     monkeypatch.setattr(
@@ -704,6 +711,31 @@ def test_cooling_page_renders_real_resources_only(client, db_session, monkeypatc
     assert '都昌县图书馆' not in body
     assert '万达广场' not in body
     assert '待核验场所预览' not in body
+    assert '筛选将在人工核验发布后开放，待核验预览不参与筛选' not in body
+    assert not re.search(r'id="coolingCommunity"[^>]*\sdisabled(?:\s|>)', body)
+    assert not re.search(r'id="coolingResourceType"[^>]*\sdisabled(?:\s|>)', body)
+    assert not re.search(r'id="coolingFilterSubmit"[^>]*\sdisabled(?:\s|>)', body)
+
+
+def test_cooling_location_button_meets_minimum_touch_target():
+    import re
+    from pathlib import Path
+
+    stylesheet = (
+        Path(__file__).resolve().parents[1]
+        / 'static'
+        / 'css'
+        / 'cooling-map.css'
+    ).read_text(encoding='utf-8')
+    rule = re.search(
+        r'\.cooling-locate-button\s*\{(?P<body>.*?)\}',
+        stylesheet,
+        re.DOTALL,
+    )
+
+    assert rule is not None
+    assert re.search(r'min-height:\s*44px', rule.group('body'))
+    assert re.search(r'min-width:\s*44px', rule.group('body'))
 
 
 def test_public_cooling_candidates_reject_unapproved_category(


### PR DESCRIPTION
## 这次改了什么
修正老人模式返回路径，补齐家人建档到监测的引导与删除入口，明确零核验避暑资源时的筛选状态，修正个人资料时区，并补足移动端触控目标。

## 为什么要改
生产回归确认老人会被带到家属看板，建档流程缺少下一步，避暑筛选在零正式资源时看似无效，资料页直接显示 UTC，多个移动控件低于 44px。

## 怎么验证
- Python 全量：1679 passed, 2 skipped, 11 deselected
- 手工离线：9 passed
- Web Node：11 passed
- 小程序既有回归：310 passed
- 相关定向：76 passed
- compileall 与 git diff --check 通过
- Chrome 390px 真人路径：老人页、家人档案、监测对象、档案详情、避暑页、个人资料均通过，无横向溢出；有效触控区达到 44px

## 文件与发布边界
- 无文件迁移
- 未修改 shell 或 githooks
- 无 cloudflare、miniprogram、scripts 差异
- 微信小程序本批次不上传
- 未访问 Notion，发布记录待回填
