### PR TITLE
chore: 新增 Cloud Agent 开发环境配置

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "Weather Web (Flask)",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh",
+  "terminals": [
+    {
+      "name": "flask-dev-server",
+      "command": "cd /workspace && DEBUG=true FLASK_HOST=0.0.0.0 FLASK_PORT=5000 .venv/bin/python app.py"
+    }
+  ],
+  "ports": [
+    {
+      "name": "flask web server",
+      "port": 5000
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for the Flask weather/health web app.
+# Prepares a Python virtualenv, installs pinned dependencies, and initializes
+# the local SQLite database so the dev server and pytest suite are ready.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Create the virtualenv. The stock image may lack the venv seeding package, so
+# install python3-venv on demand before retrying.
+if [ ! -x .venv/bin/python ]; then
+  if ! python3 -m venv .venv 2>/dev/null; then
+    sudo apt-get update -qq
+    sudo apt-get install -y -qq python3-venv
+    python3 -m venv .venv
+  fi
+fi
+
+.venv/bin/pip install --upgrade pip
+.venv/bin/pip install -r requirements.txt
+
+# Initialize the database schema (creates tables on an empty DB, otherwise
+# applies Alembic migrations). DEBUG=true skips production config validation.
+DEBUG=true FLASK_APP=app.py .venv/bin/flask init-db


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 这次改了什么

新增 Cloud Agent 开发环境配置，让本仓库可以在 Cursor Cloud Agent 中开箱即用：

- `.cursor/environment.json`
  - `install`: 运行 `.cursor/install.sh`
  - `terminals`: `flask-dev-server`，以 `DEBUG=true` 在 `0.0.0.0:5000` 运行 `python app.py`
  - `ports`: 暴露 5000 端口
- `.cursor/install.sh`（幂等）
  - 创建 `.venv`（stock 镜像缺少 venv 播种包时按需 `apt-get install python3-venv` 后重试）
  - `pip install -r requirements.txt`
  - `flask init-db` 初始化 SQLite 数据库（空库建表，否则走 Alembic 迁移）

未改动任何应用代码。QWeather / AMap / SILICONFLOW / Redis 均为可选项，未配置时走 Open-Meteo / 规则兜底与 `memory://` 限流，开发环境无需任何密钥即可运行。

## 为什么要改

仓库此前没有 `.cursor/environment.json`，Cloud Agent 无法自动准备依赖与数据库。此配置提供最小、可复现的一键开发环境。

## 怎么验证改动生效

在干净 VM 上验证通过：

- `pip check`: 无冲突依赖
- 默认测试：`pytest -q -W error::DeprecationWarning -W ignore::DeprecationWarning:flask_login.login_manager` → **416 passed, 11 deselected**
- 手工契约测试：`pytest -q -m manual` → **10 passed, 1 skipped**
- CI 语法检查：`compileall` 与 `bash -n scripts/*.sh .githooks/*` 通过
- `install.sh` 连续运行两次均成功（幂等）
- 开发服务器 `python app.py` 正常启动，`GET /api/v1/weather/current?city=都昌` 返回真实 Open-Meteo 数据（`is_mock: false`）
- 浏览器走查首页 / 健康评估 / 7 天预报 / 社区风险页面，含注册+登录流程，均正常渲染无报错

[Homepage](https://cursor.com/agents/bc-96ff2829-0053-4057-89fe-a9f44e7c261a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_homepage.png)
[Health assessment form](https://cursor.com/agents/bc-96ff2829-0053-4057-89fe-a9f44e7c261a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_health_assessment.png)
[7-day forecast page](https://cursor.com/agents/bc-96ff2829-0053-4057-89fe-a9f44e7c261a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_forecast_7day.png)
[weather_web_env_walkthrough.mp4](https://cursor.com/agents/bc-96ff2829-0053-4057-89fe-a9f44e7c261a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweather_web_env_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96ff2829-0053-4057-89fe-a9f44e7c261a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96ff2829-0053-4057-89fe-a9f44e7c261a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

